### PR TITLE
Changed packing strategy from pixel scanning to maintaining free space bins

### DIFF
--- a/MakeSpriteFont/ByWidthXY.cs
+++ b/MakeSpriteFont/ByWidthXY.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+
+namespace MakeSpriteFont
+{
+    public class ByWidthXY : IComparer<Rectangle>
+    {
+        public int Compare(Rectangle a, Rectangle b)
+        {
+            var result = a.Width.CompareTo(b.Width);
+            if (0 == result)
+            {
+                result = a.Y.CompareTo(b.Y);
+                if (0 == result)
+                {
+                    result = a.X.CompareTo(b.X);
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/MakeSpriteFont/MakeSpriteFont.csproj
+++ b/MakeSpriteFont/MakeSpriteFont.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BitmapUtils.cs" />
+    <Compile Include="ByWidthXY.cs" />
     <Compile Include="CharacterRegion.cs" />
     <Compile Include="CommandLineParser.cs" />
     <Compile Include="GlyphCropper.cs" />


### PR DESCRIPTION
This change marginally reduces efficiency while significantly improving packing performance. Generating a spritefont of 65k glyphs for the entire the Basic Multilingual Plane (BMP) could take as little as a couple minutes. The majority of time is now taken up by importing and writing to disk. The packing portion literally takes a second.