### PR TITLE
SDKMESH2 export support for PBR materials

### DIFF
--- a/DirectXTK_Desktop_2015.vcxproj
+++ b/DirectXTK_Desktop_2015.vcxproj
@@ -80,6 +80,7 @@
     <ClCompile Include="Src\Mouse.cpp" />
     <ClCompile Include="Src\NormalMapEffect.cpp" />
     <ClCompile Include="Src\PBREffect.cpp" />
+    <ClCompile Include="Src\PBREffectFactory.cpp" />
     <ClCompile Include="Src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/DirectXTK_Desktop_2015.vcxproj.filters
+++ b/DirectXTK_Desktop_2015.vcxproj.filters
@@ -236,6 +236,9 @@
     <ClCompile Include="Src\DebugEffect.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Src\PBREffectFactory.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Src\Shaders\CompileShaders.cmd">

--- a/DirectXTK_Desktop_2015_Win10.vcxproj
+++ b/DirectXTK_Desktop_2015_Win10.vcxproj
@@ -92,6 +92,7 @@
     <ClCompile Include="Src\Mouse.cpp" />
     <ClCompile Include="Src\NormalMapEffect.cpp" />
     <ClCompile Include="Src\PBREffect.cpp" />
+    <ClCompile Include="Src\PBREffectFactory.cpp" />
     <ClCompile Include="Src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/DirectXTK_Desktop_2015_Win10.vcxproj.filters
+++ b/DirectXTK_Desktop_2015_Win10.vcxproj.filters
@@ -275,6 +275,9 @@
     <ClCompile Include="Src\DebugEffect.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Src\PBREffectFactory.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Src\Shaders\CompileShaders.cmd">

--- a/DirectXTK_Desktop_2017.vcxproj
+++ b/DirectXTK_Desktop_2017.vcxproj
@@ -80,6 +80,7 @@
     <ClCompile Include="Src\Mouse.cpp" />
     <ClCompile Include="Src\NormalMapEffect.cpp" />
     <ClCompile Include="Src\PBREffect.cpp" />
+    <ClCompile Include="Src\PBREffectFactory.cpp" />
     <ClCompile Include="Src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/DirectXTK_Desktop_2017.vcxproj.filters
+++ b/DirectXTK_Desktop_2017.vcxproj.filters
@@ -236,6 +236,9 @@
     <ClCompile Include="Src\DebugEffect.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Src\PBREffectFactory.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Src\Shaders\CompileShaders.cmd">

--- a/DirectXTK_Desktop_2017_Win10.vcxproj
+++ b/DirectXTK_Desktop_2017_Win10.vcxproj
@@ -92,6 +92,7 @@
     <ClCompile Include="Src\Mouse.cpp" />
     <ClCompile Include="Src\NormalMapEffect.cpp" />
     <ClCompile Include="Src\PBREffect.cpp" />
+    <ClCompile Include="Src\PBREffectFactory.cpp" />
     <ClCompile Include="Src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/DirectXTK_Desktop_2017_Win10.vcxproj.filters
+++ b/DirectXTK_Desktop_2017_Win10.vcxproj.filters
@@ -275,6 +275,9 @@
     <ClCompile Include="Src\DebugEffect.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Src\PBREffectFactory.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Src\Shaders\CompileShaders.cmd">

--- a/DirectXTK_Windows10.vcxproj
+++ b/DirectXTK_Windows10.vcxproj
@@ -444,6 +444,7 @@
     <ClCompile Include="Src\Mouse.cpp" />
     <ClCompile Include="Src\NormalMapEffect.cpp" />
     <ClCompile Include="Src\PBREffect.cpp" />
+    <ClCompile Include="Src\PBREffectFactory.cpp" />
     <ClCompile Include="Src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/DirectXTK_Windows10.vcxproj.filters
+++ b/DirectXTK_Windows10.vcxproj.filters
@@ -1324,6 +1324,9 @@
     <ClCompile Include="Src\DebugEffect.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Src\PBREffectFactory.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Text Include="Readme.txt" />

