### PR TITLE
SoundStreamInstance for playing streaming wavebanks

### DIFF
--- a/Audio/DirectXTKAudio_Desktop_2017_DXSDK.vcxproj
+++ b/Audio/DirectXTKAudio_Desktop_2017_DXSDK.vcxproj
@@ -35,6 +35,7 @@
     <ClCompile Include="SoundCommon.cpp" />
     <ClCompile Include="SoundEffect.cpp" />
     <ClCompile Include="SoundEffectInstance.cpp" />
+    <ClCompile Include="SoundStreamInstance.cpp" />
     <ClCompile Include="WaveBank.cpp" />
     <ClCompile Include="WaveBankReader.cpp" />
     <ClCompile Include="WAVFileReader.cpp" />

--- a/Audio/DirectXTKAudio_Desktop_2017_DXSDK.vcxproj.filters
+++ b/Audio/DirectXTKAudio_Desktop_2017_DXSDK.vcxproj.filters
@@ -49,5 +49,8 @@
     <ClCompile Include="DynamicSoundEffectInstance.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="SoundStreamInstance.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/Audio/DirectXTKAudio_Desktop_2017_Win7.vcxproj
+++ b/Audio/DirectXTKAudio_Desktop_2017_Win7.vcxproj
@@ -35,6 +35,7 @@
     <ClCompile Include="SoundCommon.cpp" />
     <ClCompile Include="SoundEffect.cpp" />
     <ClCompile Include="SoundEffectInstance.cpp" />
+    <ClCompile Include="SoundStreamInstance.cpp" />
     <ClCompile Include="WaveBank.cpp" />
     <ClCompile Include="WaveBankReader.cpp" />
     <ClCompile Include="WAVFileReader.cpp" />

--- a/Audio/DirectXTKAudio_Desktop_2017_Win7.vcxproj.filters
+++ b/Audio/DirectXTKAudio_Desktop_2017_Win7.vcxproj.filters
@@ -49,6 +49,9 @@
     <ClCompile Include="DynamicSoundEffectInstance.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="SoundStreamInstance.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Audio/DirectXTKAudio_Desktop_2017_Win8.vcxproj
+++ b/Audio/DirectXTKAudio_Desktop_2017_Win8.vcxproj
@@ -35,6 +35,7 @@
     <ClCompile Include="SoundCommon.cpp" />
     <ClCompile Include="SoundEffect.cpp" />
     <ClCompile Include="SoundEffectInstance.cpp" />
+    <ClCompile Include="SoundStreamInstance.cpp" />
     <ClCompile Include="WaveBank.cpp" />
     <ClCompile Include="WaveBankReader.cpp" />
     <ClCompile Include="WAVFileReader.cpp" />

--- a/Audio/DirectXTKAudio_Desktop_2017_Win8.vcxproj.filters
+++ b/Audio/DirectXTKAudio_Desktop_2017_Win8.vcxproj.filters
@@ -49,5 +49,8 @@
     <ClCompile Include="DynamicSoundEffectInstance.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="SoundStreamInstance.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/Audio/DirectXTKAudio_Desktop_2019_Win7.vcxproj
+++ b/Audio/DirectXTKAudio_Desktop_2019_Win7.vcxproj
@@ -35,6 +35,7 @@
     <ClCompile Include="SoundCommon.cpp" />
     <ClCompile Include="SoundEffect.cpp" />
     <ClCompile Include="SoundEffectInstance.cpp" />
+    <ClCompile Include="SoundStreamInstance.cpp" />
     <ClCompile Include="WaveBank.cpp" />
     <ClCompile Include="WaveBankReader.cpp" />
     <ClCompile Include="WAVFileReader.cpp" />

--- a/Audio/DirectXTKAudio_Desktop_2019_Win7.vcxproj.filters
+++ b/Audio/DirectXTKAudio_Desktop_2019_Win7.vcxproj.filters
@@ -49,6 +49,9 @@
     <ClCompile Include="DynamicSoundEffectInstance.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="SoundStreamInstance.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Audio/DirectXTKAudio_Desktop_2019_Win8.vcxproj
+++ b/Audio/DirectXTKAudio_Desktop_2019_Win8.vcxproj
@@ -35,6 +35,7 @@
     <ClCompile Include="SoundCommon.cpp" />
     <ClCompile Include="SoundEffect.cpp" />
     <ClCompile Include="SoundEffectInstance.cpp" />
+    <ClCompile Include="SoundStreamInstance.cpp" />
     <ClCompile Include="WaveBank.cpp" />
     <ClCompile Include="WaveBankReader.cpp" />
     <ClCompile Include="WAVFileReader.cpp" />

