### PR TITLE
Ex texture loaders updated with additional parameter validation

### DIFF
--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -1001,6 +1001,11 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
         return E_INVALIDARG;
     }
 
+    if (textureView && !(bindFlags & D3D11_BIND_SHADER_RESOURCE))
+    {
+        return E_INVALIDARG;
+    }
+
     // Validate DDS file in memory
     const DDS_HEADER* header = nullptr;
     const uint8_t* bitData = nullptr;
@@ -1080,6 +1085,11 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
     }
 
     if (!d3dDevice || !ddsData || (!texture && !textureView))
+    {
+        return E_INVALIDARG;
+    }
+
+    if (textureView && !(bindFlags & D3D11_BIND_SHADER_RESOURCE))
     {
         return E_INVALIDARG;
     }
@@ -1201,6 +1211,11 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
         return E_INVALIDARG;
     }
 
+    if (textureView && !(bindFlags & D3D11_BIND_SHADER_RESOURCE))
+    {
+        return E_INVALIDARG;
+    }
+
     const DDS_HEADER* header = nullptr;
     const uint8_t* bitData = nullptr;
     size_t bitSize = 0;
@@ -1273,6 +1288,11 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
     }
 
     if (!d3dDevice || !fileName || (!texture && !textureView))
+    {
+        return E_INVALIDARG;
+    }
+
+    if (textureView && !(bindFlags & D3D11_BIND_SHADER_RESOURCE))
     {
         return E_INVALIDARG;
     }

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -839,7 +839,14 @@ HRESULT DirectX::CreateWICTextureFromMemoryEx(
     }
 
     if (!d3dDevice || !wicData || (!texture && !textureView))
+    {
         return E_INVALIDARG;
+    }
+
+    if (textureView && !(bindFlags & D3D11_BIND_SHADER_RESOURCE))
+    {
+        return E_INVALIDARG;
+    }
 
     if (!wicDataSize)
         return E_FAIL;
@@ -927,7 +934,14 @@ _Use_decl_annotations_
     }
 
     if (!d3dDevice || !wicData || (!texture && !textureView))
+    {
         return E_INVALIDARG;
+    }
+
+    if (textureView && !(bindFlags & D3D11_BIND_SHADER_RESOURCE))
+    {
+        return E_INVALIDARG;
+    }
 
     if (!wicDataSize)
         return E_FAIL;
@@ -1048,7 +1062,14 @@ HRESULT DirectX::CreateWICTextureFromFileEx(
     }
 
     if (!d3dDevice || !fileName || (!texture && !textureView))
+    {
         return E_INVALIDARG;
+    }
+
+    if (textureView && !(bindFlags & D3D11_BIND_SHADER_RESOURCE))
+    {
+        return E_INVALIDARG;
+    }
 
     auto pWIC = _GetWIC();
     if (!pWIC)
@@ -1117,7 +1138,14 @@ _Use_decl_annotations_
     }
 
     if (!d3dDevice || !fileName || (!texture && !textureView))
+    {
         return E_INVALIDARG;
+    }
+
+    if (textureView && !(bindFlags & D3D11_BIND_SHADER_RESOURCE))
+    {
+        return E_INVALIDARG;
+    }
 
     auto pWIC = _GetWIC();
     if (!pWIC)


### PR DESCRIPTION
If you pass a 'non-null' value to the DDS or WIC texture loaders, but when calling the ``Ex`` version you provide a ``bindFlags`` without the ``D3D11_BIND_SHADER_RESOURCE`` then it will fail when it calls ``CreateShaderResourceView``.

This PR adds validation early in the function to catch this rather than failing later on...