--- a/DirectXTK_Windows10_2015.vcxproj
+++ b/DirectXTK_Windows10_2015.vcxproj
@@ -436,6 +436,7 @@
     <ClCompile Include="Src\Mouse.cpp" />
     <ClCompile Include="Src\NormalMapEffect.cpp" />
     <ClCompile Include="Src\PBREffect.cpp" />
+    <ClCompile Include="Src\PBREffectFactory.cpp" />
     <ClCompile Include="Src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/DirectXTK_Windows10_2015.vcxproj.filters
+++ b/DirectXTK_Windows10_2015.vcxproj.filters
@@ -1324,6 +1324,9 @@
     <ClCompile Include="Src\DebugEffect.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Src\PBREffectFactory.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Text Include="Readme.txt" />

--- a/DirectXTK_XboxOneXDK_2015.vcxproj
+++ b/DirectXTK_XboxOneXDK_2015.vcxproj
@@ -88,6 +88,7 @@
     <ClCompile Include="Src\Mouse.cpp" />
     <ClCompile Include="Src\NormalMapEffect.cpp" />
     <ClCompile Include="Src\PBREffect.cpp" />
+    <ClCompile Include="Src\PBREffectFactory.cpp" />
     <ClCompile Include="Src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Durango'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Durango'">Create</PrecompiledHeader>

--- a/DirectXTK_XboxOneXDK_2015.vcxproj.filters
+++ b/DirectXTK_XboxOneXDK_2015.vcxproj.filters
@@ -280,6 +280,9 @@
     <ClCompile Include="Src\DebugEffect.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Src\PBREffectFactory.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Src\Shaders\CompileShaders.cmd">

--- a/DirectXTK_XboxOneXDK_2017.vcxproj
+++ b/DirectXTK_XboxOneXDK_2017.vcxproj
@@ -88,6 +88,7 @@
     <ClCompile Include="Src\Mouse.cpp" />
     <ClCompile Include="Src\NormalMapEffect.cpp" />
     <ClCompile Include="Src\PBREffect.cpp" />
+    <ClCompile Include="Src\PBREffectFactory.cpp" />
     <ClCompile Include="Src\pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Durango'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Durango'">Create</PrecompiledHeader>

--- a/DirectXTK_XboxOneXDK_2017.vcxproj.filters
+++ b/DirectXTK_XboxOneXDK_2017.vcxproj.filters
@@ -280,6 +280,9 @@
     <ClCompile Include="Src\DebugEffect.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Src\PBREffectFactory.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Src\Shaders\CompileShaders.cmd">

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -763,6 +763,7 @@ namespace DirectX
             const wchar_t*      diffuseTexture;
             const wchar_t*      specularTexture;
             const wchar_t*      normalTexture;
+            const wchar_t*      emissiveTexture;
 
             EffectInfo() noexcept :
                 name(nullptr),
@@ -779,7 +780,8 @@ namespace DirectX
                 emissiveColor(0, 0, 0),
                 diffuseTexture(nullptr),
                 specularTexture(nullptr),
-                normalTexture(nullptr)
+                normalTexture(nullptr),
+                emissiveTexture(nullptr)
                 {}
         };
 
@@ -850,7 +852,7 @@ namespace DirectX
         // DGSL methods.
         struct DGSLEffectInfo : public EffectInfo
         {
-            static const int BaseTextureOffset = 3;
+            static const int BaseTextureOffset = 4;
 
             const wchar_t* textures[DGSLEffect::MaxTextures - BaseTextureOffset];
             const wchar_t* pixelShader;

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -832,6 +832,43 @@ namespace DirectX
     };
 
 