--- a/Audio/DirectXTKAudio_Desktop_2019_Win8.vcxproj.filters
+++ b/Audio/DirectXTKAudio_Desktop_2019_Win8.vcxproj.filters
@@ -49,5 +49,8 @@
     <ClCompile Include="DynamicSoundEffectInstance.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="SoundStreamInstance.cpp">
+      <Filter>Src</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/Audio/SoundCommon.h
+++ b/Audio/SoundCommon.h
@@ -370,4 +370,11 @@ namespace DirectX
         IXAudio2Voice*              mReverbVoice;
         X3DAUDIO_DSP_SETTINGS       mDSPSettings;
     };
+
+    struct WaveBankSeekData
+    {
+        uint32_t        seekCount;
+        const uint32_t* seekTable;
+        uint32_t        tag;
+    };
 }

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -18,6 +18,7 @@ using namespace DirectX;
 namespace
 {
     const size_t DVD_SECTOR_SIZE = 2048;
+    const size_t MEMORY_ALLOC_SIZE = 4096;
     const size_t MAX_BUFFER_COUNT = 3;
 
     size_t ComputeAsyncPacketSize(_In_ const WAVEFORMATEX* wfx)
@@ -27,9 +28,12 @@ namespace
 
         // TODO - for now, just a quick calculation
         size_t buffer = wfx->nBlockAlign * wfx->nChannels * wfx->nSamplesPerSec;
-        buffer = AlignUp(buffer, DVD_SECTOR_SIZE);
+        buffer = AlignUp(buffer, MEMORY_ALLOC_SIZE);
         return buffer;
     }
+
+    static_assert(MEMORY_ALLOC_SIZE >= DVD_SECTOR_SIZE, "Memory size should be larger than sector size");
+    static_assert(MEMORY_ALLOC_SIZE >= DVD_SECTOR_SIZE || (MEMORY_ALLOC_SIZE% DVD_SECTOR_SIZE) == 0, "Memory size should be multiples of sector size");
 }
 
 
@@ -49,6 +53,8 @@ public:
         mWaveBank(waveBank),
         mIndex(index),
         mLooped(false),
+        mBuffers{},
+        mRequest{},
         mPacketSize(0)
     {
         assert(engine != nullptr);
@@ -66,15 +72,12 @@ public:
             throw std::exception("CreateEvent");
         }
 
-        mPacketSize = ComputeAsyncPacketSize(wfx);
-        if (!mPacketSize)
-        {
-            throw std::exception("Invalid packet size");
-        }
+        ThrowIfFailed(AllocateStreamingBuffers(wfx));
 
-        for (size_t j = 0; j < MAX_BUFFER_COUNT; ++j)
+        // TODO - PCM only for now...
+        if ((mPacketSize % wfx->nBlockAlign) != 0)
         {
-             mBuffers[j].reset(new uint8_t[mPacketSize]);
+            throw std::exception("ERROR: SoundStreamInstance requires block alignment matches packet size (PCM)");
         }
     }
 
@@ -82,11 +85,22 @@ public:
     {
         mBase.DestroyVoice();
 
+        if (mWaveBank && mWaveBank->GetAsyncHandle())
+        {
+            for (size_t j = 0; j < MAX_BUFFER_COUNT; ++j)
+            {
+                (void)CancelIoEx(mWaveBank->GetAsyncHandle(), &mRequest[j]);
+            }
+        }
+
         if (mBase.engine)
         {
             mBase.engine->UnregisterNotify(this, false, false);
             mBase.engine = nullptr;
         }
+
+        memset(mBuffers, 0, sizeof(mBuffers));
+        mPacketSize = 0;
     }
 
     void Play(bool loop);
@@ -125,6 +139,8 @@ public:
     virtual void __cdecl GatherStatistics(AudioStatistics& stats) const noexcept override
     {
         mBase.GatherStatistics(stats);
+
+        stats.streamingBytes += mPacketSize * MAX_BUFFER_COUNT;
     }
 
     virtual void __cdecl OnDestroyParent() noexcept override
@@ -132,7 +148,6 @@ public:
         mBase.OnDestroy();
         mWaveBank = nullptr;
     }
-
 
     SoundEffectInstanceBase         mBase;
     WaveBank*                       mWaveBank;
@@ -143,22 +158,72 @@ private:
     ScopedHandle                    mBufferEnd;
     ScopedHandle                    mBufferRead;
 
-    std::unique_ptr<uint8_t[]>      mBuffers[MAX_BUFFER_COUNT];
+    uint8_t*                        mBuffers[MAX_BUFFER_COUNT];
+    OVERLAPPED                      mRequest[MAX_BUFFER_COUNT];
 
     size_t                          mPacketSize;
