### PR TITLE
CMake package support 

### DIFF
--- a/.nuget/directxtk-config.cmake.in
+++ b/.nuget/directxtk-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
+
+check_required_components("@PROJECT_NAME@")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,17 @@
-﻿# DirectX Tool Kit for DirectX 11
-#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-#
-# http://go.microsoft.com/fwlink/?LinkId=248929
 
 cmake_minimum_required (VERSION 3.11)
 
-project (DirectXTK LANGUAGES CXX)
+set(DIRECTXTK_VERSION 1.7.6)
 
+project (DirectXTK
+  VERSION ${DIRECTXTK_VERSION}
+  DESCRIPTION "DirectX Tool Kit for DirectX 11"
+  HOMEPAGE_URL "https://go.microsoft.com/fwlink/?LinkId=248929"
+  LANGUAGES CXX)
+
+# TODO: How to build for XAudio2Redist with cmake?
 option(BUILD_XAUDIO_WIN10 "Build for XAudio 2.9" OFF)
 option(BUILD_XAUDIO_WIN8 "Build for XAudio 2.8" ON)
 
@@ -22,6 +25,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/CMake")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/CMake")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/CMake")
 
+#--- Library
 set(LIBRARY_SOURCES
     Inc/BufferHelpers.h
     Inc/CommonStates.h
@@ -155,11 +159,12 @@ source_group(Audio REGULAR_EXPRESSION Audio/*.*)
 source_group(Inc REGULAR_EXPRESSION Inc/*.*)
 source_group(Src REGULAR_EXPRESSION Src/*.*)
 
-target_include_directories(${PROJECT_NAME} PUBLIC Inc)
-target_include_directories(${PROJECT_NAME} PRIVATE Src)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Inc>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 
 if((BUILD_XAUDIO_WIN10) OR (BUILD_XAUDIO_WIN8))
-    target_include_directories(${PROJECT_NAME} PRIVATE Audio)
+    target_include_directories(${PROJECT_NAME} PRIVATE Src Audio)
 endif()
 
 if(MSVC)
@@ -173,6 +178,47 @@ if(MSVC)
     # Library needs /EHsc (Enable C++ exceptions)
 endif()
 
+#--- Package
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+  ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
+  VERSION ${DIRECTXTK_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/.nuget/${PROJECT_NAME}-config.cmake.in
+  ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
+  INSTALL_DESTINATION cmake/})
+
+install(EXPORT ${PROJECT_NAME}-targets
+  FILE ${PROJECT_NAME}-targets.cmake
+  NAMESPACE Microsoft::
+  DESTINATION cmake/)
+
+if((BUILD_XAUDIO_WIN10) OR (BUILD_XAUDIO_WIN8))
+  install(DIRECTORY Inc/
+    DESTINATION include/${PROJECT_NAME}
+    PATTERN "XboxDDSTextureLoader.h" EXCLUDE)
+else()
+  install(DIRECTORY Inc/
+    DESTINATION include/${PROJECT_NAME}
+    PATTERN "Audio.h" EXCLUDE
+    PATTERN "XboxDDSTextureLoader.h" EXCLUDE)
+endif()
+
+install(
+  FILES
+    ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
+    ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
+  DESTINATION cmake/)
+
+#--- Command-line tools
 add_executable(xwbtool
     xwbtool/xwbtool.cpp
     Audio/WAVFileReader.cpp


### PR DESCRIPTION
This PR updates the CMake support in DirectX Tool Kit to support ``find_package(directxtk CONFIG)``:

```
find_package(directxtk CONFIG REQUIRED)

target_link_libraries(foo Microsoft::DirectXTK)
```