+    // Factory for Physically Based Rendering (PBR)
+    class PBREffectFactory : public IEffectFactory
+    {
+    public:
+        explicit PBREffectFactory(_In_ ID3D11Device* device);
+        PBREffectFactory(PBREffectFactory&& moveFrom) noexcept;
+        PBREffectFactory& operator= (PBREffectFactory&& moveFrom) noexcept;
+
+        PBREffectFactory(PBREffectFactory const&) = delete;
+        PBREffectFactory& operator= (PBREffectFactory const&) = delete;
+
+        virtual ~PBREffectFactory() override;
+
+        // IEffectFactory methods.
+        virtual std::shared_ptr<IEffect> __cdecl CreateEffect(_In_ const EffectInfo& info, _In_opt_ ID3D11DeviceContext* deviceContext) override;
+        virtual void __cdecl CreateTexture(_In_z_ const wchar_t* name, _In_opt_ ID3D11DeviceContext* deviceContext, _Outptr_ ID3D11ShaderResourceView** textureView) override;
+
+        // Settings.
+        void __cdecl ReleaseCache();
+
+        void __cdecl SetSharing(bool enabled);
+
+        void __cdecl EnableForceSRGB(bool forceSRGB);
+
+        void __cdecl SetDirectory(_In_opt_z_ const wchar_t* path);
+
+        // Properties.
+        ID3D11Device* GetDevice() const;
+
+    private:
+        // Private implementation.
+        class Impl;
+
+        std::shared_ptr<Impl> pImpl;
+    };
+
+
     // Factory for sharing Visual Studio Shader Designer (DGSL) shaders and texture resources
     class DGSLEffectFactory : public IEffectFactory
     {

--- a/Src/DGSLEffectFactory.cpp
+++ b/Src/DGSLEffectFactory.cpp
@@ -310,6 +310,16 @@ std::shared_ptr<IEffect> DGSLEffectFactory::Impl::CreateDGSLEffect(DGSLEffectFac
         effect->SetTextureEnabled(true);
     }
 
+    if (info.emissiveTexture && *info.emissiveTexture)
+    {
+        ComPtr<ID3D11ShaderResourceView> srv;
+
+        factory->CreateTexture(info.emissiveTexture, deviceContext, srv.GetAddressOf());
+
+        effect->SetTexture(3, srv.Get());
+        effect->SetTextureEnabled(true);
+    }
+
     for (size_t j = 0; j < _countof(info.textures); ++j)
     {
         if (info.textures[j] && *info.textures[j])

--- a/Src/EffectFactory.cpp
+++ b/Src/EffectFactory.cpp
@@ -168,8 +168,17 @@ std::shared_ptr<IEffect> EffectFactory::Impl::CreateEffect(IEffectFactory* facto
             effect->SetTexture(srv.Get());
         }
 
-        if (info.specularTexture && *info.specularTexture)
+        if (info.emissiveTexture && *info.emissiveTexture)
         {
+            ComPtr<ID3D11ShaderResourceView> srv;
+
+            factory->CreateTexture(info.emissiveTexture, deviceContext, srv.GetAddressOf());
+
+            effect->SetTexture2(srv.Get());
+        }
+        else if (info.specularTexture && *info.specularTexture)
+        {
+            // If there's no emissive texture specified, use the specular texture as the second texture
             ComPtr<ID3D11ShaderResourceView> srv;
 
             factory->CreateTexture(info.specularTexture, deviceContext, srv.GetAddressOf());

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -797,6 +797,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(ID3D11Device* d3dDevice, co
                 info.diffuseTexture = m.texture[0].empty() ? nullptr : m.texture[0].c_str();
                 info.specularTexture = m.texture[1].empty() ? nullptr : m.texture[1].c_str();
                 info.normalTexture = m.texture[2].empty() ? nullptr : m.texture[2].c_str();
+                info.emissiveTexture = m.texture[3].empty() ? nullptr : m.texture[3].c_str();
                 info.pixelShader = m.pixelShader.c_str();
 
                 const int offset = DGSLEffectFactory::DGSLEffectInfo::BaseTextureOffset;

--- a/Src/PBREffectFactory.cpp
+++ b/Src/PBREffectFactory.cpp
@@ -1,0 +1,298 @@
+//--------------------------------------------------------------------------------------
+// File: PBREffectFactory.cpp
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248929
+//--------------------------------------------------------------------------------------
+
+#include "pch.h"
+#include "Effects.h"
+#include "DemandCreate.h"
+#include "SharedResourcePool.h"
+
+#include "DDSTextureLoader.h"
+#include "WICTextureLoader.h"
+
+using namespace DirectX;
+using Microsoft::WRL::ComPtr;
+
+// Internal PBREffectFactory implementation class. Only one of these helpers is allocated
+// per D3D device, even if there are multiple public facing PBREffectFactory instances.
+class PBREffectFactory::Impl
+{
+public:
+    Impl(_In_ ID3D11Device* device)
+        : mPath{},
+        mDevice(device),
+        mSharing(true),
+        mForceSRGB(false)
+    {}
+
+    std::shared_ptr<IEffect> CreateEffect(_In_ IEffectFactory* factory, _In_ const IEffectFactory::EffectInfo& info, _In_opt_ ID3D11DeviceContext* deviceContext);
+    void CreateTexture(_In_z_ const wchar_t* texture, _In_opt_ ID3D11DeviceContext* deviceContext, _Outptr_ ID3D11ShaderResourceView** textureView);
+
+    void ReleaseCache();
+    void SetSharing(bool enabled) { mSharing = enabled; }
+    void EnableForceSRGB(bool forceSRGB) { mForceSRGB = forceSRGB; }
+
+    static SharedResourcePool<ID3D11Device*, Impl> instancePool;
+
+    wchar_t mPath[MAX_PATH];
+
+    ComPtr<ID3D11Device> mDevice;
+
+private:
+    typedef std::map< std::wstring, std::shared_ptr<IEffect> > EffectCache;
+    typedef std::map< std::wstring, ComPtr<ID3D11ShaderResourceView> > TextureCache;
+
+    EffectCache  mEffectCache;
+    TextureCache mTextureCache;
+
+    bool mSharing;
+    bool mForceSRGB;
+
+    std::mutex mutex;
+};
+
+
+// Global instance pool.
+SharedResourcePool<ID3D11Device*, PBREffectFactory::Impl> PBREffectFactory::Impl::instancePool;
+
+
+_Use_decl_annotations_
+std::shared_ptr<IEffect> PBREffectFactory::Impl::CreateEffect(IEffectFactory* factory, const IEffectFactory::EffectInfo& info, ID3D11DeviceContext* deviceContext)
+{
+    if (mSharing && info.name && *info.name)
+    {
+        auto it = mEffectCache.find(info.name);
+        if (mSharing && it != mEffectCache.end())
+        {
+            return it->second;
+        }
+    }
+
+    auto effect = std::make_shared<PBREffect>(mDevice.Get());
+
+    effect->EnableDefaultLighting();
+
+    effect->SetAlpha(info.alpha);
+
+    ComPtr<ID3D11ShaderResourceView> albetoSrv;
+    if (info.diffuseTexture && *info.diffuseTexture)
+    {
+        factory->CreateTexture(info.diffuseTexture, deviceContext, albetoSrv.GetAddressOf());
+    }
+
+    ComPtr<ID3D11ShaderResourceView> normalSrv;
+    if (info.normalTexture && *info.normalTexture)
+    {
+        factory->CreateTexture(info.normalTexture, deviceContext, normalSrv.GetAddressOf());
+    }
+
+    ComPtr<ID3D11ShaderResourceView> rmaSrv;
+    if (info.specularTexture && *info.specularTexture)
+    {
+        // We use the specular texture for the roughness/metalness/ambient-occlusion texture
+        factory->CreateTexture(info.specularTexture, deviceContext, rmaSrv.GetAddressOf());
+    }
+
+    effect->SetSurfaceTextures(albetoSrv.Get(), normalSrv.Get(), rmaSrv.Get());
+
+    if (info.emissiveTexture && *info.emissiveTexture)
+    {
+        ComPtr<ID3D11ShaderResourceView> srv;
+        factory->CreateTexture(info.emissiveTexture, deviceContext, srv.GetAddressOf());
+
+        effect->SetEmissiveTexture(srv.Get());
+    }
+
+    if (info.biasedVertexNormals)
+    {
+        effect->SetBiasedVertexNormals(true);
+    }
+
+    if (mSharing && info.name && *info.name)
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        EffectCache::value_type v(info.name, effect);
+        mEffectCache.insert(v);
+    }
+
+    return effect;
+}
+
+_Use_decl_annotations_
+void PBREffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext* deviceContext, ID3D11ShaderResourceView** textureView)
+{
+    if (!name || !textureView)
+        throw std::exception("invalid arguments");
+
+#if defined(_XBOX_ONE) && defined(_TITLE)
+    UNREFERENCED_PARAMETER(deviceContext);
+#endif
+
+    auto it = mTextureCache.find(name);
+
+    if (mSharing && it != mTextureCache.end())
+    {
+        ID3D11ShaderResourceView* srv = it->second.Get();
+        srv->AddRef();
+        *textureView = srv;
+    }
+    else
+    {
+        wchar_t fullName[MAX_PATH] = {};
+        wcscpy_s(fullName, mPath);
+        wcscat_s(fullName, name);
+
+        WIN32_FILE_ATTRIBUTE_DATA fileAttr = {};
+        if (!GetFileAttributesExW(fullName, GetFileExInfoStandard, &fileAttr))
+        {
+            // Try Current Working Directory (CWD)
+            wcscpy_s(fullName, name);
+            if (!GetFileAttributesExW(fullName, GetFileExInfoStandard, &fileAttr))
+            {
+                DebugTrace("ERROR: PBREffectFactory could not find texture file '%ls'\n", name);
+                throw std::exception("CreateTexture");
+            }
+        }
+
+        wchar_t ext[_MAX_EXT];
+        _wsplitpath_s(name, nullptr, 0, nullptr, 0, nullptr, 0, ext, _MAX_EXT);
+
+        if (_wcsicmp(ext, L".dds") == 0)
+        {
+            HRESULT hr = CreateDDSTextureFromFileEx(
+                mDevice.Get(), fullName, 0,
+                D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
+                mForceSRGB, nullptr, textureView);
+            if (FAILED(hr))
+            {
+                DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n", hr, fullName);
+                throw std::exception("CreateDDSTextureFromFile");
+            }
+        }
+    #if !defined(_XBOX_ONE) || !defined(_TITLE)
+        else if (deviceContext)
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            HRESULT hr = CreateWICTextureFromFileEx(
+                mDevice.Get(), deviceContext, fullName, 0,
+                D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
+                mForceSRGB ? WIC_LOADER_FORCE_SRGB : WIC_LOADER_DEFAULT, nullptr, textureView);
+            if (FAILED(hr))
+            {
+                DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n", hr, fullName);
+                throw std::exception("CreateWICTextureFromFile");
+            }
+        }
+    #endif
+        else
+        {
+            HRESULT hr = CreateWICTextureFromFileEx(
+                mDevice.Get(), fullName, 0,
+                D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
+                mForceSRGB ? WIC_LOADER_FORCE_SRGB : WIC_LOADER_DEFAULT, nullptr, textureView);
+            if (FAILED(hr))
+            {
+                DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n", hr, fullName);
+                throw std::exception("CreateWICTextureFromFile");
+            }
+        }
+
+        if (mSharing && *name && it == mTextureCache.end())
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            TextureCache::value_type v(name, *textureView);
+            mTextureCache.insert(v);
+        }
+    }
+}
+
+void PBREffectFactory::Impl::ReleaseCache()
+{
+    std::lock_guard<std::mutex> lock(mutex);
+    mEffectCache.clear();
+    mTextureCache.clear();
+}
+
+
+
+//--------------------------------------------------------------------------------------
+// PBREffectFactory
+//--------------------------------------------------------------------------------------
+
+PBREffectFactory::PBREffectFactory(_In_ ID3D11Device* device)
+    : pImpl(Impl::instancePool.DemandCreate(device))
+{
+}
+
+PBREffectFactory::~PBREffectFactory()
+{
+}
+
+
+PBREffectFactory::PBREffectFactory(PBREffectFactory&& moveFrom) noexcept
+    : pImpl(std::move(moveFrom.pImpl))
+{
+}
+
+PBREffectFactory& PBREffectFactory::operator= (PBREffectFactory&& moveFrom) noexcept
+{
+    pImpl = std::move(moveFrom.pImpl);
+    return *this;
+}
+
+_Use_decl_annotations_
+std::shared_ptr<IEffect> PBREffectFactory::CreateEffect(const EffectInfo& info, ID3D11DeviceContext* deviceContext)
+{
+    return pImpl->CreateEffect(this, info, deviceContext);
+}
+
+_Use_decl_annotations_
+void PBREffectFactory::CreateTexture(const wchar_t* name, ID3D11DeviceContext* deviceContext, ID3D11ShaderResourceView** textureView)
+{
+    return pImpl->CreateTexture(name, deviceContext, textureView);
+}
+
+void PBREffectFactory::ReleaseCache()
+{
+    pImpl->ReleaseCache();
+}
+
+void PBREffectFactory::SetSharing(bool enabled)
+{
+    pImpl->SetSharing(enabled);
+}
+
+void PBREffectFactory::EnableForceSRGB(bool forceSRGB)
+{
+    pImpl->EnableForceSRGB(forceSRGB);
+}
+
+void PBREffectFactory::SetDirectory(_In_opt_z_ const wchar_t* path)
+{
+    if (path && *path != 0)
+    {
+        wcscpy_s(pImpl->mPath, path);
+        size_t len = wcsnlen(pImpl->mPath, MAX_PATH);
+        if (len > 0 && len < (MAX_PATH - 1))
+        {
+            // Ensure it has a trailing slash
+            if (pImpl->mPath[len - 1] != L'\\')
+            {
+                pImpl->mPath[len] = L'\\';
+                pImpl->mPath[len + 1] = 0;
+            }
+        }
+    }
+    else
+        *pImpl->mPath = 0;
+}
+
+ID3D11Device* PBREffectFactory::GetDevice() const
+{
+    return pImpl->mDevice.Get();
+}