+    std::unique_ptr<uint8_t[], virtual_deleter> mStreamBuffer;
+
+    HRESULT AllocateStreamingBuffers(const WAVEFORMATEX* wfx) noexcept;
 };
+
+
+HRESULT SoundStreamInstance::Impl::AllocateStreamingBuffers(const WAVEFORMATEX* wfx) noexcept
+{
+    if (!wfx)
+        return E_INVALIDARG;
+
+    size_t packetSize = ComputeAsyncPacketSize(wfx);
+    if (!packetSize)
+        return E_UNEXPECTED;
+
+    if (mPacketSize < packetSize)
+    {
+        uint64_t totalSize = uint64_t(packetSize) * uint64_t(MAX_BUFFER_COUNT);
+        if (totalSize > UINT32_MAX)
+            return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
+
+        mStreamBuffer.reset(reinterpret_cast<uint8_t*>(
+            VirtualAlloc(nullptr, static_cast<SIZE_T>(totalSize), MEM_COMMIT, PAGE_READWRITE)
+            ));
+
+        if (!mStreamBuffer)
+        {
+#ifdef _DEBUG
+            char buff[64] = {};
+            sprintf_s(buff, "ERROR: Failed allocating %llu bytes for SoundStreamInstance\n", totalSize);
+            OutputDebugStringA(buff);
+#endif
+            mPacketSize = 0;
+            return E_OUTOFMEMORY;
+        }
+
+        mPacketSize = packetSize;
+
+        uint8_t* ptr = mStreamBuffer.get();
+        for (size_t j = 0; j < MAX_BUFFER_COUNT; ++j)
+        {
+            mBuffers[j] = ptr;
+            mRequest[j].Pointer = ptr;
+            mRequest[j].hEvent = mBufferRead.get();
+            ptr += packetSize;
+        }
+    }
+
+    return S_OK;
+}
 
 
 void SoundStreamInstance::Impl::Play(bool loop)
 {
     if (!mBase.voice)
     {
-        if (mWaveBank)
-        {
-            char buff[64] = {};
-            auto wfx = reinterpret_cast<WAVEFORMATEX*>(buff);
-            mBase.AllocateVoice(mWaveBank->GetFormat(mIndex, wfx, sizeof(buff)));
-        }
+        if (!mWaveBank)
+            return;
+
+        char buff[64] = {};
+        auto wfx = reinterpret_cast<WAVEFORMATEX*>(buff);
+        mBase.AllocateVoice(mWaveBank->GetFormat(mIndex, wfx, sizeof(buff)));
     }
 
     if (!mBase.Play())

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -9,9 +9,28 @@
 //--------------------------------------------------------------------------------------
 
 #include "pch.h"
+#include "DirectXHelpers.h"
+#include "PlatformHelpers.h"
 #include "SoundCommon.h"
 
 using namespace DirectX;
+
+namespace
+{
+    const size_t DVD_SECTOR_SIZE = 2048;
+    const size_t MAX_BUFFER_COUNT = 3;
+
+    size_t ComputeAsyncPacketSize(_In_ const WAVEFORMATEX* wfx)
+    {
+        if (!wfx)
+            return 0;
+
+        // TODO - for now, just a quick calculation
+        size_t buffer = wfx->nBlockAlign * wfx->nChannels * wfx->nSamplesPerSec;
+        buffer = AlignUp(buffer, DVD_SECTOR_SIZE);
+        return buffer;
+    }
+}
 
 
 //======================================================================================
@@ -22,11 +41,15 @@ using namespace DirectX;
 class SoundStreamInstance::Impl : public IVoiceNotify
 {
 public:
-    Impl(_In_ AudioEngine* engine, _In_ WaveBank* waveBank, uint32_t index, SOUND_EFFECT_INSTANCE_FLAGS flags) :
+    Impl(_In_ AudioEngine* engine,
+        WaveBank* waveBank,
+        uint32_t index,
+        SOUND_EFFECT_INSTANCE_FLAGS flags) noexcept(false) :
         mBase(),
         mWaveBank(waveBank),
         mIndex(index),
-        mLooped(false)
+        mLooped(false),
+        mPacketSize(0)
     {
         assert(engine != nullptr);
         engine->RegisterNotify(this, true);
@@ -35,6 +58,24 @@ public:
         auto wfx = reinterpret_cast<WAVEFORMATEX*>(buff);
         assert(mWaveBank != nullptr);
         mBase.Initialize(engine, mWaveBank->GetFormat(index, wfx, sizeof(buff)), flags);
+
+        mBufferEnd.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
+        mBufferRead.reset(CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, EVENT_MODIFY_STATE | SYNCHRONIZE));
+        if (!mBufferEnd || !mBufferRead)
+        {
+            throw std::exception("CreateEvent");
+        }
+
+        mPacketSize = ComputeAsyncPacketSize(wfx);
+        if (!mPacketSize)
+        {
+            throw std::exception("Invalid packet size");
+        }
+
+        for (size_t j = 0; j < MAX_BUFFER_COUNT; ++j)
+        {
+             mBuffers[j].reset(new uint8_t[mPacketSize]);
+        }
     }
 
     virtual ~Impl() override
@@ -53,7 +94,7 @@ public:
     // IVoiceNotify
     virtual void __cdecl OnBufferEnd() override
     {
-        // TODO -
+        SetEvent(mBufferEnd.get());
     }
 
     virtual void __cdecl OnCriticalError() override
@@ -97,6 +138,14 @@ public:
     WaveBank*                       mWaveBank;
     uint32_t                        mIndex;
     bool                            mLooped;
+
+private:
+    ScopedHandle                    mBufferEnd;
+    ScopedHandle                    mBufferRead;
+
+    std::unique_ptr<uint8_t[]>      mBuffers[MAX_BUFFER_COUNT];
+
+    size_t                          mPacketSize;
 };
 
 

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -1,0 +1,228 @@
+//--------------------------------------------------------------------------------------
+// File: SoundStreamInstance.cpp
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248929
+// http://go.microsoft.com/fwlink/?LinkID=615561
+//--------------------------------------------------------------------------------------
+
+#include "pch.h"
+#include "SoundCommon.h"
+
+using namespace DirectX;
+
+
+//======================================================================================
+// SoundStreamInstance
+//======================================================================================
+
+// Internal object implementation class.
+class SoundStreamInstance::Impl : public IVoiceNotify
+{
+public:
+    Impl(_In_ AudioEngine* engine, _In_ WaveBank* waveBank, uint32_t index, SOUND_EFFECT_INSTANCE_FLAGS flags) :
+        mBase(),
+        mWaveBank(waveBank),
+        mIndex(index),
+        mLooped(false)
+    {
+        assert(engine != nullptr);
+        engine->RegisterNotify(this, true);
+
+        char buff[64] = {};
+        auto wfx = reinterpret_cast<WAVEFORMATEX*>(buff);
+        assert(mWaveBank != nullptr);
+        mBase.Initialize(engine, mWaveBank->GetFormat(index, wfx, sizeof(buff)), flags);
+    }
+
+    virtual ~Impl() override
+    {
+        mBase.DestroyVoice();
+
+        if (mBase.engine)
+        {
+            mBase.engine->UnregisterNotify(this, false, false);
+            mBase.engine = nullptr;
+        }
+    }
+
+    void Play(bool loop);
+
+    // IVoiceNotify
+    virtual void __cdecl OnBufferEnd() override
+    {
+        // TODO -
+    }
+
+    virtual void __cdecl OnCriticalError() override
+    {
+        mBase.OnCriticalError();
+    }
+
+    virtual void __cdecl OnReset() override
+    {
+        mBase.OnReset();
+    }
+
+    virtual void __cdecl OnUpdate() override
+    {
+        // TOOD -
+    }
+
+    virtual void __cdecl OnDestroyEngine() noexcept override
+    {
+        mBase.OnDestroy();
+    }
+
+    virtual void __cdecl OnTrim() override
+    {
+        mBase.OnTrim();
+    }
+
+    virtual void __cdecl GatherStatistics(AudioStatistics& stats) const noexcept override
+    {
+        mBase.GatherStatistics(stats);
+    }
+
+    virtual void __cdecl OnDestroyParent() noexcept override
+    {
+        mBase.OnDestroy();
+        mWaveBank = nullptr;
+    }
+
+
+    SoundEffectInstanceBase         mBase;
+    WaveBank*                       mWaveBank;
+    uint32_t                        mIndex;
+    bool                            mLooped;
+};
+
+
+void SoundStreamInstance::Impl::Play(bool loop)
+{
+    if (!mBase.voice)
+    {
+        if (mWaveBank)
+        {
+            char buff[64] = {};
+            auto wfx = reinterpret_cast<WAVEFORMATEX*>(buff);
+            mBase.AllocateVoice(mWaveBank->GetFormat(mIndex, wfx, sizeof(buff)));
+        }
+    }
+
+    if (!mBase.Play())
+        return;
+
+    // TODO - buffer.pContext = this;
+}
+
+
+//--------------------------------------------------------------------------------------
+// SoundStreamInstance
+//--------------------------------------------------------------------------------------
+
+// Private constructors
+_Use_decl_annotations_
+SoundStreamInstance::SoundStreamInstance(AudioEngine* engine, WaveBank* waveBank, unsigned int index, SOUND_EFFECT_INSTANCE_FLAGS flags) :
+    pImpl(std::make_unique<Impl>(engine, waveBank, index, flags))
+{
+}
+
+
+// Move constructor.
+SoundStreamInstance::SoundStreamInstance(SoundStreamInstance&& moveFrom) noexcept
+    : pImpl(std::move(moveFrom.pImpl))
+{
+}
+
+
+// Move assignment.
+SoundStreamInstance& SoundStreamInstance::operator= (SoundStreamInstance&& moveFrom) noexcept
+{
+    pImpl = std::move(moveFrom.pImpl);
+    return *this;
+}
+
+
+// Public destructor.
+SoundStreamInstance::~SoundStreamInstance()
+{
+    if (pImpl)
+    {
+        if (pImpl->mWaveBank)
+        {
+            pImpl->mWaveBank->UnregisterInstance(pImpl.get());
+            pImpl->mWaveBank = nullptr;
+        }
+    }
+}
+
+
+// Public methods.
+void SoundStreamInstance::Play(bool loop)
+{
+    pImpl->Play(loop);
+}
+
+
+void SoundStreamInstance::Stop(bool immediate) noexcept
+{
+    pImpl->mBase.Stop(immediate, pImpl->mLooped);
+}
+
+
+void SoundStreamInstance::Pause() noexcept
+{
+    pImpl->mBase.Pause();
+}
+
+
+void SoundStreamInstance::Resume()
+{
+    pImpl->mBase.Resume();
+}
+
+
+void SoundStreamInstance::SetVolume(float volume)
+{
+    pImpl->mBase.SetVolume(volume);
+}
+
+
+void SoundStreamInstance::SetPitch(float pitch)
+{
+    pImpl->mBase.SetPitch(pitch);
+}
+
+
+void SoundStreamInstance::SetPan(float pan)
+{
+    pImpl->mBase.SetPan(pan);
+}
+
+
+void SoundStreamInstance::Apply3D(const AudioListener& listener, const AudioEmitter& emitter, bool rhcoords)
+{
+    pImpl->mBase.Apply3D(listener, emitter, rhcoords);
+}
+
+
+// Public accessors.
+bool SoundStreamInstance::IsLooped() const noexcept
+{
+    return pImpl->mLooped;
+}
+
+
+SoundState SoundStreamInstance::GetState() noexcept
+{
+    return pImpl->mBase.GetState(true);
+}
+
+
+IVoiceNotify* SoundStreamInstance::GetVoiceNotify() const noexcept
+{
+    return pImpl.get();
+}

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -68,6 +68,7 @@ public:
         mPlaying(false),
         mLooped(false),
         mEndStream(false),
