### PR TITLE
Added optioal forceSRGB parameter to SaveWICTextureToFile

### DIFF
--- a/Inc/ScreenGrab.h
+++ b/Inc/ScreenGrab.h
@@ -42,5 +42,6 @@ namespace DirectX
         _In_ REFGUID guidContainerFormat,
         _In_z_ const wchar_t* fileName,
         _In_opt_ const GUID* targetFormat = nullptr,
-        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
+        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr,
+        _In_ bool forceSRGB = false);
 }

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -350,7 +350,8 @@ HRESULT DirectX::SaveWICTextureToFile(
     REFGUID guidContainerFormat,
     const wchar_t* fileName,
     const GUID* targetFormat,
-    std::function<void(IPropertyBag2*)> setCustomProps)
+    std::function<void(IPropertyBag2*)> setCustomProps,
+    bool forceSRGB)
 {
     if (!fileName)
         return E_INVALIDARG;
@@ -363,7 +364,7 @@ HRESULT DirectX::SaveWICTextureToFile(
 
     // Determine source format's WIC equivalent
     WICPixelFormatGUID pfGuid;
-    bool sRGB = false;
+    bool sRGB = forceSRGB;
     switch (desc.Format)
     {
         case DXGI_FORMAT_R32G32B32A32_FLOAT:            pfGuid = GUID_WICPixelFormat128bppRGBAFloat; break;


### PR DESCRIPTION
With the new 'flip' style presentation model for Windows 10 or later, you don't actually use ``*_SRGB`` on the backbuffer format. Therefore, the resulting ``PNG`` screenshot would be washed out.

This adds a new optional paraemeter to allow forcing the sRGB metadata.