--- a/Src/SDKMesh.h
+++ b/Src/SDKMesh.h
@@ -191,10 +191,7 @@ namespace DXUT
         uint64_t SizeBytes;
         uint64_t StrideBytes;
         D3DVERTEXELEMENT9 Decl[MAX_VERTEX_ELEMENTS];
-        union
-        {
-            uint64_t DataOffset;
-        };
+        uint64_t DataOffset;
     };
 
     struct SDKMESH_INDEX_BUFFER_HEADER
@@ -202,10 +199,7 @@ namespace DXUT
         uint64_t NumIndices;
         uint64_t SizeBytes;
         uint32_t IndexType;
-        union
-        {
-            uint64_t DataOffset;
-        };
+        uint64_t DataOffset;
     };
 
     struct SDKMESH_MESH
@@ -272,31 +266,12 @@ namespace DXUT
         DirectX::XMFLOAT4 Emissive;
         float Power;
 
-        union
-        {
-            uint64_t Force64_1;			//Force the union to 64bits
-        };
-        union
-        {
-            uint64_t Force64_2;			//Force the union to 64bits
-        };
-        union
-        {
-            uint64_t Force64_3;			//Force the union to 64bits
-        };
-
-        union
-        {
-            uint64_t Force64_4;			//Force the union to 64bits
-        };
-        union
-        {
-            uint64_t Force64_5;		    //Force the union to 64bits
-        };
-        union
-        {
-            uint64_t Force64_6;			//Force the union to 64bits
-        };
+        uint64_t Force64_1;
+        uint64_t Force64_2;
+        uint64_t Force64_3;
+        uint64_t Force64_4;
+        uint64_t Force64_5;
+        uint64_t Force64_6;
     };
 
     struct SDKMESH_MATERIAL_V2