+        mPrefetch(false),
         mPackets{},
         mCurrentDiskReadBuffer(0),
         mCurrentPlayBuffer(0),
@@ -105,6 +106,7 @@ public:
         DebugTrace("INFO (Streaming): packet size %zu, play length %zu\n", mPacketSize, mLengthInBytes);
 #endif
 
+        mPrefetch = true;
         ThrowIfFailed(ReadBuffers());
     }
 
@@ -154,6 +156,11 @@ public:
         mLooped = loop;
         mEndStream = false;
 
+        if (!mPrefetch)
+        {
+            mCurrentPosition = 0;
+        }
+
         ThrowIfFailed(PlayBuffers());
     }
 
@@ -193,6 +200,7 @@ public:
             }
             DebugTrace("]\n");
 #endif
+            mPrefetch = false;
             ThrowIfFailed(PlayBuffers());
             break;
 
@@ -242,6 +250,7 @@ public:
     bool                            mPlaying;
     bool                            mLooped;
     bool                            mEndStream;
+    bool                            mPrefetch;
 
     ScopedHandle                    mBufferEnd;
     ScopedHandle                    mBufferRead;

--- a/Audio/WaveBank.cpp
+++ b/Audio/WaveBank.cpp
@@ -434,6 +434,17 @@ void WaveBank::UnregisterInstance(_In_ IVoiceNotify* instance)
 }
 
 
