### PR TITLE
Code review for standard library header usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ if((BUILD_XAUDIO_WIN10) OR (BUILD_XAUDIO_WIN8))
 endif()
 
 if(MSVC)
-    # Use max Warning Level 
+    # Use max Warning Level
     string(REPLACE "/W3 " "/Wall " CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
     string(REPLACE "/W3 " "/Wall " CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
     string(REPLACE "/W3 " "/Wall " CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -12,6 +12,13 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <objbase.h>
 #include <mmreg.h>
 #include <Audioclient.h>
@@ -50,13 +57,6 @@
 #endif
 
 #include <DirectXMath.h>
-
-
-#include <cstdint>
-#include <functional>
-#include <memory>
-#include <string>
-#include <vector>
 
 
 namespace DirectX

--- a/Inc/BufferHelpers.h
+++ b/Inc/BufferHelpers.h
@@ -9,14 +9,15 @@
 
 #pragma once
 
+#include <cassert>
+#include <cstddef>
+
 #if defined(_XBOX_ONE) && defined(_TITLE)
 #include <d3d11_x.h>
 #include "GraphicsMemory.h"
 #else
 #include <d3d11_1.h>
 #endif
-
-#include <assert.h>
 
 #include <wrl\client.h>
 

--- a/Inc/DDSTextureLoader.h
+++ b/Inc/DDSTextureLoader.h
@@ -22,6 +22,7 @@
 #include <d3d11_1.h>
 #endif
 
+#include <cstddef>
 #include <cstdint>
 
 

--- a/Inc/DirectXHelpers.h
+++ b/Inc/DirectXHelpers.h
@@ -25,10 +25,10 @@
 #define IID_GRAPHICS_PPV_ARGS(x) IID_PPV_ARGS(x)
 #endif
 
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <exception>
-
-#include <assert.h>
 
 //
 // The core Direct3D headers provide the following helper C++ classes

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -15,8 +15,10 @@
 #include <d3d11_1.h>
 #endif
 
-#include <DirectXMath.h>
+#include <cstddef>
 #include <memory>
+
+#include <DirectXMath.h>
 
 
 namespace DirectX

--- a/Inc/GeometricPrimitive.h
+++ b/Inc/GeometricPrimitive.h
@@ -11,10 +11,12 @@
 
 #include "VertexTypes.h"
 
-#include <DirectXColors.h>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <vector>
+
+#include <DirectXColors.h>
 
 
 namespace DirectX

--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -15,6 +15,7 @@
 #include <d3d11_1.h>
 #endif
 
+#include <cstddef>
 #include <memory>
 
 

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -16,9 +16,7 @@
 #include <dxgiformat.h>
 #endif
 
-#include <DirectXMath.h>
-#include <DirectXCollision.h>
-
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <functional>
@@ -27,6 +25,9 @@
 #include <vector>
 
 #include <wrl\client.h>
+
+#include <DirectXMath.h>
+#include <DirectXCollision.h>
 
 
 namespace DirectX

--- a/Inc/PostProcess.h
+++ b/Inc/PostProcess.h
@@ -15,9 +15,10 @@
 #include <d3d11_1.h>
 #endif
 
-#include <DirectXMath.h>
 #include <memory>
 #include <functional>
+
+#include <DirectXMath.h>
 
 
 namespace DirectX

--- a/Inc/PrimitiveBatch.h
+++ b/Inc/PrimitiveBatch.h
@@ -15,7 +15,9 @@
 #include <d3d11_1.h>
 #endif
 
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <utility>
 

--- a/Inc/ScreenGrab.h
+++ b/Inc/ScreenGrab.h
@@ -1,4 +1,3 @@
-
 //--------------------------------------------------------------------------------------
 // File: ScreenGrab.h
 //
@@ -24,8 +23,9 @@
 #include <d3d11_1.h>
 #endif
 
-#include <OCIdl.h>
 #include <functional>
+
+#include <OCIdl.h>
 
 #pragma comment(lib,"uuid.lib")
 

--- a/Inc/SimpleMath.h
+++ b/Inc/SimpleMath.h
@@ -14,10 +14,10 @@
 #include <dxgi1_2.h>
 #endif
 
+#include <cassert>
+#include <cstddef>
+#include <cstring>
 #include <functional>
-
-#include <assert.h>
-#include <memory.h>
 
 #include <DirectXMath.h>
 #include <DirectXPackedVector.h>
@@ -403,7 +403,7 @@ namespace DirectX
 
             static void Barycentric(const Vector4& v1, const Vector4& v2, const Vector4& v3, float f, float g, Vector4& result) noexcept;
             static Vector4 Barycentric(const Vector4& v1, const Vector4& v2, const Vector4& v3, float f, float g) noexcept;
-             
+
             static void CatmullRom(const Vector4& v1, const Vector4& v2, const Vector4& v3, const Vector4& v4, float t, Vector4& result) noexcept;
             static Vector4 CatmullRom(const Vector4& v1, const Vector4& v2, const Vector4& v3, const Vector4& v4, float t) noexcept;
 

--- a/Inc/SpriteBatch.h
+++ b/Inc/SpriteBatch.h
@@ -16,10 +16,12 @@
 #include <dxgi.h>
 #endif
 
-#include <DirectXMath.h>
-#include <DirectXColors.h>
+#include <cstdint>
 #include <functional>
 #include <memory>
+
+#include <DirectXMath.h>
+#include <DirectXColors.h>
 
 
 namespace DirectX

--- a/Inc/SpriteFont.h
+++ b/Inc/SpriteFont.h
@@ -11,6 +11,8 @@
 
 #include "SpriteBatch.h"
 
+#include <cstddef>
+
 
 namespace DirectX
 {

--- a/Inc/VertexTypes.h
+++ b/Inc/VertexTypes.h
@@ -15,6 +15,8 @@
 #include <d3d11_1.h>
 #endif
 
+#include <cstdint>
+
 #include <DirectXMath.h>
 
 

--- a/Inc/WICTextureLoader.h
+++ b/Inc/WICTextureLoader.h
@@ -29,6 +29,7 @@
 #include <d3d11_1.h>
 #endif
 
+#include <cstddef>
 #include <cstdint>
 
 #pragma comment(lib,"uuid.lib")

--- a/Inc/XboxDDSTextureLoader.h
+++ b/Inc/XboxDDSTextureLoader.h
@@ -23,6 +23,7 @@
 
 #include <d3d11_x.h>
 
+#include <cstddef>
 #include <cstdint>
 
 #ifndef DDS_ALPHA_MODE_DEFINED
@@ -51,7 +52,7 @@ namespace Xbox
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
         _Outptr_ void** grfxMemory,
-        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr, 
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr,
         _In_ bool forceSRGB = false) noexcept;
 
     HRESULT __cdecl CreateDDSTextureFromFile( _In_ ID3D11DeviceX* d3dDevice,

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -112,6 +112,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <exception>
 #include <list>

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -107,16 +107,12 @@
 #include <d3d11_1.h>
 #endif
 
-#define _XM_NO_XMVECTOR_OVERLOADS_
-
-#include <DirectXMath.h>
-#include <DirectXPackedVector.h>
-#include <DirectXCollision.h>
-
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <exception>
 #include <list>
 #include <map>
@@ -134,6 +130,12 @@
 #pragma warning(pop)
 
 #include <malloc.h>
+
+#define _XM_NO_XMVECTOR_OVERLOADS_
+
+#include <DirectXMath.h>
+#include <DirectXPackedVector.h>
+#include <DirectXCollision.h>
 
 #pragma warning(push)
 #pragma warning(disable : 4467 5038 5204 5220)

--- a/XWBTool/xwbtool.cpp
+++ b/XWBTool/xwbtool.cpp
@@ -28,14 +28,15 @@
 
 #include <Windows.h>
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-
 #include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <list>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "WAVFileReader.h"


### PR DESCRIPTION
Reviewed all the C++ standard library header usage and normalized usage for improved conformance.

* ``size_t`` requires ``cstddef``
* ``memcpy``, ``memcpy_s`` is officially in ``cstring``
* Use ``cassert`` instead of ``assert.h``

> The non-standard malloc.h is still being included for ``_aligned_malloc`` / ``_aligned_free``. To be conformant, I should update it to use ``aligned_alloc`` and ``free`` when building for C++17 which is in ``cstdlib``.

Also trimmed trailing whitespace in these files.