@@ -313,31 +288,12 @@ namespace DXUT
 
         char    Reserved[60];
 
-        union
-        {
-            uint64_t Force64_1;			//Force the union to 64bits
-        };
-        union
-        {
-            uint64_t Force64_2;			//Force the union to 64bits
-        };
-        union
-        {
-            uint64_t Force64_3;			//Force the union to 64bits
-        };
-
-        union
-        {
-            uint64_t Force64_4;			//Force the union to 64bits
-        };
-        union
-        {
-            uint64_t Force64_5;		    //Force the union to 64bits
-        };
-        union
-        {
-            uint64_t Force64_6;			//Force the union to 64bits
-        };
+        uint64_t Force64_1;
+        uint64_t Force64_2;
+        uint64_t Force64_3;
+        uint64_t Force64_4;
+        uint64_t Force64_5;
+        uint64_t Force64_6;
     };
 
     struct SDKANIMATION_FILE_HEADER
@@ -362,11 +318,7 @@ namespace DXUT
     struct SDKANIMATION_FRAME_DATA
     {
         char FrameName[MAX_FRAME_NAME];
-        union
-        {
-            uint64_t DataOffset;
-            SDKANIMATION_DATA* pAnimationData;
-        };
+        uint64_t DataOffset;
     };
 
     #pragma pack(pop)