+HANDLE WaveBank::GetAsyncHandle() const noexcept
+{
+    if (pImpl)
+    {
+        return pImpl->mReader.GetAsyncHandle();
+    }
+
+    return nullptr;
+}
+
+
 // Public accessors.
 bool WaveBank::IsPrepared() const noexcept
 {

--- a/Audio/WaveBank.cpp
+++ b/Audio/WaveBank.cpp
@@ -434,17 +434,6 @@ void WaveBank::UnregisterInstance(_In_ IVoiceNotify* instance)
 }
 
 
-HANDLE WaveBank::GetAsyncHandle() const noexcept
-{
-    if (pImpl)
-    {
-        return pImpl->mReader.GetAsyncHandle();
-    }
-
-    return nullptr;
-}
-
-
 // Public accessors.
 bool WaveBank::IsPrepared() const noexcept
 {
@@ -584,3 +573,31 @@ void WaveBank::FillSubmitBuffer(unsigned int index, XAUDIO2_BUFFER& buffer) cons
 }
 
 #endif
+
+
+HANDLE WaveBank::GetAsyncHandle() const noexcept
+{
+    if (pImpl)
+    {
+        return pImpl->mReader.GetAsyncHandle();
+    }
+
+    return nullptr;
+}
+
+
+_Use_decl_annotations_
+bool WaveBank::GetPrivateData(unsigned int index, void* data, size_t datasize)
+{
+    if (index >= pImpl->mReader.Count())
+        return false;
+
+    if (!data)
+        return false;
+
+    if (datasize != sizeof(WaveBankReader::Metadata))
+        return false;
+
+    auto ptr = reinterpret_cast<WaveBankReader::Metadata*>(data);
+    return SUCCEEDED(pImpl->mReader.GetMetadata(index, *ptr));
+}

