### PR TITLE
Fix compiler errors (Clang 6)

### DIFF
--- a/Audio/WAVFileReader.cpp
+++ b/Audio/WAVFileReader.cpp
@@ -16,15 +16,9 @@
 
 using namespace DirectX;
 
-#ifndef MAKEFOURCC
-#define MAKEFOURCC(ch0, ch1, ch2, ch3)                              \
-                ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) |       \
-                ((uint32_t)(uint8_t)(ch2) << 16) | ((uint32_t)(uint8_t)(ch3) << 24 ))
-#endif /* defined(MAKEFOURCC) */
 
 namespace
 {
-
     //---------------------------------------------------------------------------------
     // .WAV files
     //---------------------------------------------------------------------------------

--- a/Audio/WaveBankReader.cpp
+++ b/Audio/WaveBankReader.cpp
@@ -19,11 +19,6 @@
 #include <apu.h>
 #endif
 
-#ifndef MAKEFOURCC
-#define MAKEFOURCC(ch0, ch1, ch2, ch3)                              \
-                ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) |       \
-                ((uint32_t)(uint8_t)(ch2) << 16) | ((uint32_t)(uint8_t)(ch3) << 24 ))
-#endif /* defined(MAKEFOURCC) */
 
 namespace
 {

--- a/Audio/WaveBankReader.cpp
+++ b/Audio/WaveBankReader.cpp
@@ -224,7 +224,7 @@ namespace
         DWORD AdpcmSamplesPerBlock() const
         {
             uint32_t nBlockAlign = (wBlockAlign + ADPCM_BLOCKALIGN_CONVERSION_OFFSET) * nChannels;
-            return nBlockAlign * 2 / (uint32_t)nChannels - 12;
+            return nBlockAlign * 2 / uint32_t(nChannels) - 12;
         }
 
         void AdpcmFillCoefficientTable(ADPCMWAVEFORMAT *fmt) const
@@ -968,7 +968,7 @@ HRESULT WaveBankReader::Impl::GetFormat(uint32_t index, WAVEFORMATEX* pFormat, s
             pFormat->cbSize = 32 /*MSADPCM_FORMAT_EXTRA_BYTES*/;
             {
                 auto adpcmFmt = reinterpret_cast<ADPCMWAVEFORMAT*>(pFormat);
-                adpcmFmt->wSamplesPerBlock = (WORD)miniFmt.AdpcmSamplesPerBlock();
+                adpcmFmt->wSamplesPerBlock = static_cast<WORD>(miniFmt.AdpcmSamplesPerBlock());
                 miniFmt.AdpcmFillCoefficientTable(adpcmFmt);
             }
             break;
@@ -1061,7 +1061,7 @@ HRESULT WaveBankReader::Impl::GetFormat(uint32_t index, WAVEFORMATEX* pFormat, s
 
     pFormat->nChannels = miniFmt.nChannels;
     pFormat->wBitsPerSample = miniFmt.BitsPerSample();
-    pFormat->nBlockAlign = (WORD)miniFmt.BlockAlign();
+    pFormat->nBlockAlign = static_cast<WORD>(miniFmt.BlockAlign());
     pFormat->nSamplesPerSec = miniFmt.nSamplesPerSec;
     pFormat->nAvgBytesPerSec = miniFmt.AvgBytesPerSec();
 

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -473,8 +473,9 @@ namespace DirectX
             {
                 XMVECTOR lastPos = XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(&Position));
 
-                XMVECTOR vDelta = (newPos - lastPos);
-                XMVECTOR v = vDelta / dt;
+                XMVECTOR vDelta = XMVectorSubtract(newPos, lastPos);
+                XMVECTOR vt = XMVectorReplicate(dt);
+                XMVECTOR v = XMVectorDivide(vDelta, vt);
                 XMStoreFloat3(reinterpret_cast<XMFLOAT3*>(&Velocity), v);
 
                 vDelta = XMVector3Normalize(vDelta);
@@ -566,8 +567,9 @@ namespace DirectX
             {
                 XMVECTOR lastPos = XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(&Position));
 
-                XMVECTOR vDelta = (newPos - lastPos);
-                XMVECTOR v = vDelta / dt;
+                XMVECTOR vDelta = XMVectorSubtract(newPos, lastPos);
+                XMVECTOR vt = XMVectorReplicate(dt);
+                XMVECTOR v = XMVectorDivide(vDelta, vt);
                 XMStoreFloat3(reinterpret_cast<XMFLOAT3*>(&Velocity), v);
 
                 vDelta = XMVector3Normalize(vDelta);

--- a/Src/AlphaTestEffect.cpp
+++ b/Src/AlphaTestEffect.cpp
@@ -193,7 +193,7 @@ void AlphaTestEffect::Impl::Apply(_In_ ID3D11DeviceContext* deviceContext)
     if (dirtyFlags & EffectDirtyFlags::AlphaTest)
     {
         // Convert reference alpha from 8 bit integer to 0-1 float format.
-        float reference = (float)referenceAlpha / 255.0f;
+        auto reference = static_cast<float>(referenceAlpha) / 255.0f;
                 
         // Comparison tolerance of half the 8 bit integer precision.
         const float threshold = 0.5f / 255.0f;

--- a/Src/BasicEffect.cpp
+++ b/Src/BasicEffect.cpp
@@ -378,6 +378,7 @@ const int EffectBase<BasicEffectTraits>::PixelShaderIndices[] =
 
 
 // Global pool of per-device BasicEffect resources.
+template<>
 SharedResourcePool<ID3D11Device*, EffectBase<BasicEffectTraits>::DeviceResources> EffectBase<BasicEffectTraits>::deviceResourcesPool;
 
 

--- a/Src/BasicPostProcess.cpp
+++ b/Src/BasicPostProcess.cpp
@@ -409,10 +409,12 @@ void BasicPostProcess::Impl::GaussianBlur5x5(float multiplier)
     // blur kernels add to 1.0f to ensure that the intensity of the image isn't
     // changed when the blur occurs. An optional multiplier variable is used to
     // add or remove image intensity during the blur.
+    XMVECTOR vtw = XMVectorReplicate(totalWeight);
+    XMVECTOR vm = XMVectorReplicate(multiplier);
     for (size_t i = 0; i < index; ++i)
     {
-        weights[i] /= totalWeight;
-        weights[i] *= multiplier;
+        weights[i] = XMVectorDivide(weights[i], vtw);
+        weights[i] = XMVectorMultiply(weights[i], vm);
     }
 }
 

--- a/Src/Bezier.h
+++ b/Src/Bezier.h
@@ -89,11 +89,11 @@ namespace Bezier
 
         for (size_t i = 0; i <= tessellation; i++)
         {
-            float u = (float)i / tessellation;
+            float u = float(i) / tessellation;
 
             for (size_t j = 0; j <= tessellation; j++)
             {
-                float v = (float)j / tessellation;
+                float v = float(j) / tessellation;
 
                 // Perform four horizontal bezier interpolations
                 // between the control points of this patch.

--- a/Src/Bezier.h
+++ b/Src/Bezier.h
@@ -19,25 +19,37 @@ namespace Bezier
 {
     // Performs a cubic bezier interpolation between four control points,
     // returning the value at the specified time (t ranges 0 to 1).
-    // This template implementation can be used to interpolate XMVECTOR,
-    // float, or any other types that define suitable * and + operators.
     template<typename T>
-    T CubicInterpolate(T const& p1, T const& p2, T const& p3, T const& p4, float t)
+    inline T CubicInterpolate(T const& p1, T const& p2, T const& p3, T const& p4, float t)
     {
-        using DirectX::operator*;
-        using DirectX::operator+;
-
         return p1 * (1 - t) * (1 - t) * (1 - t) +
             p2 * 3 * t * (1 - t) * (1 - t) +
             p3 * 3 * t * t * (1 - t) +
             p4 * t * t * t;
     }
 
+     template<>
+     inline DirectX::XMVECTOR CubicInterpolate(DirectX::XMVECTOR const& p1, DirectX::XMVECTOR const& p2, DirectX::XMVECTOR const& p3, DirectX::XMVECTOR const& p4, float t)
+    {
+        using namespace DirectX;
+
+        XMVECTOR T0 = XMVectorReplicate((1 - t) * (1 - t) * (1 - t));
+        XMVECTOR T1 = XMVectorReplicate(3 * t * (1 - t) * (1 - t));
+        XMVECTOR T2 = XMVectorReplicate(3 * t * t * (1 - t));
+        XMVECTOR T3 = XMVectorReplicate(t * t * t);
+
+        XMVECTOR Result = XMVectorMultiply(p1, T0);
+        Result = XMVectorMultiplyAdd(p2, T1, Result);
+        Result = XMVectorMultiplyAdd(p3, T2, Result);
+        Result = XMVectorMultiplyAdd(p4, T3, Result);
+
+        return Result;
+    }
+
 
     // Computes the tangent of a cubic bezier curve at the specified time.
-    // Template supports XMVECTOR, float, or any other types with * and + operators.
     template<typename T>
-    T CubicTangent(T const& p1, T const& p2, T const& p3, T const& p4, float t)
+    inline T CubicTangent(T const& p1, T const& p2, T const& p3, T const& p4, float t)
     {
         using DirectX::operator*;
         using DirectX::operator+;
@@ -46,6 +58,24 @@ namespace Bezier
             p2 * (1 - 4 * t + 3 * t * t) +
             p3 * (2 * t - 3 * t * t) +
             p4 * (t * t);
+    }
+
+    template<>
+    inline DirectX::XMVECTOR CubicTangent(DirectX::XMVECTOR const& p1, DirectX::XMVECTOR const& p2, DirectX::XMVECTOR const& p3, DirectX::XMVECTOR const& p4, float t)
+    {
+        using namespace DirectX;
+
+        XMVECTOR T0 = XMVectorReplicate(-1 + 2 * t - t * t);
+        XMVECTOR T1 = XMVectorReplicate(1 - 4 * t + 3 * t * t);
+        XMVECTOR T2 = XMVectorReplicate(2 * t - 3 * t * t);
+        XMVECTOR T3 = XMVectorReplicate(t * t);
+
+        XMVECTOR Result = XMVectorMultiply(p1, T0);
+        Result = XMVectorMultiplyAdd(p2, T1, Result);
+        Result = XMVectorMultiplyAdd(p3, T2, Result);
+        Result = XMVectorMultiplyAdd(p4, T3, Result);
+
+        return Result;
     }
 
 
@@ -97,7 +127,7 @@ namespace Bezier
                     // If this patch is mirrored, we must invert the normal.
                     if (isMirrored)
                     {
-                        normal = -normal;
+                        normal = XMVectorNegate(normal);
                     }
                 }
                 else

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -18,9 +18,9 @@
 
 #include "DDSTextureLoader.h"
 
+#include "PlatformHelpers.h"
 #include "dds.h"
 #include "DirectXHelpers.h"
-#include "PlatformHelpers.h"
 #include "LoaderHelpers.h"
 
 using namespace DirectX;

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -870,7 +870,7 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(ID3D11Device* d3dDevice,
         return E_FAIL;
     }
 
-    uint32_t dwMagicNumber = *(const uint32_t*)(ddsData);
+    auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
     if (dwMagicNumber != DDS_MAGIC)
     {
         return E_FAIL;

--- a/Src/DGSLEffect.cpp
+++ b/Src/DGSLEffect.cpp
@@ -312,8 +312,7 @@ private:
         DeviceResources(_In_ ID3D11Device* device)
             : EffectDeviceResources(device),
             mVertexShaders{},
-            mPixelShaders{},
-            mDefaultTexture{}
+            mPixelShaders{}
         { }
 
         // Gets or lazily creates the vertex shader.
@@ -339,7 +338,6 @@ private:
     private:
         ComPtr<ID3D11VertexShader> mVertexShaders[DGSLEffectTraits::VertexShaderCount];
         ComPtr<ID3D11PixelShader> mPixelShaders[DGSLEffectTraits::PixelShaderCount];
-        ComPtr<ID3D11ShaderResourceView> mDefaultTexture;
     };
 
     // Per-device resources.
@@ -349,6 +347,7 @@ private:
 };
 
 
+// Global pool of per-device DGSLEffect resources.
 SharedResourcePool<ID3D11Device*, DGSLEffect::Impl::DeviceResources> DGSLEffect::Impl::deviceResourcesPool;
 
 
@@ -500,7 +499,7 @@ void DGSLEffect::Impl::Apply(_In_ ID3D11DeviceContext* deviceContext)
     }
     else
     {
-        ID3D11ShaderResourceView* txt[MaxTextures] = { mDeviceResources->GetDefaultTexture(), 0 };
+        ID3D11ShaderResourceView* txt[MaxTextures] = { mDeviceResources->GetDefaultTexture(), nullptr };
         deviceContext->PSSetShaderResources(0, MaxTextures, txt);
     }
 }

--- a/Src/DemandCreate.h
+++ b/Src/DemandCreate.h
@@ -17,7 +17,7 @@ namespace DirectX
 {
     // Helper for lazily creating a D3D resource.
     template<typename T, typename TCreateFunc>
-    static T* DemandCreate(Microsoft::WRL::ComPtr<T>& comPtr, std::mutex& mutex, TCreateFunc createFunc)
+    inline T* DemandCreate(Microsoft::WRL::ComPtr<T>& comPtr, std::mutex& mutex, TCreateFunc createFunc)
     {
         T* result = comPtr.Get();
 

--- a/Src/EnvironmentMapEffect.cpp
+++ b/Src/EnvironmentMapEffect.cpp
@@ -256,6 +256,7 @@ const int EffectBase<EnvironmentMapEffectTraits>::PixelShaderIndices[] =
 
 
 // Global pool of per-device EnvironmentMapEffect resources.
+template<>
 SharedResourcePool<ID3D11Device*, EffectBase<EnvironmentMapEffectTraits>::DeviceResources> EffectBase<EnvironmentMapEffectTraits>::deviceResourcesPool;
 
 

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -1163,14 +1163,14 @@ private:
         if (mConnected[player])
             return false;
 
-        for (size_t j = 0; j < XUSER_MAX_COUNT; ++j)
+        for (int j = 0; j < XUSER_MAX_COUNT; ++j)
         {
             if (!mConnected[j])
             {
                 LONGLONG delta = time - mLastReadTime[j];
 
                 LONGLONG interval = 1000;
-                if ((int)j != player)
+                if (j != player)
                     interval /= 4;
 
                 if ((delta >= 0) && (delta < interval))

--- a/Src/GeometricPrimitive.cpp
+++ b/Src/GeometricPrimitive.cpp
@@ -29,7 +29,7 @@ namespace
 
         D3D11_BUFFER_DESC bufferDesc = {};
 
-        bufferDesc.ByteWidth = (UINT)data.size() * sizeof(typename T::value_type);
+        bufferDesc.ByteWidth = static_cast<UINT>(data.size() * sizeof(typename T::value_type));
         bufferDesc.BindFlags = bindFlags;
         bufferDesc.Usage = D3D11_USAGE_DEFAULT;
 

--- a/Src/Geometry.cpp
+++ b/Src/Geometry.cpp
@@ -32,7 +32,7 @@ namespace
     inline void index_push_back(IndexCollection& indices, size_t value)
     {
         CheckIndexOverflow(value);
-        indices.push_back((uint16_t)value);
+        indices.push_back(static_cast<uint16_t>(value));
     }
 
 
@@ -160,7 +160,7 @@ void DirectX::ComputeSphere(VertexCollection& vertices, IndexCollection& indices
     // Create rings of vertices at progressively higher latitudes.
     for (size_t i = 0; i <= verticalSegments; i++)
     {
-        float v = 1 - (float)i / verticalSegments;
+        float v = 1 - float(i) / verticalSegments;
 
         float latitude = (i * XM_PI / verticalSegments) - XM_PIDIV2;
         float dy, dxz;
@@ -170,7 +170,7 @@ void DirectX::ComputeSphere(VertexCollection& vertices, IndexCollection& indices
         // Create a single ring of vertices at this latitude.
         for (size_t j = 0; j <= horizontalSegments; j++)
         {
-            float u = (float)j / horizontalSegments;
+            float u = float(j) / horizontalSegments;
 
             float longitude = j * XM_2PI / horizontalSegments;
             float dx, dz;
@@ -633,7 +633,7 @@ void DirectX::ComputeCylinder(VertexCollection& vertices, IndexCollection& indic
 
         XMVECTOR sideOffset = XMVectorScale(normal, radius);
 
-        float u = (float)i / tessellation;
+        float u = float(i) / tessellation;
 
         XMVECTOR textureCoordinate = XMLoadFloat(&u);
 
@@ -682,7 +682,7 @@ void DirectX::ComputeCone(VertexCollection& vertices, IndexCollection& indices, 
 
         XMVECTOR sideOffset = XMVectorScale(circlevec, radius);
 
-        float u = (float)i / tessellation;
+        float u = float(i) / tessellation;
 
         XMVECTOR textureCoordinate = XMLoadFloat(&u);
 
@@ -727,7 +727,7 @@ void DirectX::ComputeTorus(VertexCollection& vertices, IndexCollection& indices,
     // First we loop around the main ring of the torus.
     for (size_t i = 0; i <= tessellation; i++)
     {
-        float u = (float)i / tessellation;
+        float u = float(i) / tessellation;
 
         float outerAngle = i * XM_2PI / tessellation - XM_PIDIV2;
 
@@ -738,7 +738,7 @@ void DirectX::ComputeTorus(VertexCollection& vertices, IndexCollection& indices,
         // Now we loop along the other axis, around the side of the tube.
         for (size_t j = 0; j <= tessellation; j++)
         {
-            float v = 1 - (float)j / tessellation;
+            float v = 1 - float(j) / tessellation;
 
             float innerAngle = j * XM_2PI / tessellation + XM_PI;
             float dx, dy;

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -794,7 +794,7 @@ namespace DirectX
             {
                 if (MAKEFOURCC('D', 'X', '1', '0') == header->ddspf.fourCC)
                 {
-                    auto d3d10ext = reinterpret_cast<const DDS_HEADER_DXT10*>((const char*)header + sizeof(DDS_HEADER));
+                    auto d3d10ext = reinterpret_cast<const DDS_HEADER_DXT10*>(reinterpret_cast<const uint8_t*>(header) + sizeof(DDS_HEADER));
                     auto mode = static_cast<DDS_ALPHA_MODE>(d3d10ext->miscFlags2 & DDS_MISC_FLAGS2_ALPHA_MODE_MASK);
                     switch (mode)
                     {

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -283,7 +283,7 @@ void Model::UpdateEffects(_In_ std::function<void(IEffect*)> setEffect)
 
             for (auto it = mesh->meshParts.cbegin(); it != mesh->meshParts.cend(); ++it)
             {
-                if ((*it)->effect != 0)
+                if ((*it)->effect)
                     mEffectCache.insert((*it)->effect.get());
             }
         }

--- a/Src/PlatformHelpers.h
+++ b/Src/PlatformHelpers.h
@@ -15,6 +15,13 @@
 #include <exception>
 #include <memory>
 
+#ifndef MAKEFOURCC
+    #define MAKEFOURCC(ch0, ch1, ch2, ch3) \
+                (static_cast<uint32_t>(static_cast<uint8_t>(ch0)) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch1)) << 8) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch2)) << 16) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch3)) << 24))
+#endif /* defined(MAKEFOURCC) */
 
 namespace DirectX
 {

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -88,7 +88,7 @@ namespace
     {
         D3D11_BUFFER_DESC desc = {};
 
-        desc.ByteWidth = (UINT)bufferSize;
+        desc.ByteWidth = static_cast<UINT>(bufferSize);
         desc.BindFlags = bindFlag;
         desc.Usage = D3D11_USAGE_DYNAMIC;
         desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
@@ -176,7 +176,7 @@ void PrimitiveBatchBase::Impl::Begin()
 
     // Bind the vertex buffer.
     auto vertexBuffer = mVertexBuffer.Get();
-    UINT vertexStride = (UINT)mVertexSize;
+    UINT vertexStride = static_cast<UINT>(mVertexSize);
     UINT vertexOffset = 0;
 
     mDeviceContext->IASetVertexBuffers(0, 1, &vertexBuffer, &vertexStride, &vertexOffset);
@@ -336,7 +336,7 @@ void PrimitiveBatchBase::Impl::Draw(D3D11_PRIMITIVE_TOPOLOGY topology, bool isIn
         
         for (size_t i = 0; i < indexCount; i++)
         {
-            outputIndices[i] = (uint16_t)(indices[i] + mCurrentVertex - mBaseVertex);
+            outputIndices[i] = static_cast<uint16_t>(indices[i] + mCurrentVertex - mBaseVertex);
         }
  
         mCurrentIndex += indexCount;
@@ -385,12 +385,12 @@ void PrimitiveBatchBase::Impl::FlushBatch()
         // Draw indexed geometry.
         mDeviceContext->Unmap(mIndexBuffer.Get(), 0);
 
-        mDeviceContext->DrawIndexed((UINT)(mCurrentIndex - mBaseIndex), (UINT)mBaseIndex, (UINT)mBaseVertex);
+        mDeviceContext->DrawIndexed(static_cast<UINT>(mCurrentIndex - mBaseIndex), static_cast<UINT>(mBaseIndex), static_cast<UINT>(mBaseVertex));
     }
     else
     {
         // Draw non-indexed geometry.
-        mDeviceContext->Draw((UINT)(mCurrentVertex - mBaseVertex), (UINT)mBaseVertex);
+        mDeviceContext->Draw(static_cast<UINT>(mCurrentVertex - mBaseVertex), static_cast<UINT>(mBaseVertex));
     }
 #endif
 

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -26,8 +26,8 @@
 #include "ScreenGrab.h"
 #include "DirectXHelpers.h"
 
-#include "dds.h"
 #include "PlatformHelpers.h"
+#include "dds.h"
 #include "LoaderHelpers.h"
 
 using Microsoft::WRL::ComPtr;

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -71,7 +71,7 @@ namespace
             desc.SampleDesc.Quality = 0;
 
             ComPtr<ID3D11Texture2D> pTemp;
-            hr = d3dDevice->CreateTexture2D(&desc, 0, pTemp.GetAddressOf());
+            hr = d3dDevice->CreateTexture2D(&desc, nullptr, pTemp.GetAddressOf());
             if (FAILED(hr))
                 return hr;
 
@@ -101,7 +101,7 @@ namespace
             desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
             desc.Usage = D3D11_USAGE_STAGING;
 
-            hr = d3dDevice->CreateTexture2D(&desc, 0, pStaging.ReleaseAndGetAddressOf());
+            hr = d3dDevice->CreateTexture2D(&desc, nullptr, pStaging.ReleaseAndGetAddressOf());
             if (FAILED(hr))
                 return hr;
 
@@ -122,7 +122,7 @@ namespace
             desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
             desc.Usage = D3D11_USAGE_STAGING;
 
-            hr = d3dDevice->CreateTexture2D(&desc, 0, pStaging.ReleaseAndGetAddressOf());
+            hr = d3dDevice->CreateTexture2D(&desc, nullptr, pStaging.ReleaseAndGetAddressOf());
             if (FAILED(hr))
                 return hr;
 

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -788,8 +788,8 @@ void SpriteBatch::Impl::RenderBatch(ID3D11ShaderResourceView* texture, SpriteInf
 #endif
 
         // Ok lads, the time has come for us draw ourselves some sprites!
-        UINT startIndex = (UINT)mContextResources->vertexBufferPosition * IndicesPerSprite;
-        UINT indexCount = (UINT)batchSize * IndicesPerSprite;
+        auto startIndex = static_cast<UINT>(mContextResources->vertexBufferPosition * IndicesPerSprite);
+        auto indexCount = static_cast<UINT>(batchSize * IndicesPerSprite);
 
         deviceContext->DrawIndexed(indexCount, startIndex, 0);
 

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -50,7 +50,7 @@ namespace
         v = XMConvertVectorIntToFloat(v, 0);
 
         // Convert right/bottom to width/height.
-        v -= XMVectorPermute<0, 1, 4, 5>(XMVectorZero(), v);
+        v = XMVectorSubtract(v, XMVectorPermute<0, 1, 4, 5>(g_XMZero, v));
 
         return v;
     }
@@ -483,7 +483,7 @@ void XM_CALLCONV SpriteBatch::Impl::Draw(ID3D11ShaderResourceView* texture,
         // If the destination size is relative to the source region, convert it to pixels.
         if (!(flags & SpriteInfo::DestSizeInPixels))
         {
-            dest = XMVectorPermute<0, 1, 6, 7>(dest, dest * source); // dest.zw *= source.zw
+            dest = XMVectorPermute<0, 1, 6, 7>(dest, XMVectorMultiply(dest, source)); // dest.zw *= source.zw
         }
 
         flags |= SpriteInfo::SourceInTexels | SpriteInfo::DestSizeInPixels;
@@ -833,18 +833,18 @@ void XM_CALLCONV SpriteBatch::Impl::RenderSprite(SpriteInfo const* sprite,
     // Convert the source region from texels to mod-1 texture coordinate format.
     if (flags & SpriteInfo::SourceInTexels)
     {
-        source *= inverseTextureSize;
-        sourceSize *= inverseTextureSize;
+        source = XMVectorMultiply(source, inverseTextureSize);
+        sourceSize = XMVectorMultiply(sourceSize, inverseTextureSize);
     }
     else
     {
-        origin *= inverseTextureSize;
+        origin = XMVectorMultiply(origin, inverseTextureSize);
     }
 
     // If the destination size is relative to the source region, convert it to pixels.
     if (!(flags & SpriteInfo::DestSizeInPixels))
     {
-        destinationSize *= textureSize;
+        destinationSize = XMVectorMultiply(destinationSize, textureSize);
     }
 
     // Compute a 2x2 rotation matrix.
@@ -861,7 +861,7 @@ void XM_CALLCONV SpriteBatch::Impl::RenderSprite(SpriteInfo const* sprite,
         XMVECTOR cosV = XMLoadFloat(&cos);
 
         rotationMatrix1 = XMVectorMergeXY(cosV, sinV);
-        rotationMatrix2 = XMVectorMergeXY(-sinV, cosV);
+        rotationMatrix2 = XMVectorMergeXY(XMVectorNegate(sinV), cosV);
     }
     else
     {
@@ -894,7 +894,7 @@ void XM_CALLCONV SpriteBatch::Impl::RenderSprite(SpriteInfo const* sprite,
     for (size_t i = 0; i < VerticesPerSprite; i++)
     {
         // Calculate position.
-        XMVECTOR cornerOffset = (cornerOffsets[i] - origin) * destinationSize;
+        XMVECTOR cornerOffset = XMVectorMultiply(XMVectorSubtract(cornerOffsets[i], origin), destinationSize);
         
         // Apply 2x2 rotation matrix.
         XMVECTOR position1 = XMVectorMultiplyAdd(XMVectorSplatX(cornerOffset), rotationMatrix1, destination);

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -93,7 +93,7 @@ SpriteFont::Impl::Impl(_In_ ID3D11Device* device, _In_ BinaryReader* reader, boo
     // Read font properties.
     lineSpacing = reader->Read<float>();
 
-    SetDefaultCharacter((wchar_t)reader->Read<uint32_t>());
+    SetDefaultCharacter(static_cast<wchar_t>(reader->Read<uint32_t>()));
 
     // Read the texture data.
     auto textureWidth = reader->Read<uint32_t>();
@@ -353,8 +353,8 @@ XMVECTOR XM_CALLCONV SpriteFont::MeasureString(_In_z_ wchar_t const* text) const
     {
         UNREFERENCED_PARAMETER(advance);
 
-        float w = (float)(glyph->Subrect.right - glyph->Subrect.left);
-        float h = (float)(glyph->Subrect.bottom - glyph->Subrect.top) + glyph->YOffset;
+        auto w = static_cast<float>(glyph->Subrect.right - glyph->Subrect.left);
+        auto h = static_cast<float>(glyph->Subrect.bottom - glyph->Subrect.top) + glyph->YOffset;
 
         h = std::max(h, pImpl->lineSpacing);
 
@@ -371,8 +371,8 @@ RECT SpriteFont::MeasureDrawBounds(_In_z_ wchar_t const* text, XMFLOAT2 const& p
 
     pImpl->ForEachGlyph(text, [&](Glyph const* glyph, float x, float y, float advance)
     {
-        float w = (float)(glyph->Subrect.right - glyph->Subrect.left);
-        float h = (float)(glyph->Subrect.bottom - glyph->Subrect.top);
+        auto w = static_cast<float>(glyph->Subrect.right - glyph->Subrect.left);
+        auto h = static_cast<float>(glyph->Subrect.bottom - glyph->Subrect.top);
 
         float minX = position.x + x;
         float minY = position.y + y + glyph->YOffset;
@@ -428,7 +428,7 @@ void SpriteFont::SetLineSpacing(float spacing)
 // Font properties
 wchar_t SpriteFont::GetDefaultCharacter() const
 {
-    return pImpl->defaultGlyph ? (wchar_t)pImpl->defaultGlyph->Character : 0;
+    return static_cast<wchar_t>(pImpl->defaultGlyph ? pImpl->defaultGlyph->Character : 0);
 }
 
 

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -316,7 +316,10 @@ void XM_CALLCONV SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wc
     // If the text is mirrored, offset the start position accordingly.
     if (effects)
     {
-        baseOffset -= MeasureString(text) * axisIsMirroredTable[effects & 3];
+        baseOffset = XMVectorNegativeMultiplySubtract(
+            MeasureString(text),
+            axisIsMirroredTable[effects & 3],
+            baseOffset);
     }
 
     // Draw each character in turn.
@@ -332,7 +335,7 @@ void XM_CALLCONV SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wc
             XMVECTOR glyphRect = XMConvertVectorIntToFloat(XMLoadInt4(reinterpret_cast<uint32_t const*>(&glyph->Subrect)), 0);
 
             // xy = glyph width/height.
-            glyphRect = XMVectorSwizzle<2, 3, 0, 1>(glyphRect) - glyphRect;
+            glyphRect = XMVectorSubtract(XMVectorSwizzle<2, 3, 0, 1>(glyphRect), glyphRect);
 
             offset = XMVectorMultiplyAdd(glyphRect, axisIsMirroredTable[effects & 3], offset);
         }

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -111,7 +111,7 @@ SpriteFont::Impl::Impl(_In_ ID3D11Device* device, _In_ BinaryReader* reader, boo
     // Create the D3D texture.
     CD3D11_TEXTURE2D_DESC textureDesc(textureFormat, textureWidth, textureHeight, 1, 1, D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_IMMUTABLE);
     CD3D11_SHADER_RESOURCE_VIEW_DESC viewDesc(D3D11_SRV_DIMENSION_TEXTURE2D, textureFormat);
-    D3D11_SUBRESOURCE_DATA initData = { textureData, textureStride };
+    D3D11_SUBRESOURCE_DATA initData = { textureData, textureStride, 0 };
     ComPtr<ID3D11Texture2D> texture2D;
 
     ThrowIfFailed(

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -142,7 +142,7 @@ namespace
 
     bool g_WIC2 = false;
 
-    BOOL WINAPI InitializeWICFactory(PINIT_ONCE, PVOID, PVOID *ifactory)
+    BOOL WINAPI InitializeWICFactory(PINIT_ONCE, PVOID, PVOID *ifactory) noexcept
     {
     #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
         HRESULT hr = CoCreateInstance(

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -141,12 +141,49 @@ namespace
     };
 
     bool g_WIC2 = false;
+
+    BOOL WINAPI InitializeWICFactory(PINIT_ONCE, PVOID, PVOID *ifactory)
+    {
+    #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
+        HRESULT hr = CoCreateInstance(
+            CLSID_WICImagingFactory2,
+            nullptr,
+            CLSCTX_INPROC_SERVER,
+            __uuidof(IWICImagingFactory2),
+            ifactory
+        );
+
+        if (SUCCEEDED(hr))
+        {
+            // WIC2 is available on Windows 10, Windows 8.x, and Windows 7 SP1 with KB 2670838 installed
+            g_WIC2 = true;
+            return TRUE;
+        }
+        else
+        {
+            hr = CoCreateInstance(
+                CLSID_WICImagingFactory1,
+                nullptr,
+                CLSCTX_INPROC_SERVER,
+                __uuidof(IWICImagingFactory),
+                ifactory
+            );
+            return SUCCEEDED(hr) ? TRUE : FALSE;
+        }
+    #else
+        return SUCCEEDED(CoCreateInstance(
+            CLSID_WICImagingFactory,
+            nullptr,
+            CLSCTX_INPROC_SERVER,
+            __uuidof(IWICImagingFactory),
+            ifactory)) ? TRUE : FALSE;
+    #endif
+    }
 }
 
 //--------------------------------------------------------------------------------------
 namespace DirectX
 {
-
     bool _IsWIC2()
     {
         return g_WIC2;
@@ -157,44 +194,11 @@ namespace DirectX
         static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
         IWICImagingFactory* factory = nullptr;
-        InitOnceExecuteOnce(&s_initOnce,
-                            [](PINIT_ONCE, PVOID, PVOID *ifactory) -> BOOL
-        {
-        #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
-            HRESULT hr = CoCreateInstance(
-                CLSID_WICImagingFactory2,
-                nullptr,
-                CLSCTX_INPROC_SERVER,
-                __uuidof(IWICImagingFactory2),
-                ifactory
-            );
-
-            if (SUCCEEDED(hr))
-            {
-                // WIC2 is available on Windows 10, Windows 8.x, and Windows 7 SP1 with KB 2670838 installed
-                g_WIC2 = true;
-                return TRUE;
-            }
-            else
-            {
-                hr = CoCreateInstance(
-                    CLSID_WICImagingFactory1,
-                    nullptr,
-                    CLSCTX_INPROC_SERVER,
-                    __uuidof(IWICImagingFactory),
-                    ifactory
-                );
-                return SUCCEEDED(hr) ? TRUE : FALSE;
-            }
-        #else
-            return SUCCEEDED(CoCreateInstance(
-                CLSID_WICImagingFactory,
-                nullptr,
-                CLSCTX_INPROC_SERVER,
-                __uuidof(IWICImagingFactory),
-                ifactory)) ? TRUE : FALSE;
-        #endif
-        }, nullptr, reinterpret_cast<LPVOID*>(&factory));
+        (void)InitOnceExecuteOnce(
+            &s_initOnce,
+            InitializeWICFactory,
+            nullptr,
+            reinterpret_cast<LPVOID*>(&factory));
 
         return factory;
     }

--- a/Src/XboxDDSTextureLoader.cpp
+++ b/Src/XboxDDSTextureLoader.cpp
@@ -19,9 +19,9 @@
 
 #include "XboxDDSTextureLoader.h"
 
+#include "PlatformHelpers.h"
 #include "dds.h"
 #include "DirectXHelpers.h"
-#include "PlatformHelpers.h"
 
 #include <xdk.h>
 

--- a/Src/dds.h
+++ b/Src/dds.h
@@ -49,12 +49,6 @@ struct DDS_PIXELFORMAT
 #define DDS_PAL8A       0x00000021  // DDPF_PALETTEINDEXED8 | DDPF_ALPHAPIXELS
 #define DDS_BUMPDUDV    0x00080000  // DDPF_BUMPDUDV
 
-#ifndef MAKEFOURCC
-    #define MAKEFOURCC(ch0, ch1, ch2, ch3)                              \
-                ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) |       \
-                ((uint32_t)(uint8_t)(ch2) << 16) | ((uint32_t)(uint8_t)(ch3) << 24 ))
-#endif /* defined(MAKEFOURCC) */
-
 extern __declspec(selectany) const DDS_PIXELFORMAT DDSPF_DXT1 =
     { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','1'), 0, 0, 0, 0, 0 };
 

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -83,6 +83,8 @@
 #pragma warning(pop)
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
+
 #include <DirectXMath.h>
 #include <DirectXPackedVector.h>
 #include <DirectXCollision.h>

--- a/XWBTool/xwbtool.cpp
+++ b/XWBTool/xwbtool.cpp
@@ -50,9 +50,11 @@
 //////////////////////////////////////////////////////////////////////////////
 
 #ifndef MAKEFOURCC
-#define MAKEFOURCC(ch0, ch1, ch2, ch3)                              \
-                ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) |       \
-                ((uint32_t)(uint8_t)(ch2) << 16) | ((uint32_t)(uint8_t)(ch3) << 24 ))
+#define MAKEFOURCC(ch0, ch1, ch2, ch3) \
+                (static_cast<uint32_t>(static_cast<uint8_t>(ch0)) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch1)) << 8) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch2)) << 16) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch3)) << 24))
 #endif /* defined(MAKEFOURCC) */
 
 #ifndef WAVE_FORMAT_XMA2


### PR DESCRIPTION
The change here is to make the _DirectX Tool Kit_ math code build correctly with DirectXMath 3.12 or later when using ``_XM_NO_XMVECTOR_OVERLOADS_``.