--- a/Src/SDKMesh.h
+++ b/Src/SDKMesh.h
@@ -106,6 +106,8 @@ namespace DXUT
     // Hard Defines for the various structures
     //--------------------------------------------------------------------------------------
     const uint32_t SDKMESH_FILE_VERSION = 101;
+    const uint32_t SDKMESH_FILE_VERSION_V2 = 200;
+
     const uint32_t MAX_VERTEX_ELEMENTS = 32;
     const uint32_t MAX_VERTEX_STREAMS = 16;
     const uint32_t MAX_FRAME_NAME = 100;
@@ -297,6 +299,47 @@ namespace DXUT
         };
     };
 
+    struct SDKMESH_MATERIAL_V2
+    {
+        char    Name[MAX_MATERIAL_NAME];
+
+        // PBR materials
+        char    RMATexture[MAX_TEXTURE_NAME];
+        char    AlbetoTexture[MAX_TEXTURE_NAME];
+        char    NormalTexture[MAX_TEXTURE_NAME];
+        char    EmissiveTexture[MAX_TEXTURE_NAME];
+
+        float   Alpha;
+
+        char    Reserved[60];
+
+        union
+        {
+            uint64_t Force64_1;			//Force the union to 64bits
+        };
+        union
+        {
+            uint64_t Force64_2;			//Force the union to 64bits
+        };
+        union
+        {
+            uint64_t Force64_3;			//Force the union to 64bits
+        };
+
+        union
+        {
+            uint64_t Force64_4;			//Force the union to 64bits
+        };
+        union
+        {
+            uint64_t Force64_5;		    //Force the union to 64bits
+        };
+        union
+        {
+            uint64_t Force64_6;			//Force the union to 64bits
+        };
+    };
+
     struct SDKANIMATION_FILE_HEADER
     {
         uint32_t Version;
@@ -338,6 +381,7 @@ static_assert( sizeof(DXUT::SDKMESH_MESH) == 224, "SDK Mesh structure size incor
 static_assert( sizeof(DXUT::SDKMESH_SUBSET) == 144, "SDK Mesh structure size incorrect" );
 static_assert( sizeof(DXUT::SDKMESH_FRAME) == 184, "SDK Mesh structure size incorrect" );
 static_assert( sizeof(DXUT::SDKMESH_MATERIAL) == 1256, "SDK Mesh structure size incorrect" );
+static_assert( sizeof(DXUT::SDKMESH_MATERIAL_V2) == sizeof(DXUT::SDKMESH_MATERIAL), "SDK Mesh structure size incorrect" );
 static_assert( sizeof(DXUT::SDKANIMATION_FILE_HEADER) == 40, "SDK Mesh structure size incorrect" );
 static_assert( sizeof(DXUT::SDKANIMATION_DATA) == 40, "SDK Mesh structure size incorrect" );
 static_assert( sizeof(DXUT::SDKANIMATION_FRAME_DATA) == 112, "SDK Mesh structure size incorrect" );


### PR DESCRIPTION
Adds ``PBREffectFactory`` class and ``sdkmesh2`` materials loading

> EffectInfo now has one more texture for emissive channel, with DGSLEffectInfo updated to have one less array entry to maintain the 8 texture slots.