--- a/Audio/WaveBank.cpp
+++ b/Audio/WaveBank.cpp
@@ -595,9 +595,21 @@ bool WaveBank::GetPrivateData(unsigned int index, void* data, size_t datasize)
     if (!data)
         return false;
 
-    if (datasize != sizeof(WaveBankReader::Metadata))
-        return false;
+    switch (datasize)
+    {
+        case sizeof(WaveBankReader::Metadata):
+        {
+            auto ptr = reinterpret_cast<WaveBankReader::Metadata*>(data);
+            return SUCCEEDED(pImpl->mReader.GetMetadata(index, *ptr));
+        }
 
-    auto ptr = reinterpret_cast<WaveBankReader::Metadata*>(data);
-    return SUCCEEDED(pImpl->mReader.GetMetadata(index, *ptr));
+        case sizeof(WaveBankSeekData):
+        {
+            auto ptr = reinterpret_cast<WaveBankSeekData*>(data);
+            return SUCCEEDED(pImpl->mReader.GetSeekTable(index, &ptr->seekTable, ptr->seekCount, ptr->tag));
+        }
+
+        default:
+            return false;
+    }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ if((BUILD_XAUDIO_WIN10 MATCHES ON) OR (BUILD_XAUDIO_WIN8 MATCHES ON))
         Audio/SoundCommon.h
         Audio/SoundEffect.cpp
         Audio/SoundEffectInstance.cpp
+        Audio/SoundStreamInstance.cpp
         Audio/WaveBank.cpp
         Audio/WaveBankReader.cpp
         Audio/WaveBankReader.h

--- a/DirectXTK_Desktop_2017_Win10.vcxproj
+++ b/DirectXTK_Desktop_2017_Win10.vcxproj
@@ -71,6 +71,7 @@
     <ClCompile Include="Audio\SoundCommon.cpp" />
     <ClCompile Include="Audio\SoundEffect.cpp" />
     <ClCompile Include="Audio\SoundEffectInstance.cpp" />
+    <ClCompile Include="Audio\SoundStreamInstance.cpp" />
     <ClCompile Include="Audio\WaveBank.cpp" />
     <ClCompile Include="Audio\WaveBankReader.cpp" />
     <ClCompile Include="Audio\WAVFileReader.cpp" />

--- a/DirectXTK_Desktop_2017_Win10.vcxproj.filters
+++ b/DirectXTK_Desktop_2017_Win10.vcxproj.filters
@@ -278,6 +278,9 @@
     <ClCompile Include="Src\PBREffectFactory.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Audio\SoundStreamInstance.cpp">
+      <Filter>Audio</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Src\Shaders\CompileShaders.cmd">

--- a/DirectXTK_Desktop_2019_Win10.vcxproj
+++ b/DirectXTK_Desktop_2019_Win10.vcxproj
@@ -71,6 +71,7 @@
     <ClCompile Include="Audio\SoundCommon.cpp" />
     <ClCompile Include="Audio\SoundEffect.cpp" />
     <ClCompile Include="Audio\SoundEffectInstance.cpp" />
+    <ClCompile Include="Audio\SoundStreamInstance.cpp" />
     <ClCompile Include="Audio\WaveBank.cpp" />
     <ClCompile Include="Audio\WaveBankReader.cpp" />
     <ClCompile Include="Audio\WAVFileReader.cpp" />

--- a/DirectXTK_Desktop_2019_Win10.vcxproj.filters
+++ b/DirectXTK_Desktop_2019_Win10.vcxproj.filters
@@ -278,6 +278,9 @@
     <ClCompile Include="Src\PBREffectFactory.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Audio\SoundStreamInstance.cpp">
+      <Filter>Audio</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Src\Shaders\CompileShaders.cmd">

--- a/DirectXTK_Windows10_2017.vcxproj
+++ b/DirectXTK_Windows10_2017.vcxproj
@@ -416,6 +416,7 @@
     <ClCompile Include="Audio\SoundCommon.cpp" />
     <ClCompile Include="Audio\SoundEffect.cpp" />
     <ClCompile Include="Audio\SoundEffectInstance.cpp" />
+    <ClCompile Include="Audio\SoundStreamInstance.cpp" />
     <ClCompile Include="Audio\WaveBank.cpp" />
     <ClCompile Include="Audio\WaveBankReader.cpp" />
     <ClCompile Include="Audio\WAVFileReader.cpp" />

--- a/DirectXTK_Windows10_2017.vcxproj.filters
+++ b/DirectXTK_Windows10_2017.vcxproj.filters
@@ -1328,5 +1328,8 @@
     <ClCompile Include="Src\PBREffectFactory.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Audio\SoundStreamInstance.cpp">
+      <Filter>Audio</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/DirectXTK_Windows10_2019.vcxproj
+++ b/DirectXTK_Windows10_2019.vcxproj
@@ -416,6 +416,7 @@
     <ClCompile Include="Audio\SoundCommon.cpp" />
     <ClCompile Include="Audio\SoundEffect.cpp" />
     <ClCompile Include="Audio\SoundEffectInstance.cpp" />
+    <ClCompile Include="Audio\SoundStreamInstance.cpp" />
     <ClCompile Include="Audio\WaveBank.cpp" />
     <ClCompile Include="Audio\WaveBankReader.cpp" />
     <ClCompile Include="Audio\WAVFileReader.cpp" />

--- a/DirectXTK_Windows10_2019.vcxproj.filters
+++ b/DirectXTK_Windows10_2019.vcxproj.filters
@@ -1328,5 +1328,8 @@
     <ClCompile Include="Src\PBREffectFactory.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Audio\SoundStreamInstance.cpp">
+      <Filter>Audio</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/DirectXTK_XboxOneXDK_2017.vcxproj
+++ b/DirectXTK_XboxOneXDK_2017.vcxproj
@@ -59,6 +59,7 @@
     <ClCompile Include="Audio\SoundCommon.cpp" />
     <ClCompile Include="Audio\SoundEffect.cpp" />
     <ClCompile Include="Audio\SoundEffectInstance.cpp" />
+    <ClCompile Include="Audio\SoundStreamInstance.cpp" />
     <ClCompile Include="Audio\WaveBank.cpp" />
     <ClCompile Include="Audio\WaveBankReader.cpp" />
     <ClCompile Include="Audio\WAVFileReader.cpp" />

--- a/DirectXTK_XboxOneXDK_2017.vcxproj.filters
+++ b/DirectXTK_XboxOneXDK_2017.vcxproj.filters
@@ -277,6 +277,9 @@
     <ClCompile Include="Src\PBREffectFactory.cpp">
       <Filter>Src</Filter>
     </ClCompile>
+    <ClCompile Include="Audio\SoundStreamInstance.cpp">
+      <Filter>Audio</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Src\Shaders\CompileShaders.cmd">

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -363,6 +363,8 @@ namespace DirectX
 
         HANDLE __cdecl GetAsyncHandle() const noexcept;
 
+        bool __cdecl GetPrivateData(unsigned int index, _Out_writes_bytes_(datasize) void* data, size_t datasize);
+
     private:
         // Private implementation.
         class Impl;

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -85,6 +85,7 @@ namespace DirectX
 #if defined(_XBOX_ONE) && defined(_TITLE)
         size_t  xmaAudioBytes;          // Total wave data (in bytes) in SoundEffects and in-memory WaveBanks allocated with ApuAlloc
 #endif
+        size_t  streamingBytes;         // Total size of streaming buffers (in bytes) in streaming WaveBanks
     };
 
 
@@ -359,6 +360,8 @@ namespace DirectX
 #endif
 
         void __cdecl UnregisterInstance(_In_ IVoiceNotify* instance);
+
+        HANDLE __cdecl GetAsyncHandle() const noexcept;
 
     private:
         // Private implementation.

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -69,6 +69,7 @@
 namespace DirectX
 {
     class SoundEffectInstance;
+    class SoundStreamInstance;
 
     //----------------------------------------------------------------------------------
     struct AudioStatistics
@@ -327,6 +328,11 @@ namespace DirectX
         std::unique_ptr<SoundEffectInstance> __cdecl CreateInstance(unsigned int index,
             SOUND_EFFECT_INSTANCE_FLAGS flags = SoundEffectInstance_Default);
         std::unique_ptr<SoundEffectInstance> __cdecl CreateInstance(_In_z_ const char* name,
+            SOUND_EFFECT_INSTANCE_FLAGS flags = SoundEffectInstance_Default);
+
+        std::unique_ptr<SoundStreamInstance> __cdecl CreateStreamInstance(unsigned int index,
+            SOUND_EFFECT_INSTANCE_FLAGS flags = SoundEffectInstance_Default);
+        std::unique_ptr<SoundStreamInstance> __cdecl CreateStreamInstance(_In_z_ const char* name,
             SOUND_EFFECT_INSTANCE_FLAGS flags = SoundEffectInstance_Default);
 
         bool __cdecl IsPrepared() const noexcept;
@@ -643,6 +649,48 @@ namespace DirectX
 
         friend std::unique_ptr<SoundEffectInstance> __cdecl SoundEffect::CreateInstance(SOUND_EFFECT_INSTANCE_FLAGS);
         friend std::unique_ptr<SoundEffectInstance> __cdecl WaveBank::CreateInstance(unsigned int, SOUND_EFFECT_INSTANCE_FLAGS);
+    };
+
+
+    //----------------------------------------------------------------------------------
+    class SoundStreamInstance
+    {
+    public:
+        SoundStreamInstance(SoundStreamInstance&& moveFrom) noexcept;
+        SoundStreamInstance& operator= (SoundStreamInstance&& moveFrom) noexcept;
+
+        SoundStreamInstance(SoundStreamInstance const&) = delete;
+        SoundStreamInstance& operator= (SoundStreamInstance const&) = delete;
+
+        virtual ~SoundStreamInstance();
+
+        void __cdecl Play(bool loop = false);
+        void __cdecl Stop(bool immediate = true) noexcept;
+        void __cdecl Pause() noexcept;
+        void __cdecl Resume();
+
+        void __cdecl SetVolume(float volume);
+        void __cdecl SetPitch(float pitch);
+        void __cdecl SetPan(float pan);
+
+        void __cdecl Apply3D(const AudioListener& listener, const AudioEmitter& emitter, bool rhcoords = true);
+
+        bool __cdecl IsLooped() const noexcept;
+
+        SoundState __cdecl GetState() noexcept;
+
+        IVoiceNotify* __cdecl GetVoiceNotify() const noexcept;
+
+    private:
+        // Private implementation.
+        class Impl;
+
+        std::unique_ptr<Impl> pImpl;
+
+        // Private constructors
+        SoundStreamInstance(_In_ AudioEngine* engine, _In_ WaveBank* effect, unsigned int index, SOUND_EFFECT_INSTANCE_FLAGS flags);
+
+        friend std::unique_ptr<SoundStreamInstance> __cdecl WaveBank::CreateStreamInstance(unsigned int, SOUND_EFFECT_INSTANCE_FLAGS);
     };
 
 

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -283,15 +283,16 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
     if (!pImpl)
         return;
 
-    HANDLE evts[3];
-    evts[0] = pImpl->mScrollWheelValue.get();
-    evts[1] = pImpl->mAbsoluteMode.get();
-    evts[2] = pImpl->mRelativeMode.get();
-    switch (WaitForMultipleObjectsEx(_countof(evts), evts, FALSE, 0, FALSE))
+    HANDLE events[3] = { pImpl->mScrollWheelValue.get(), pImpl->mAbsoluteMode.get(), pImpl->mRelativeMode.get() };
+    switch (WaitForMultipleObjectsEx(_countof(events), events, FALSE, 0, FALSE))
     {
+        default:
+        case WAIT_TIMEOUT:
+            break;
+
         case WAIT_OBJECT_0:
             pImpl->mState.scrollWheelValue = 0;
-            ResetEvent(evts[0]);
+            ResetEvent(events[0]);
             break;
 
         case (WAIT_OBJECT_0 + 1):


### PR DESCRIPTION
*DirectX Tool Kit for Audio* feature for supporting 'streaming' XACT3-style WaveBanks.

This supports PCM, ADPCM, and xWMA encoded wavebanks.

> This implementation does not support loop-points.