### PR TITLE
Clean up use of std::exception

### DIFF
--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1262,7 +1262,7 @@ void AudioEngine::SetMasterVolume(float volume)
 void AudioEngine::SetReverb(AUDIO_ENGINE_REVERB reverb)
 {
     if (reverb >= Reverb_MAX)
-        throw std::out_of_range("AudioEngine::SetReverb");
+        throw std::invalid_argument("AudioEngine::SetReverb");
 
     if (reverb == Reverb_Off)
     {

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1262,7 +1262,7 @@ void AudioEngine::SetMasterVolume(float volume)
 void AudioEngine::SetReverb(AUDIO_ENGINE_REVERB reverb)
 {
     if (reverb >= Reverb_MAX)
-        throw std::invalid_argument("AudioEngine::SetReverb");
+        throw std::invalid_argument("reverb parameter is invalid");
 
     if (reverb == Reverb_Off)
     {

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1350,7 +1350,7 @@ bool AudioEngine::IsCriticalError() const noexcept
 void AudioEngine::SetDefaultSampleRate(int sampleRate)
 {
     if ((sampleRate < XAUDIO2_MIN_SAMPLE_RATE) || (sampleRate > XAUDIO2_MAX_SAMPLE_RATE))
-        throw std::invalid_argument("Default sample rate is out of range");
+        throw std::out_of_range("Default sample rate is out of range");
 
     pImpl->defaultRate = sampleRate;
 }

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -32,7 +32,7 @@ namespace
             mCriticalError.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
             if (!mCriticalError)
             {
-                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
             }
         }
 
@@ -66,7 +66,7 @@ namespace
             mBufferEnd.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
             if (!mBufferEnd)
             {
-                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
             }
         }
 
@@ -723,7 +723,7 @@ bool AudioEngine::Impl::Update()
             break;
 
         case WAIT_FAILED:
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForMultipleObjectsEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForMultipleObjectsEx");
     }
 
     //

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -32,7 +32,7 @@ namespace
             mCriticalError.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
             if (!mCriticalError)
             {
-                throw std::exception("CreateEvent");
+                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
             }
         }
 
@@ -66,7 +66,7 @@ namespace
             mBufferEnd.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
             if (!mBufferEnd)
             {
-                throw std::exception("CreateEvent");
+                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
             }
         }
 
@@ -723,7 +723,7 @@ bool AudioEngine::Impl::Update()
             break;
 
         case WAIT_FAILED:
-            throw std::exception("WaitForMultipleObjects");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForMultipleObjectsEx");
     }
 
     //
@@ -827,12 +827,12 @@ void AudioEngine::Impl::AllocateVoice(
     IXAudio2SourceVoice** voice)
 {
     if (!wfx)
-        throw std::exception("Wave format is required\n");
+        throw std::invalid_argument("Wave format is required\n");
 
     // No need to call IsValid on wfx because CreateSourceVoice will do that
 
     if (!voice)
-        throw std::exception("Voice pointer must be non-null");
+        throw std::invalid_argument("Voice pointer must be non-null");
 
     *voice = nullptr;
 
@@ -852,7 +852,7 @@ void AudioEngine::Impl::AllocateVoice(
             DebugTrace((flags & SoundEffectInstance_NoSetPitch)
                        ? "ERROR: One-shot voices must support pitch-shifting for voice reuse\n"
                        : "ERROR: One-use voices cannot use 3D positional audio\n");
-            throw std::exception("Invalid flags for one-shot voice");
+            throw std::invalid_argument("Invalid flags for one-shot voice");
         }
 
     #ifdef VERBOSE_TRACE
@@ -947,7 +947,7 @@ void AudioEngine::Impl::AllocateVoice(
                     if (FAILED(hr))
                     {
                         DebugTrace("ERROR: CreateSourceVoice (reuse) failed with error %08X\n", static_cast<unsigned int>(hr));
-                        throw std::exception("CreateSourceVoice");
+                        throw std::runtime_error("CreateSourceVoice");
                     }
                 }
 
@@ -956,7 +956,7 @@ void AudioEngine::Impl::AllocateVoice(
                 if (FAILED(hr))
                 {
                     DebugTrace("ERROR: SetSourceSampleRate failed with error %08X\n", static_cast<unsigned int>(hr));
-                    throw std::exception("SetSourceSampleRate");
+                    throw std::runtime_error("SetSourceSampleRate");
                 }
             }
         }
@@ -977,7 +977,7 @@ void AudioEngine::Impl::AllocateVoice(
         {
             DebugTrace("ERROR: Too many instance voices (%zu >= %zu); see TrimVoicePool\n",
                 mVoiceInstances + 1, maxVoiceInstances);
-            throw std::exception("Too many instance voices");
+            throw std::runtime_error("Too many instance voices");
         }
 
         UINT32 vflags = (flags & SoundEffectInstance_NoSetPitch) ? XAUDIO2_VOICE_NOPITCH : 0u;
@@ -1012,7 +1012,7 @@ void AudioEngine::Impl::AllocateVoice(
         if (FAILED(hr))
         {
             DebugTrace("ERROR: CreateSourceVoice failed with error %08X\n", static_cast<unsigned int>(hr));
-            throw std::exception("CreateSourceVoice");
+            throw std::runtime_error("CreateSourceVoice");
         }
         else if (!oneshot)
         {
@@ -1131,7 +1131,7 @@ AudioEngine::AudioEngine(
             if (flags & AudioEngine_ThrowOnNoAudioHW)
             {
                 DebugTrace("ERROR: AudioEngine found no default audio device\n");
-                throw std::exception("AudioEngineNoAudioHW");
+                throw std::runtime_error("AudioEngineNoAudioHW");
             }
             else
             {
@@ -1143,7 +1143,7 @@ AudioEngine::AudioEngine(
             DebugTrace("ERROR: AudioEngine failed (%08X) to initialize using device [%ls]\n",
                 static_cast<unsigned int>(hr),
                 (deviceId) ? deviceId : L"default");
-            throw std::exception("AudioEngine");
+            throw std::runtime_error("AudioEngine");
         }
     }
 }
@@ -1198,7 +1198,7 @@ bool AudioEngine::Reset(const WAVEFORMATEX* wfx, const wchar_t* deviceId)
             if (pImpl->mEngineFlags & AudioEngine_ThrowOnNoAudioHW)
             {
                 DebugTrace("ERROR: AudioEngine found no default audio device on Reset\n");
-                throw std::exception("AudioEngineNoAudioHW");
+                throw std::runtime_error("AudioEngineNoAudioHW");
             }
             else
             {
@@ -1210,7 +1210,7 @@ bool AudioEngine::Reset(const WAVEFORMATEX* wfx, const wchar_t* deviceId)
         {
             DebugTrace("ERROR: AudioEngine failed (%08X) to Reset using device [%ls]\n",
                 static_cast<unsigned int>(hr), (deviceId) ? deviceId : L"default");
-            throw std::exception("AudioEngine::Reset");
+            throw std::runtime_error("AudioEngine::Reset");
         }
     }
 
@@ -1350,7 +1350,7 @@ bool AudioEngine::IsCriticalError() const noexcept
 void AudioEngine::SetDefaultSampleRate(int sampleRate)
 {
     if ((sampleRate < XAUDIO2_MIN_SAMPLE_RATE) || (sampleRate > XAUDIO2_MAX_SAMPLE_RATE))
-        throw std::exception("Default sample rate is out of range");
+        throw std::invalid_argument("Default sample rate is out of range");
 
     pImpl->defaultRate = sampleRate;
 }
@@ -1552,7 +1552,7 @@ std::vector<AudioEngine::RendererDetail> AudioEngine::GetRendererDetails()
     while (operation->Status == Windows::Foundation::AsyncStatus::Started) { Sleep(100); }
     if (operation->Status != Windows::Foundation::AsyncStatus::Completed)
     {
-        throw std::exception("FindAllAsync");
+        throw std::runtime_error("FindAllAsync");
     }
 
     DeviceInformationCollection^ devices = operation->GetResults();
@@ -1607,7 +1607,7 @@ std::vector<AudioEngine::RendererDetail> AudioEngine::GetRendererDetails()
 
     if (status != ABI::Windows::Foundation::AsyncStatus::Completed)
     {
-        throw std::exception("FindAllAsyncDeviceClass");
+        throw std::runtime_error("FindAllAsyncDeviceClass");
     }
 
     ComPtr<IVectorView<DeviceInformation*>> devices;

--- a/Audio/DynamicSoundEffectInstance.cpp
+++ b/Audio/DynamicSoundEffectInstance.cpp
@@ -58,7 +58,7 @@ public:
         mBufferEvent.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mBufferEvent)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
 
         CreateIntegerPCM(&mWaveFormat, sampleRate, channels, sampleBits);
@@ -226,7 +226,7 @@ void DynamicSoundEffectInstance::Impl::OnUpdate()
             break;
 
         case WAIT_FAILED:
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
     }
 }
 

--- a/Audio/DynamicSoundEffectInstance.cpp
+++ b/Audio/DynamicSoundEffectInstance.cpp
@@ -41,7 +41,7 @@ public:
         if (!channels || (channels > 8))
         {
             DebugTrace("DynamicSoundEffectInstance channels must be in range 1...8\n");
-            throw std::invalid_argument("DynamicSoundEffectInstance");
+            throw std::out_of_range("DynamicSoundEffectInstance channel count out of range");
         }
 
         switch (sampleBits)
@@ -52,7 +52,7 @@ public:
 
             default:
                 DebugTrace("DynamicSoundEffectInstance sampleBits must be 8-bit or 16-bit\n");
-                throw std::invalid_argument("DynamicSoundEffectInstance");
+                throw std::invalid_argument("DynamicSoundEffectInstance supports 8 or 16 bit");
         }
 
         mBufferEvent.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));

--- a/Audio/DynamicSoundEffectInstance.cpp
+++ b/Audio/DynamicSoundEffectInstance.cpp
@@ -58,7 +58,7 @@ public:
         mBufferEvent.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mBufferEvent)
         {
-            throw std::exception("CreateEvent");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
 
         CreateIntegerPCM(&mWaveFormat, sampleRate, channels, sampleBits);
@@ -177,7 +177,7 @@ _Use_decl_annotations_
 void DynamicSoundEffectInstance::Impl::SubmitBuffer(const uint8_t* pAudioData, uint32_t offset, size_t audioBytes)
 {
     if (!pAudioData || !audioBytes)
-        throw std::exception("Invalid audio data buffer");
+        throw std::invalid_argument("Invalid audio data buffer");
 
     if (audioBytes > UINT32_MAX)
         throw std::out_of_range("SubmitBuffer");
@@ -204,7 +204,7 @@ void DynamicSoundEffectInstance::Impl::SubmitBuffer(const uint8_t* pAudioData, u
         DebugTrace("\tFormat Tag %u, %u channels, %u-bit, %u Hz, %zu bytes [%u offset)\n",
             mWaveFormat.wFormatTag, mWaveFormat.nChannels, mWaveFormat.wBitsPerSample, mWaveFormat.nSamplesPerSec, audioBytes, offset);
     #endif
-        throw std::exception("SubmitSourceBuffer");
+        throw std::runtime_error("SubmitSourceBuffer");
     }
 }
 
@@ -226,7 +226,7 @@ void DynamicSoundEffectInstance::Impl::OnUpdate()
             break;
 
         case WAIT_FAILED:
-            throw std::exception("WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
     }
 }
 

--- a/Audio/DynamicSoundEffectInstance.cpp
+++ b/Audio/DynamicSoundEffectInstance.cpp
@@ -35,7 +35,7 @@ public:
             || (sampleRate > XAUDIO2_MAX_SAMPLE_RATE))
         {
             DebugTrace("DynamicSoundEffectInstance sampleRate must be in range %u...%u\n", XAUDIO2_MIN_SAMPLE_RATE, XAUDIO2_MAX_SAMPLE_RATE);
-            throw std::invalid_argument("DynamicSoundEffectInstance");
+            throw std::out_of_range("DynamicSoundEffectInstance");
         }
 
         if (!channels || (channels > 8))

--- a/Audio/SoundCommon.cpp
+++ b/Audio/SoundCommon.cpp
@@ -717,7 +717,7 @@ void SoundEffectInstanceBase::Apply3D(const AudioListener& listener, const Audio
     if (!(mFlags & SoundEffectInstance_Use3D))
     {
         DebugTrace("ERROR: Apply3D called for an instance created without SoundEffectInstance_Use3D set\n");
-        throw std::exception("Apply3D");
+        throw std::runtime_error("Apply3D");
     }
 
     DWORD dwCalcFlags = X3DAUDIO_CALCULATE_MATRIX | X3DAUDIO_CALCULATE_DOPPLER | X3DAUDIO_CALCULATE_LPF_DIRECT;

--- a/Audio/SoundCommon.h
+++ b/Audio/SoundCommon.h
@@ -248,7 +248,7 @@ namespace DirectX
             if ((mFlags & SoundEffectInstance_NoSetPitch) && pitch != 0.f)
             {
                 DebugTrace("ERROR: Sound effect instance was created with the NoSetPitch flag\n");
-                throw std::exception("SetPitch");
+                throw std::runtime_error("SetPitch");
             }
 
             mPitch = pitch;

--- a/Audio/SoundEffect.cpp
+++ b/Audio/SoundEffect.cpp
@@ -352,7 +352,7 @@ void SoundEffect::Impl::Play(float volume, float pitch, float pan)
         DebugTrace("ERROR: SoundEffect failed (%08X) when submitting buffer:\n", static_cast<unsigned int>(hr));
         DebugTrace("\tFormat Tag %u, %u channels, %u-bit, %u Hz, %u bytes\n",
             mWaveFormat->wFormatTag, mWaveFormat->nChannels, mWaveFormat->wBitsPerSample, mWaveFormat->nSamplesPerSec, mAudioBytes);
-        throw std::exception("SubmitSourceBuffer");
+        throw std::runtime_error("SubmitSourceBuffer");
     }
 
     InterlockedIncrement(&mOneShots);
@@ -375,7 +375,7 @@ SoundEffect::SoundEffect(AudioEngine* engine, const wchar_t* waveFileName)
     {
         DebugTrace("ERROR: SoundEffect failed (%08X) to load from .wav file \"%ls\"\n",
             static_cast<unsigned int>(hr), waveFileName);
-        throw std::exception("SoundEffect");
+        throw std::runtime_error("SoundEffect");
     }
 
 #ifdef DIRECTX_ENABLE_SEEK_TABLES
@@ -391,7 +391,7 @@ SoundEffect::SoundEffect(AudioEngine* engine, const wchar_t* waveFileName)
     {
         DebugTrace("ERROR: SoundEffect failed (%08X) to intialize from .wav file \"%ls\"\n",
             static_cast<unsigned int>(hr), waveFileName);
-        throw std::exception("SoundEffect");
+        throw std::runtime_error("SoundEffect");
     }
 }
 
@@ -409,7 +409,7 @@ SoundEffect::SoundEffect(AudioEngine* engine, std::unique_ptr<uint8_t[]>& wavDat
     if (FAILED(hr))
     {
         DebugTrace("ERROR: SoundEffect failed (%08X) to intialize\n", static_cast<unsigned int>(hr));
-        throw std::exception("SoundEffect");
+        throw std::runtime_error("SoundEffect");
     }
 }
 
@@ -428,7 +428,7 @@ SoundEffect::SoundEffect(AudioEngine* engine, std::unique_ptr<uint8_t[]>& wavDat
     if (FAILED(hr))
     {
         DebugTrace("ERROR: SoundEffect failed (%08X) to intialize\n", static_cast<unsigned int>(hr));
-        throw std::exception("SoundEffect");
+        throw std::runtime_error("SoundEffect");
     }
 }
 
@@ -444,7 +444,7 @@ SoundEffect::SoundEffect(AudioEngine* engine, std::unique_ptr<uint8_t[]>& wavDat
     if (FAILED(hr))
     {
         DebugTrace("ERROR: SoundEffect failed (%08X) to intialize\n", static_cast<unsigned int>(hr));
-        throw std::exception("SoundEffect");
+        throw std::runtime_error("SoundEffect");
     }
 }
 

--- a/Audio/SoundEffectInstance.cpp
+++ b/Audio/SoundEffectInstance.cpp
@@ -215,7 +215,7 @@ void SoundEffectInstance::Impl::Play(bool loop)
             wfx->wFormatTag, wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, length);
     #endif
         mBase.Stop(true, mLooped);
-        throw std::exception("SubmitSourceBuffer");
+        throw std::runtime_error("SubmitSourceBuffer");
     }
 }
 

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -140,7 +140,7 @@ public:
         mBufferRead.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mBufferEnd || !mBufferRead)
         {
-            throw std::exception("CreateEvent");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
 
         ThrowIfFailed(AllocateStreamingBuffers(wfx));
@@ -263,7 +263,7 @@ public:
             break;
 
         case WAIT_FAILED:
-            throw std::exception("WaitForMultipleObjects");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForMultipleObjectsEx");
         }
     }
 

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -140,7 +140,7 @@ public:
         mBufferRead.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mBufferEnd || !mBufferRead)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
 
         ThrowIfFailed(AllocateStreamingBuffers(wfx));
@@ -263,7 +263,7 @@ public:
             break;
 
         case WAIT_FAILED:
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForMultipleObjectsEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForMultipleObjectsEx");
         }
     }
 

--- a/Audio/WaveBank.cpp
+++ b/Audio/WaveBank.cpp
@@ -162,7 +162,7 @@ void WaveBank::Impl::Play(unsigned int index, float volume, float pitch, float p
     if (mStreaming)
     {
         DebugTrace("ERROR: One-shots can only be created from an in-memory wave bank\n");
-        throw std::exception("WaveBank::Play");
+        throw std::runtime_error("WaveBank::Play");
     }
 
     if (index >= mReader.Count())
@@ -249,7 +249,7 @@ void WaveBank::Impl::Play(unsigned int index, float volume, float pitch, float p
         DebugTrace("ERROR: WaveBank failed (%08X) when submitting buffer:\n", static_cast<unsigned int>(hr));
         DebugTrace("\tFormat Tag %u, %u channels, %u-bit, %u Hz, %u bytes\n",
             wfx->wFormatTag, wfx->nChannels, wfx->wBitsPerSample, wfx->nSamplesPerSec, metadata.lengthBytes);
-        throw std::exception("SubmitSourceBuffer");
+        throw std::runtime_error("SubmitSourceBuffer");
     }
 
     InterlockedIncrement(&mOneShots);
@@ -270,7 +270,7 @@ WaveBank::WaveBank(AudioEngine* engine, const wchar_t* wbFileName)
     {
         DebugTrace("ERROR: WaveBank failed (%08X) to intialize from .xwb file \"%ls\"\n",
             static_cast<unsigned int>(hr), wbFileName);
-        throw std::exception("WaveBank");
+        throw std::runtime_error("WaveBank");
     }
 
     DebugTrace("INFO: WaveBank \"%hs\" with %u entries loaded from .xwb file \"%ls\"\n",
@@ -346,7 +346,7 @@ std::unique_ptr<SoundEffectInstance> WaveBank::CreateInstance(unsigned int index
     if (pImpl->mStreaming)
     {
         DebugTrace("ERROR: SoundEffectInstances can only be created from an in-memory wave bank\n");
-        throw std::exception("WaveBank::CreateInstance");
+        throw std::runtime_error("WaveBank::CreateInstance");
     }
 
     if (index >= wb.Count())
@@ -389,7 +389,7 @@ std::unique_ptr<SoundStreamInstance> WaveBank::CreateStreamInstance(unsigned int
     if (!pImpl->mStreaming)
     {
         DebugTrace("ERROR: SoundStreamInstances can only be created from a streaming wave bank\n");
-        throw std::exception("WaveBank::CreateStreamInstance");
+        throw std::runtime_error("WaveBank::CreateStreamInstance");
     }
 
     if (index >= wb.Count())

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ set(LIBRARY_SOURCES
     Src/BinaryReader.h
     Src/BufferHelpers.cpp
     Src/CommonStates.cpp
-    Src/dds.h
+    Src/DDS.h
     Src/DDSTextureLoader.cpp
     Src/DebugEffect.cpp
     Src/DemandCreate.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ set(LIBRARY_SOURCES
     Src/BinaryReader.h
     Src/BufferHelpers.cpp
     Src/CommonStates.cpp
-    Src/DDS.h
+    Src/dds.h
     Src/DDSTextureLoader.cpp
     Src/DebugEffect.cpp
     Src/DemandCreate.h

--- a/Src/AlphaTestEffect.cpp
+++ b/Src/AlphaTestEffect.cpp
@@ -259,7 +259,7 @@ void AlphaTestEffect::Impl::Apply(_In_ ID3D11DeviceContext* deviceContext)
                 break;
 
             default:
-                throw std::exception("Unknown alpha test function");
+                throw std::runtime_error("Unknown alpha test function");
         }
 
         // x = compareTo, y = threshold, zw = resultSelector.

--- a/Src/BasicPostProcess.cpp
+++ b/Src/BasicPostProcess.cpp
@@ -318,7 +318,7 @@ void BasicPostProcess::Impl::DownScale2x2()
 
     if (!texWidth || !texHeight)
     {
-        throw std::runtime_error("Call SetSourceTexture before setting post-process effect");
+        throw std::logic_error("Call SetSourceTexture before setting post-process effect");
     }
 
     float tu = 1.0f / float(texWidth);
@@ -345,7 +345,7 @@ void BasicPostProcess::Impl::DownScale4x4()
 
     if (!texWidth || !texHeight)
     {
-        throw std::runtime_error("Call SetSourceTexture before setting post-process effect");
+        throw std::logic_error("Call SetSourceTexture before setting post-process effect");
     }
 
     float tu = 1.0f / float(texWidth);
@@ -373,7 +373,7 @@ void BasicPostProcess::Impl::GaussianBlur5x5(float multiplier)
 
     if (!texWidth || !texHeight)
     {
-        throw std::runtime_error("Call SetSourceTexture before setting post-process effect");
+        throw std::logic_error("Call SetSourceTexture before setting post-process effect");
     }
 
     float tu = 1.0f / float(texWidth);
@@ -429,7 +429,7 @@ void  BasicPostProcess::Impl::Bloom(bool horizontal, float size, float brightnes
 
     if (!texWidth || !texHeight)
     {
-        throw std::runtime_error("Call SetSourceTexture before setting post-process effect");
+        throw std::logic_error("Call SetSourceTexture before setting post-process effect");
     }
 
     float tu = 0.f;

--- a/Src/BasicPostProcess.cpp
+++ b/Src/BasicPostProcess.cpp
@@ -209,7 +209,7 @@ BasicPostProcess::Impl::Impl(_In_ ID3D11Device* device)
 {
     if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
     {
-        throw std::exception("BasicPostProcess requires Feature Level 10.0 or later");
+        throw std::runtime_error("BasicPostProcess requires Feature Level 10.0 or later");
     }
 
     SetDebugObjectName(mConstantBuffer.GetBuffer(), "BasicPostProcess");
@@ -318,7 +318,7 @@ void BasicPostProcess::Impl::DownScale2x2()
 
     if (!texWidth || !texHeight)
     {
-        throw std::exception("Call SetSourceTexture before setting post-process effect");
+        throw std::runtime_error("Call SetSourceTexture before setting post-process effect");
     }
 
     float tu = 1.0f / float(texWidth);
@@ -345,7 +345,7 @@ void BasicPostProcess::Impl::DownScale4x4()
 
     if (!texWidth || !texHeight)
     {
-        throw std::exception("Call SetSourceTexture before setting post-process effect");
+        throw std::runtime_error("Call SetSourceTexture before setting post-process effect");
     }
 
     float tu = 1.0f / float(texWidth);
@@ -373,7 +373,7 @@ void BasicPostProcess::Impl::GaussianBlur5x5(float multiplier)
 
     if (!texWidth || !texHeight)
     {
-        throw std::exception("Call SetSourceTexture before setting post-process effect");
+        throw std::runtime_error("Call SetSourceTexture before setting post-process effect");
     }
 
     float tu = 1.0f / float(texWidth);
@@ -429,7 +429,7 @@ void  BasicPostProcess::Impl::Bloom(bool horizontal, float size, float brightnes
 
     if (!texWidth || !texHeight)
     {
-        throw std::exception("Call SetSourceTexture before setting post-process effect");
+        throw std::runtime_error("Call SetSourceTexture before setting post-process effect");
     }
 
     float tu = 0.f;
@@ -510,7 +510,7 @@ void BasicPostProcess::Process(
 void BasicPostProcess::SetEffect(Effect fx)
 {
     if (fx >= Effect_Max)
-        throw std::out_of_range("Effect not defined");
+        throw std::invalid_argument("Effect not defined");
 
     pImpl->fx = fx;
 
@@ -573,7 +573,7 @@ void BasicPostProcess::SetSourceTexture(_In_opt_ ID3D11ShaderResourceView* value
         case D3D11_RESOURCE_DIMENSION_BUFFER:
         case D3D11_RESOURCE_DIMENSION_TEXTURE3D:
         default:
-            throw std::exception("Unsupported texture type");
+            throw std::invalid_argument("Unsupported texture type");
         }
     }
     else

--- a/Src/BinaryReader.cpp
+++ b/Src/BinaryReader.cpp
@@ -27,7 +27,7 @@ BinaryReader::BinaryReader(_In_z_ wchar_t const* fileName) noexcept(false) :
     {
         DebugTrace("ERROR: BinaryReader failed (%08X) to load '%ls'\n",
             static_cast<unsigned int>(hr), fileName);
-        throw std::exception("BinaryReader");
+        throw std::runtime_error("BinaryReader");
     }
 
     mPos = mOwnedData.get();

--- a/Src/BinaryReader.h
+++ b/Src/BinaryReader.h
@@ -48,7 +48,7 @@ namespace DirectX
                 throw std::overflow_error("ReadArray");
 
             if (newPos > mEnd)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             auto result = reinterpret_cast<T const*>(mPos);
 

--- a/Src/BufferHelpers.cpp
+++ b/Src/BufferHelpers.cpp
@@ -361,7 +361,7 @@ void Internal::ConstantBufferBase::CreateBuffer(
     ID3D11Buffer** pBuffer)
 {
     if (!pBuffer)
-        throw std::invalid_argument("ConstantBuffer");
+        throw std::invalid_argument("ConstantBuffer needs valid buffer parameter");
 
     *pBuffer = nullptr;
 

--- a/Src/DGSLEffect.cpp
+++ b/Src/DGSLEffect.cpp
@@ -773,7 +773,7 @@ void XM_CALLCONV DGSLEffect::SetAmbientLightColor(FXMVECTOR value)
 void DGSLEffect::SetLightEnabled(int whichLight, bool value)
 {
     if (whichLight < 0 || whichLight >= MaxDirectionalLights)
-        throw std::out_of_range("whichLight parameter out of range");
+        throw std::invalid_argument("whichLight parameter out of range");
 
     if (pImpl->lightEnabled[whichLight] == value)
         return;
@@ -801,7 +801,7 @@ void DGSLEffect::SetLightEnabled(int whichLight, bool value)
 void XM_CALLCONV DGSLEffect::SetLightDirection(int whichLight, FXMVECTOR value)
 {
     if (whichLight < 0 || whichLight >= MaxDirectionalLights)
-        throw std::out_of_range("whichLight parameter out of range");
+        throw std::invalid_argument("whichLight parameter out of range");
 
     // DGSL effects lights do not negate the direction like BasicEffect
     pImpl->constants.light.LightDirection[whichLight] = XMVectorNegate(value);
@@ -813,7 +813,7 @@ void XM_CALLCONV DGSLEffect::SetLightDirection(int whichLight, FXMVECTOR value)
 void XM_CALLCONV DGSLEffect::SetLightDiffuseColor(int whichLight, FXMVECTOR value)
 {
     if (whichLight < 0 || whichLight >= MaxDirectionalLights)
-        throw std::out_of_range("whichLight parameter out of range");
+        throw std::invalid_argument("whichLight parameter out of range");
 
     pImpl->lightDiffuseColor[whichLight] = value;
 
@@ -829,7 +829,7 @@ void XM_CALLCONV DGSLEffect::SetLightDiffuseColor(int whichLight, FXMVECTOR valu
 void XM_CALLCONV DGSLEffect::SetLightSpecularColor(int whichLight, FXMVECTOR value)
 {
     if (whichLight < 0 || whichLight >= MaxDirectionalLights)
-        throw std::out_of_range("whichLight parameter out of range");
+        throw std::invalid_argument("whichLight parameter out of range");
 
     pImpl->lightSpecularColor[whichLight] = value;
 
@@ -870,7 +870,7 @@ void DGSLEffect::SetTexture(_In_opt_ ID3D11ShaderResourceView* value)
 void DGSLEffect::SetTexture(int whichTexture, _In_opt_ ID3D11ShaderResourceView* value)
 {
     if (whichTexture < 0 || whichTexture >= MaxTextures)
-        throw std::out_of_range("whichTexture parameter out of range");
+        throw std::invalid_argument("whichTexture parameter out of range");
 
     pImpl->textures[whichTexture] = value;
 }
@@ -889,7 +889,7 @@ void DGSLEffect::SetWeightsPerVertex(int value)
         (value != 2) &&
         (value != 4))
     {
-        throw std::out_of_range("WeightsPerVertex must be 1, 2, or 4");
+        throw std::invalid_argument("WeightsPerVertex must be 1, 2, or 4");
     }
 
     pImpl->weightsPerVertex = value;
@@ -899,10 +899,10 @@ void DGSLEffect::SetWeightsPerVertex(int value)
 void DGSLEffect::SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count)
 {
     if (!pImpl->weightsPerVertex)
-        throw std::exception("Skinning not enabled for this effect");
+        throw std::runtime_error("Skinning not enabled for this effect");
 
     if (count > MaxBones)
-        throw std::out_of_range("count parameter out of range");
+        throw std::invalid_argument("count parameter out of range");
 
     auto boneConstant = pImpl->constants.bones.Bones;
 

--- a/Src/DGSLEffect.cpp
+++ b/Src/DGSLEffect.cpp
@@ -773,7 +773,7 @@ void XM_CALLCONV DGSLEffect::SetAmbientLightColor(FXMVECTOR value)
 void DGSLEffect::SetLightEnabled(int whichLight, bool value)
 {
     if (whichLight < 0 || whichLight >= MaxDirectionalLights)
-        throw std::invalid_argument("whichLight parameter out of range");
+        throw std::invalid_argument("whichLight parameter invalid");
 
     if (pImpl->lightEnabled[whichLight] == value)
         return;
@@ -801,7 +801,7 @@ void DGSLEffect::SetLightEnabled(int whichLight, bool value)
 void XM_CALLCONV DGSLEffect::SetLightDirection(int whichLight, FXMVECTOR value)
 {
     if (whichLight < 0 || whichLight >= MaxDirectionalLights)
-        throw std::invalid_argument("whichLight parameter out of range");
+        throw std::invalid_argument("whichLight parameter invalid");
 
     // DGSL effects lights do not negate the direction like BasicEffect
     pImpl->constants.light.LightDirection[whichLight] = XMVectorNegate(value);
@@ -813,7 +813,7 @@ void XM_CALLCONV DGSLEffect::SetLightDirection(int whichLight, FXMVECTOR value)
 void XM_CALLCONV DGSLEffect::SetLightDiffuseColor(int whichLight, FXMVECTOR value)
 {
     if (whichLight < 0 || whichLight >= MaxDirectionalLights)
-        throw std::invalid_argument("whichLight parameter out of range");
+        throw std::invalid_argument("whichLight parameter invalid");
 
     pImpl->lightDiffuseColor[whichLight] = value;
 
@@ -829,7 +829,7 @@ void XM_CALLCONV DGSLEffect::SetLightDiffuseColor(int whichLight, FXMVECTOR valu
 void XM_CALLCONV DGSLEffect::SetLightSpecularColor(int whichLight, FXMVECTOR value)
 {
     if (whichLight < 0 || whichLight >= MaxDirectionalLights)
-        throw std::invalid_argument("whichLight parameter out of range");
+        throw std::invalid_argument("whichLight parameter invalid");
 
     pImpl->lightSpecularColor[whichLight] = value;
 
@@ -870,7 +870,7 @@ void DGSLEffect::SetTexture(_In_opt_ ID3D11ShaderResourceView* value)
 void DGSLEffect::SetTexture(int whichTexture, _In_opt_ ID3D11ShaderResourceView* value)
 {
     if (whichTexture < 0 || whichTexture >= MaxTextures)
-        throw std::invalid_argument("whichTexture parameter out of range");
+        throw std::invalid_argument("whichTexture parameter invalid");
 
     pImpl->textures[whichTexture] = value;
 }
@@ -902,7 +902,7 @@ void DGSLEffect::SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size
         throw std::runtime_error("Skinning not enabled for this effect");
 
     if (count > MaxBones)
-        throw std::invalid_argument("count parameter out of range");
+        throw std::invalid_argument("count parameter exceeds MaxBones");
 
     auto boneConstant = pImpl->constants.bones.Bones;
 

--- a/Src/DGSLEffectFactory.cpp
+++ b/Src/DGSLEffectFactory.cpp
@@ -400,7 +400,7 @@ void DGSLEffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCon
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::runtime_error("CreateDDSTextureFromFile");
+                throw std::runtime_error("DGSLEffectFactory::CreateDDSTextureFromFile");
             }
         }
     #if !defined(_XBOX_ONE) || !defined(_TITLE)
@@ -415,7 +415,7 @@ void DGSLEffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCon
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::runtime_error("CreateWICTextureFromFile");
+                throw std::runtime_error("DGSLEffectFactory::CreateWICTextureFromFile");
             }
         }
     #endif
@@ -429,7 +429,7 @@ void DGSLEffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCon
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::runtime_error("CreateWICTextureFromFile");
+                throw std::runtime_error("DGSLEffectFactory::CreateWICTextureFromFile");
             }
         }
 
@@ -482,7 +482,7 @@ void DGSLEffectFactory::Impl::CreatePixelShader(const wchar_t* name, ID3D11Pixel
         {
             DebugTrace("ERROR: CreatePixelShader failed (%08X) to load shader file '%ls'\n",
                 static_cast<unsigned int>(hr), fullName);
-            throw std::runtime_error("CreatePixelShader");
+            throw std::runtime_error("DGSLEffectFactory::CreatePixelShader");
         }
 
         ThrowIfFailed(

--- a/Src/DGSLEffectFactory.cpp
+++ b/Src/DGSLEffectFactory.cpp
@@ -355,7 +355,7 @@ _Use_decl_annotations_
 void DGSLEffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext* deviceContext, ID3D11ShaderResourceView** textureView)
 {
     if (!name || !textureView)
-        throw std::invalid_argument("DGSLEffectFactory");
+        throw std::invalid_argument("name and textureView parameters can't be null");
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
     UNREFERENCED_PARAMETER(deviceContext);
@@ -447,7 +447,7 @@ _Use_decl_annotations_
 void DGSLEffectFactory::Impl::CreatePixelShader(const wchar_t* name, ID3D11PixelShader** pixelShader)
 {
     if (!name || !pixelShader)
-        throw std::invalid_argument("DGSLEffectFactory");
+        throw std::invalid_argument("name and pixelShader parameters can't be null");
 
     auto it = mShaderCache.find(name);
 

--- a/Src/DGSLEffectFactory.cpp
+++ b/Src/DGSLEffectFactory.cpp
@@ -77,7 +77,7 @@ std::shared_ptr<IEffect> DGSLEffectFactory::Impl::CreateEffect(DGSLEffectFactory
 {
     if (info.enableDualTexture)
     {
-        throw std::exception("DGSLEffect does not support multiple texcoords");
+        throw std::runtime_error("DGSLEffect does not support multiple texcoords");
     }
 
     if (mSharing && info.name && *info.name)
@@ -355,7 +355,7 @@ _Use_decl_annotations_
 void DGSLEffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext* deviceContext, ID3D11ShaderResourceView** textureView)
 {
     if (!name || !textureView)
-        throw std::exception("invalid arguments");
+        throw std::invalid_argument("DGSLEffectFactory");
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
     UNREFERENCED_PARAMETER(deviceContext);
@@ -383,7 +383,7 @@ void DGSLEffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCon
             if (!GetFileAttributesExW(fullName, GetFileExInfoStandard, &fileAttr))
             {
                 DebugTrace("ERROR: DGSLEffectFactory could not find texture file '%ls'\n", name);
-                throw std::exception("CreateTexture");
+                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "DGSLEffectFactory::CreateTexture");
             }
         }
 
@@ -400,7 +400,7 @@ void DGSLEffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCon
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::exception("CreateDDSTextureFromFile");
+                throw std::runtime_error("CreateDDSTextureFromFile");
             }
         }
     #if !defined(_XBOX_ONE) || !defined(_TITLE)
@@ -415,7 +415,7 @@ void DGSLEffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCon
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::exception("CreateWICTextureFromFile");
+                throw std::runtime_error("CreateWICTextureFromFile");
             }
         }
     #endif
@@ -429,7 +429,7 @@ void DGSLEffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCon
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::exception("CreateWICTextureFromFile");
+                throw std::runtime_error("CreateWICTextureFromFile");
             }
         }
 
@@ -447,7 +447,7 @@ _Use_decl_annotations_
 void DGSLEffectFactory::Impl::CreatePixelShader(const wchar_t* name, ID3D11PixelShader** pixelShader)
 {
     if (!name || !pixelShader)
-        throw std::exception("invalid arguments");
+        throw std::invalid_argument("DGSLEffectFactory");
 
     auto it = mShaderCache.find(name);
 
@@ -471,7 +471,7 @@ void DGSLEffectFactory::Impl::CreatePixelShader(const wchar_t* name, ID3D11Pixel
             if (!GetFileAttributesExW(fullName, GetFileExInfoStandard, &fileAttr))
             {
                 DebugTrace("ERROR: DGSLEffectFactory could not find shader file '%ls'\n", name);
-                throw std::exception("CreatePixelShader");
+                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "DGSLEffectFactory::CreatePixelShader");
             }
         }
 
@@ -482,7 +482,7 @@ void DGSLEffectFactory::Impl::CreatePixelShader(const wchar_t* name, ID3D11Pixel
         {
             DebugTrace("ERROR: CreatePixelShader failed (%08X) to load shader file '%ls'\n",
                 static_cast<unsigned int>(hr), fullName);
-            throw std::exception("CreatePixelShader");
+            throw std::runtime_error("CreatePixelShader");
         }
 
         ThrowIfFailed(

--- a/Src/DGSLEffectFactory.cpp
+++ b/Src/DGSLEffectFactory.cpp
@@ -383,7 +383,7 @@ void DGSLEffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCon
             if (!GetFileAttributesExW(fullName, GetFileExInfoStandard, &fileAttr))
             {
                 DebugTrace("ERROR: DGSLEffectFactory could not find texture file '%ls'\n", name);
-                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "DGSLEffectFactory::CreateTexture");
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "DGSLEffectFactory::CreateTexture");
             }
         }
 
@@ -471,7 +471,7 @@ void DGSLEffectFactory::Impl::CreatePixelShader(const wchar_t* name, ID3D11Pixel
             if (!GetFileAttributesExW(fullName, GetFileExInfoStandard, &fileAttr))
             {
                 DebugTrace("ERROR: DGSLEffectFactory could not find shader file '%ls'\n", name);
-                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "DGSLEffectFactory::CreatePixelShader");
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "DGSLEffectFactory::CreatePixelShader");
             }
         }
 

--- a/Src/DebugEffect.cpp
+++ b/Src/DebugEffect.cpp
@@ -169,7 +169,7 @@ DebugEffect::Impl::Impl(_In_ ID3D11Device* device)
 {
     if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
     {
-        throw std::exception("DebugEffect requires Feature Level 10.0 or later");
+        throw std::runtime_error("DebugEffect requires Feature Level 10.0 or later");
     }
 
     static_assert(static_cast<int>(std::size(EffectBase<DebugEffectTraits>::VertexShaderIndices)) == DebugEffectTraits::ShaderPermutationCount, "array/max mismatch");

--- a/Src/DualPostProcess.cpp
+++ b/Src/DualPostProcess.cpp
@@ -176,7 +176,7 @@ DualPostProcess::Impl::Impl(_In_ ID3D11Device* device)
 {
     if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
     {
-        throw std::exception("DualPostProcess requires Feature Level 10.0 or later");
+        throw std::runtime_error("DualPostProcess requires Feature Level 10.0 or later");
     }
 
     SetDebugObjectName(mConstantBuffer.GetBuffer(), "DualPostProcess");
@@ -308,7 +308,7 @@ void DualPostProcess::Process(
 void DualPostProcess::SetEffect(Effect fx)
 {
     if (fx >= Effect_Max)
-        throw std::out_of_range("Effect not defined");
+        throw std::invalid_argument("Effect not defined");
 
     pImpl->fx = fx;
     pImpl->SetDirtyFlag();

--- a/Src/EffectCommon.cpp
+++ b/Src/EffectCommon.cpp
@@ -340,7 +340,7 @@ void EffectLights::ValidateLightIndex(int whichLight)
 {
     if (whichLight < 0 || whichLight >= MaxDirectionalLights)
     {
-        throw std::invalid_argument("whichLight parameter out of range");
+        throw std::invalid_argument("whichLight parameter invalid");
     }
 }
 

--- a/Src/EffectCommon.cpp
+++ b/Src/EffectCommon.cpp
@@ -340,7 +340,7 @@ void EffectLights::ValidateLightIndex(int whichLight)
 {
     if (whichLight < 0 || whichLight >= MaxDirectionalLights)
     {
-        throw std::out_of_range("whichLight parameter out of range");
+        throw std::invalid_argument("whichLight parameter out of range");
     }
 }
 

--- a/Src/EffectFactory.cpp
+++ b/Src/EffectFactory.cpp
@@ -402,7 +402,7 @@ void EffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::runtime_error("CreateDDSTextureFromFile");
+                throw std::runtime_error("EffectFactory::CreateDDSTextureFromFile");
             }
         }
     #if !defined(_XBOX_ONE) || !defined(_TITLE)
@@ -417,7 +417,7 @@ void EffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::runtime_error("CreateWICTextureFromFile");
+                throw std::runtime_error("EffectFactory::CreateWICTextureFromFile");
             }
         }
     #endif
@@ -431,7 +431,7 @@ void EffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::runtime_error("CreateWICTextureFromFile");
+                throw std::runtime_error("EffectFactory::CreateWICTextureFromFile");
             }
         }
 

--- a/Src/EffectFactory.cpp
+++ b/Src/EffectFactory.cpp
@@ -357,7 +357,7 @@ _Use_decl_annotations_
 void EffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext* deviceContext, ID3D11ShaderResourceView** textureView)
 {
     if (!name || !textureView)
-        throw std::invalid_argument("EffectFactory");
+        throw std::invalid_argument("name and textureView parameters can't be null");
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
     UNREFERENCED_PARAMETER(deviceContext);

--- a/Src/EffectFactory.cpp
+++ b/Src/EffectFactory.cpp
@@ -385,7 +385,7 @@ void EffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext
             if (!GetFileAttributesExW(fullName, GetFileExInfoStandard, &fileAttr))
             {
                 DebugTrace("ERROR: EffectFactory could not find texture file '%ls'\n", name);
-                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "EffectFactory::CreateTexture");
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "EffectFactory::CreateTexture");
             }
         }
 

--- a/Src/EffectFactory.cpp
+++ b/Src/EffectFactory.cpp
@@ -357,7 +357,7 @@ _Use_decl_annotations_
 void EffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext* deviceContext, ID3D11ShaderResourceView** textureView)
 {
     if (!name || !textureView)
-        throw std::exception("invalid arguments");
+        throw std::invalid_argument("EffectFactory");
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
     UNREFERENCED_PARAMETER(deviceContext);
@@ -385,7 +385,7 @@ void EffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext
             if (!GetFileAttributesExW(fullName, GetFileExInfoStandard, &fileAttr))
             {
                 DebugTrace("ERROR: EffectFactory could not find texture file '%ls'\n", name);
-                throw std::exception("CreateTexture");
+                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "EffectFactory::CreateTexture");
             }
         }
 
@@ -402,7 +402,7 @@ void EffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::exception("CreateDDSTextureFromFile");
+                throw std::runtime_error("CreateDDSTextureFromFile");
             }
         }
     #if !defined(_XBOX_ONE) || !defined(_TITLE)
@@ -417,7 +417,7 @@ void EffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::exception("CreateWICTextureFromFile");
+                throw std::runtime_error("CreateWICTextureFromFile");
             }
         }
     #endif
@@ -431,7 +431,7 @@ void EffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::exception("CreateWICTextureFromFile");
+                throw std::runtime_error("CreateWICTextureFromFile");
             }
         }
 

--- a/Src/EnvironmentMapEffect.cpp
+++ b/Src/EnvironmentMapEffect.cpp
@@ -571,7 +571,7 @@ void EnvironmentMapEffect::SetLightingEnabled(bool value)
 {
     if (!value)
     {
-        throw std::exception("EnvironmentMapEffect does not support turning off lighting");
+        throw std::invalid_argument("EnvironmentMapEffect does not support turning off lighting");
     }
 }
 
@@ -684,7 +684,7 @@ void EnvironmentMapEffect::SetMode(EnvironmentMapEffect::Mapping mapping)
     {
         if (pImpl->GetDeviceFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
         {
-            throw std::exception("Dual Parabola requires Feature Level 10.0 or later");
+            throw std::runtime_error("Dual Parabola requires Feature Level 10.0 or later");
         }
     }
 

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -100,7 +100,7 @@ public:
     {
         if (s_gamePad)
         {
-            throw std::exception("GamePad is a singleton");
+            throw std::logic_error("GamePad is a singleton");
         }
 
         s_gamePad = this;
@@ -419,7 +419,7 @@ public:
 
         if (s_gamePad)
         {
-            throw std::exception("GamePad is a singleton");
+            throw std::logic_error("GamePad is a singleton");
         }
 
         s_gamePad = this;
@@ -427,7 +427,7 @@ public:
         mChanged.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mChanged)
         {
-            throw std::exception("CreateEventEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
 
         ThrowIfFailed(GetActivationFactory(HStringReference(RuntimeClass_Windows_Gaming_Input_Gamepad).Get(), mStatics.GetAddressOf()));
@@ -902,7 +902,7 @@ public:
 
         if (s_gamePad)
         {
-            throw std::exception("GamePad is a singleton");
+            throw std::logic_error("GamePad is a singleton");
         }
 
         s_gamePad = this;
@@ -910,7 +910,7 @@ public:
         mChanged.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mChanged)
         {
-            throw std::exception("CreateEventEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
 
         ThrowIfFailed(GetActivationFactory(HStringReference(RuntimeClass_Windows_Xbox_Input_Gamepad).Get(), mStatics.GetAddressOf()));
@@ -1203,7 +1203,7 @@ private:
                 {
                     if (empty >= MAX_PLAYER_COUNT)
                     {
-                        throw std::exception("Too many gamepads found");
+                        throw std::runtime_error("Too many gamepads found");
                     }
 
                     mGamePad[empty] = pad;
@@ -1257,7 +1257,7 @@ public:
 
         if (s_gamePad)
         {
-            throw std::exception("GamePad is a singleton");
+            throw std::logic_error("GamePad is a singleton");
         }
 
         s_gamePad = this;
@@ -1667,7 +1667,7 @@ void GamePad::RegisterEvents(HANDLE ctrlChanged, HANDLE userChanged) noexcept
 GamePad& GamePad::Get()
 {
     if (!Impl::s_gamePad || !Impl::s_gamePad->mOwner)
-        throw std::exception("GamePad is a singleton");
+        throw std::logic_error("GamePad singleton not created");
 
     return *Impl::s_gamePad->mOwner;
 }

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -427,7 +427,7 @@ public:
         mChanged.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mChanged)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
 
         ThrowIfFailed(GetActivationFactory(HStringReference(RuntimeClass_Windows_Gaming_Input_Gamepad).Get(), mStatics.GetAddressOf()));
@@ -910,7 +910,7 @@ public:
         mChanged.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mChanged)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
 
         ThrowIfFailed(GetActivationFactory(HStringReference(RuntimeClass_Windows_Xbox_Input_Gamepad).Get(), mStatics.GetAddressOf()));

--- a/Src/GeometricPrimitive.cpp
+++ b/Src/GeometricPrimitive.cpp
@@ -148,10 +148,10 @@ _Use_decl_annotations_
 void GeometricPrimitive::Impl::Initialize(ID3D11DeviceContext* deviceContext, const VertexCollection& vertices, const IndexCollection& indices)
 {
     if (vertices.size() >= USHRT_MAX)
-        throw std::invalid_argument("Too many vertices for 16-bit index buffer");
+        throw std::out_of_range("Too many vertices for 16-bit index buffer");
 
     if (indices.size() > UINT32_MAX)
-        throw std::invalid_argument("Too many indices");
+        throw std::out_of_range("Too many indices");
 
     mResources = sharedResourcesPool.DemandCreate(deviceContext);
 
@@ -754,7 +754,7 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateCustom(
 
     size_t nVerts = vertices.size();
     if (nVerts >= USHRT_MAX)
-        throw std::invalid_argument("Too many vertices for 16-bit index buffer");
+        throw std::out_of_range("Too many vertices for 16-bit index buffer");
 
     for (auto it = indices.cbegin(); it != indices.cend(); ++it)
     {

--- a/Src/GeometricPrimitive.cpp
+++ b/Src/GeometricPrimitive.cpp
@@ -148,10 +148,10 @@ _Use_decl_annotations_
 void GeometricPrimitive::Impl::Initialize(ID3D11DeviceContext* deviceContext, const VertexCollection& vertices, const IndexCollection& indices)
 {
     if (vertices.size() >= USHRT_MAX)
-        throw std::exception("Too many vertices for 16-bit index buffer");
+        throw std::invalid_argument("Too many vertices for 16-bit index buffer");
 
     if (indices.size() > UINT32_MAX)
-        throw std::exception("Too many indices");
+        throw std::invalid_argument("Too many indices");
 
     mResources = sharedResourcesPool.DemandCreate(deviceContext);
 
@@ -747,20 +747,20 @@ std::unique_ptr<GeometricPrimitive> GeometricPrimitive::CreateCustom(
 {
     // Extra validation
     if (vertices.empty() || indices.empty())
-        throw std::exception("Requires both vertices and indices");
+        throw std::invalid_argument("Requires both vertices and indices");
 
     if (indices.size() % 3)
-        throw std::exception("Expected triangular faces");
+        throw std::invalid_argument("Expected triangular faces");
 
     size_t nVerts = vertices.size();
     if (nVerts >= USHRT_MAX)
-        throw std::exception("Too many vertices for 16-bit index buffer");
+        throw std::invalid_argument("Too many vertices for 16-bit index buffer");
 
     for (auto it = indices.cbegin(); it != indices.cend(); ++it)
     {
         if (*it >= nVerts)
         {
-            throw std::exception("Index not in vertices list");
+            throw std::out_of_range("Index not in vertices list");
         }
     }
 

--- a/Src/Geometry.cpp
+++ b/Src/Geometry.cpp
@@ -24,7 +24,7 @@ namespace
     {
         // Use >=, not > comparison, because some D3D level 9_x hardware does not support 0xFFFF index values.
         if (value >= USHRT_MAX)
-            throw std::exception("Index value out of range: cannot tesselate primitive so finely");
+            throw std::out_of_range("Index value out of range: cannot tesselate primitive so finely");
     }
 
 
@@ -150,7 +150,7 @@ void DirectX::ComputeSphere(VertexCollection& vertices, IndexCollection& indices
     indices.clear();
 
     if (tessellation < 3)
-        throw std::out_of_range("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter out of range");
 
     size_t verticalSegments = tessellation;
     size_t horizontalSegments = tessellation * 2;
@@ -617,7 +617,7 @@ void DirectX::ComputeCylinder(VertexCollection& vertices, IndexCollection& indic
     indices.clear();
 
     if (tessellation < 3)
-        throw std::out_of_range("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter out of range");
 
     height /= 2;
 
@@ -666,7 +666,7 @@ void DirectX::ComputeCone(VertexCollection& vertices, IndexCollection& indices, 
     indices.clear();
 
     if (tessellation < 3)
-        throw std::out_of_range("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter out of range");
 
     height /= 2;
 
@@ -720,7 +720,7 @@ void DirectX::ComputeTorus(VertexCollection& vertices, IndexCollection& indices,
     indices.clear();
 
     if (tessellation < 3)
-        throw std::out_of_range("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter out of range");
 
     size_t stride = tessellation + 1;
 
@@ -1162,7 +1162,7 @@ void DirectX::ComputeTeapot(VertexCollection& vertices, IndexCollection& indices
     indices.clear();
 
     if (tessellation < 1)
-        throw std::out_of_range("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter out of range");
 
     XMVECTOR scaleVector = XMVectorReplicate(size);
 

--- a/Src/Geometry.cpp
+++ b/Src/Geometry.cpp
@@ -150,7 +150,7 @@ void DirectX::ComputeSphere(VertexCollection& vertices, IndexCollection& indices
     indices.clear();
 
     if (tessellation < 3)
-        throw std::invalid_argument("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter must be at least 3");
 
     size_t verticalSegments = tessellation;
     size_t horizontalSegments = tessellation * 2;
@@ -617,7 +617,7 @@ void DirectX::ComputeCylinder(VertexCollection& vertices, IndexCollection& indic
     indices.clear();
 
     if (tessellation < 3)
-        throw std::invalid_argument("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter must be at least 3");
 
     height /= 2;
 
@@ -666,7 +666,7 @@ void DirectX::ComputeCone(VertexCollection& vertices, IndexCollection& indices, 
     indices.clear();
 
     if (tessellation < 3)
-        throw std::invalid_argument("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter must be at least 3");
 
     height /= 2;
 
@@ -720,7 +720,7 @@ void DirectX::ComputeTorus(VertexCollection& vertices, IndexCollection& indices,
     indices.clear();
 
     if (tessellation < 3)
-        throw std::invalid_argument("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter must be at least 3");
 
     size_t stride = tessellation + 1;
 
@@ -1162,7 +1162,7 @@ void DirectX::ComputeTeapot(VertexCollection& vertices, IndexCollection& indices
     indices.clear();
 
     if (tessellation < 1)
-        throw std::invalid_argument("tesselation parameter out of range");
+        throw std::invalid_argument("tesselation parameter must be non-zero");
 
     XMVECTOR scaleVector = XMVectorReplicate(size);
 

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -32,7 +32,7 @@ public:
     {
         if (s_graphicsMemory)
         {
-            throw std::exception("GraphicsMemory is a singleton");
+            throw std::logic_error("GraphicsMemory is a singleton");
         }
 
         s_graphicsMemory = this;
@@ -113,7 +113,7 @@ public:
                                        MEM_LARGE_PAGES | MEM_GRAPHICS | MEM_RESERVE | MEM_COMMIT,
                                        PAGE_WRITECOMBINE | PAGE_READWRITE | PAGE_GPU_READONLY);
             if (!mGrfxMemory)
-                throw  std::bad_alloc();
+                throw std::bad_alloc();
         }
 
         size_t mPageSize;
@@ -222,7 +222,7 @@ public:
     {
         if (s_graphicsMemory)
         {
-            throw std::exception("GraphicsMemory is a singleton");
+            throw std::logic_error("GraphicsMemory is a singleton");
         }
 
         s_graphicsMemory = this;
@@ -321,7 +321,7 @@ void GraphicsMemory::Commit()
 GraphicsMemory& GraphicsMemory::Get()
 {
     if (!Impl::s_graphicsMemory || !Impl::s_graphicsMemory->mOwner)
-        throw std::exception("GraphicsMemory singleton not created");
+        throw std::logic_error("GraphicsMemory singleton not created");
 
     return *Impl::s_graphicsMemory->mOwner;
 }

--- a/Src/Keyboard.cpp
+++ b/Src/Keyboard.cpp
@@ -67,7 +67,7 @@ public:
     {
         if (s_keyboard)
         {
-            throw std::exception("Keyboard is a singleton");
+            throw std::logic_error("Keyboard is a singleton");
         }
 
         s_keyboard = this;
@@ -209,7 +209,7 @@ public:
     {
         if (s_keyboard)
         {
-            throw std::exception("Keyboard is a singleton");
+            throw std::logic_error("Keyboard is a singleton");
         }
 
         s_keyboard = this;
@@ -342,7 +342,7 @@ public:
     {
         if (s_keyboard)
         {
-            throw std::exception("Keyboard is a singleton");
+            throw std::logic_error("Keyboard is a singleton");
         }
 
         s_keyboard = this;
@@ -603,7 +603,7 @@ bool Keyboard::IsConnected() const
 Keyboard& Keyboard::Get()
 {
     if (!Impl::s_keyboard || !Impl::s_keyboard->mOwner)
-        throw std::exception("Keyboard is a singleton");
+        throw std::logic_error("Keyboard singleton not created");
 
     return *Impl::s_keyboard->mOwner;
 }

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -120,10 +120,10 @@ void ModelMeshPart::CreateInputLayout(ID3D11Device* d3dDevice, IEffect* ieffect,
     }
 
     if (!vbDecl || vbDecl->empty())
-        throw std::exception("Model mesh part missing vertex buffer input elements data");
+        throw std::runtime_error("Model mesh part missing vertex buffer input elements data");
 
     if (vbDecl->size() > D3D11_IA_VERTEX_INPUT_STRUCTURE_ELEMENT_COUNT)
-        throw std::exception("Model mesh part input layout size is too large for DirectX 11");
+        throw std::runtime_error("Model mesh part input layout size is too large for DirectX 11");
 
     ThrowIfFailed(
         CreateInputLayoutFromEffect(d3dDevice, ieffect, vbDecl->data(), vbDecl->size(), iinputLayout)
@@ -138,10 +138,10 @@ _Use_decl_annotations_
 void ModelMeshPart::ModifyEffect(ID3D11Device* d3dDevice, std::shared_ptr<IEffect>& ieffect, bool isalpha)
 {
     if (!vbDecl || vbDecl->empty())
-        throw std::exception("Model mesh part missing vertex buffer input elements data");
+        throw std::runtime_error("Model mesh part missing vertex buffer input elements data");
 
     if (vbDecl->size() > D3D11_IA_VERTEX_INPUT_STRUCTURE_ELEMENT_COUNT)
-        throw std::exception("Model mesh part input layout size is too large for DirectX 11");
+        throw std::runtime_error("Model mesh part input layout size is too large for DirectX 11");
 
     assert(ieffect != nullptr);
     this->effect = ieffect;

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -266,7 +266,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
     ModelLoaderFlags flags)
 {
     if (!InitOnceExecuteOnce(&g_InitOnce, InitializeDecl, nullptr, nullptr))
-        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "InitOnceExecuteOnce");
+        throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "InitOnceExecuteOnce");
 
     if (!device || !meshData)
         throw std::invalid_argument("Device and meshData cannot be null");

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -266,10 +266,10 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
     ModelLoaderFlags flags)
 {
     if (!InitOnceExecuteOnce(&g_InitOnce, InitializeDecl, nullptr, nullptr))
-        throw std::exception("One-time initialization failed");
+        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "InitOnceExecuteOnce");
 
     if (!device || !meshData)
-        throw std::exception("Device and meshData cannot be null");
+        throw std::invalid_argument("Device and meshData cannot be null");
 
     auto fxFactoryDGSL = dynamic_cast<DGSLEffectFactory*>(&fxFactory);
 
@@ -277,10 +277,10 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
     auto nMesh = reinterpret_cast<const UINT*>(meshData);
     size_t usedSize = sizeof(UINT);
     if (dataSize < usedSize)
-        throw std::exception("End of file");
+        throw std::runtime_error("End of file");
 
     if (!*nMesh)
-        throw std::exception("No meshes found");
+        throw std::runtime_error("No meshes found");
 
     auto model = std::make_unique<Model>();
 
@@ -290,13 +290,13 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         auto nName = reinterpret_cast<const UINT*>(meshData + usedSize);
         usedSize += sizeof(UINT);
         if (dataSize < usedSize)
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         auto meshName = reinterpret_cast<const wchar_t*>(meshData + usedSize);
 
         usedSize += sizeof(wchar_t)*(*nName);
         if (dataSize < usedSize)
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         auto mesh = std::make_shared<ModelMesh>();
         mesh->name.assign(meshName, *nName);
@@ -307,7 +307,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         auto nMats = reinterpret_cast<const UINT*>(meshData + usedSize);
         usedSize += sizeof(UINT);
         if (dataSize < usedSize)
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         std::vector<MaterialRecordCMO> materials;
         materials.reserve(*nMats);
@@ -319,13 +319,13 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             nName = reinterpret_cast<const UINT*>(meshData + usedSize);
             usedSize += sizeof(UINT);
             if (dataSize < usedSize)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             auto matName = reinterpret_cast<const wchar_t*>(meshData + usedSize);
 
             usedSize += sizeof(wchar_t)*(*nName);
             if (dataSize < usedSize)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             m.name.assign(matName, *nName);
 
@@ -333,7 +333,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             auto matSetting = reinterpret_cast<const VSD3DStarter::Material*>(meshData + usedSize);
             usedSize += sizeof(VSD3DStarter::Material);
             if (dataSize < usedSize)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             m.pMaterial = matSetting;
 
@@ -341,13 +341,13 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             nName = reinterpret_cast<const UINT*>(meshData + usedSize);
             usedSize += sizeof(UINT);
             if (dataSize < usedSize)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             auto psName = reinterpret_cast<const wchar_t*>(meshData + usedSize);
 
             usedSize += sizeof(wchar_t)*(*nName);
             if (dataSize < usedSize)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             m.pixelShader.assign(psName, *nName);
 
@@ -356,13 +356,13 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                 nName = reinterpret_cast<const UINT*>(meshData + usedSize);
                 usedSize += sizeof(UINT);
                 if (dataSize < usedSize)
-                    throw std::exception("End of file");
+                    throw std::runtime_error("End of file");
 
                 auto txtName = reinterpret_cast<const wchar_t*>(meshData + usedSize);
 
                 usedSize += sizeof(wchar_t)*(*nName);
                 if (dataSize < usedSize)
-                    throw std::exception("End of file");
+                    throw std::runtime_error("End of file");
 
                 m.texture[t].assign(txtName, *nName);
             }
@@ -385,30 +385,30 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         const BYTE* bSkeleton = meshData + usedSize;
         usedSize += sizeof(BYTE);
         if (dataSize < usedSize)
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         // Submeshes
         auto nSubmesh = reinterpret_cast<const UINT*>(meshData + usedSize);
         usedSize += sizeof(UINT);
         if (dataSize < usedSize)
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         if (!*nSubmesh)
-            throw std::exception("No submeshes found\n");
+            throw std::runtime_error("No submeshes found\n");
 
         auto subMesh = reinterpret_cast<const VSD3DStarter::SubMesh*>(meshData + usedSize);
         usedSize += sizeof(VSD3DStarter::SubMesh) * (*nSubmesh);
         if (dataSize < usedSize)
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         // Index buffers
         auto nIBs = reinterpret_cast<const UINT*>(meshData + usedSize);
         usedSize += sizeof(UINT);
         if (dataSize < usedSize)
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         if (!*nIBs)
-            throw std::exception("No index buffers found\n");
+            throw std::runtime_error("No index buffers found\n");
 
         struct IBData
         {
@@ -427,20 +427,20 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             auto nIndexes = reinterpret_cast<const UINT*>(meshData + usedSize);
             usedSize += sizeof(UINT);
             if (dataSize < usedSize)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             if (!*nIndexes)
-                throw std::exception("Empty index buffer found\n");
+                throw std::runtime_error("Empty index buffer found\n");
 
             uint64_t sizeInBytes = uint64_t(*(nIndexes)) * sizeof(USHORT);
 
             if (sizeInBytes > UINT32_MAX)
-                throw std::exception("IB too large");
+                throw std::runtime_error("IB too large");
 
             if (!(flags & ModelLoader_AllowLargeModels))
             {
                 if (sizeInBytes > (D3D11_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u))
-                    throw std::exception("IB too large for DirectX 11");
+                    throw std::runtime_error("IB too large for DirectX 11");
             }
 
             auto ibBytes = static_cast<size_t>(sizeInBytes);
@@ -448,7 +448,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             auto indexes = reinterpret_cast<const USHORT*>(meshData + usedSize);
             usedSize += ibBytes;
             if (dataSize < usedSize)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             IBData ib;
             ib.nIndices = *nIndexes;
@@ -476,10 +476,10 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         auto nVBs = reinterpret_cast<const UINT*>(meshData + usedSize);
         usedSize += sizeof(UINT);
         if (dataSize < usedSize)
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         if (!*nVBs)
-            throw std::exception("No vertex buffers found\n");
+            throw std::runtime_error("No vertex buffers found\n");
 
         struct VBData
         {
@@ -495,17 +495,17 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             auto nVerts = reinterpret_cast<const UINT*>(meshData + usedSize);
             usedSize += sizeof(UINT);
             if (dataSize < usedSize)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             if (!*nVerts)
-                throw std::exception("Empty vertex buffer found\n");
+                throw std::runtime_error("Empty vertex buffer found\n");
 
             size_t vbBytes = sizeof(VertexPositionNormalTangentColorTexture) * (*(nVerts));
 
             auto verts = reinterpret_cast<const VertexPositionNormalTangentColorTexture*>(meshData + usedSize);
             usedSize += vbBytes;
             if (dataSize < usedSize)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             VBData vb;
             vb.nVerts = *nVerts;
@@ -520,32 +520,32 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         auto nSkinVBs = reinterpret_cast<const UINT*>(meshData + usedSize);
         usedSize += sizeof(UINT);
         if (dataSize < usedSize)
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         if (*nSkinVBs)
         {
             if (*nSkinVBs != *nVBs)
-                throw std::exception("Number of VBs not equal to number of skin VBs");
+                throw std::runtime_error("Number of VBs not equal to number of skin VBs");
 
             for (UINT j = 0; j < *nSkinVBs; ++j)
             {
                 auto nVerts = reinterpret_cast<const UINT*>(meshData + usedSize);
                 usedSize += sizeof(UINT);
                 if (dataSize < usedSize)
-                    throw std::exception("End of file");
+                    throw std::runtime_error("End of file");
 
                 if (!*nVerts)
-                    throw std::exception("Empty skinning vertex buffer found\n");
+                    throw std::runtime_error("Empty skinning vertex buffer found\n");
 
                 if (vbData[j].nVerts != *nVerts)
-                    throw std::exception("Mismatched number of verts for skin VBs");
+                    throw std::runtime_error("Mismatched number of verts for skin VBs");
 
                 size_t vbBytes = sizeof(VSD3DStarter::SkinningVertex) * (*(nVerts));
 
                 auto verts = reinterpret_cast<const VSD3DStarter::SkinningVertex*>(meshData + usedSize);
                 usedSize += vbBytes;
                 if (dataSize < usedSize)
-                    throw std::exception("End of file");
+                    throw std::runtime_error("End of file");
 
                 vbData[j].skinPtr = verts;
             }
@@ -555,7 +555,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         auto extents = reinterpret_cast<const VSD3DStarter::MeshExtents*>(meshData + usedSize);
         usedSize += sizeof(VSD3DStarter::MeshExtents);
         if (dataSize < usedSize)
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         mesh->boundingSphere.Center.x = extents->CenterX;
         mesh->boundingSphere.Center.y = extents->CenterY;
@@ -574,10 +574,10 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             auto nBones = reinterpret_cast<const UINT*>(meshData + usedSize);
             usedSize += sizeof(UINT);
             if (dataSize < usedSize)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             if (!*nBones)
-                throw std::exception("Animation bone data is missing\n");
+                throw std::runtime_error("Animation bone data is missing\n");
 
             for (UINT j = 0; j < *nBones; ++j)
             {
@@ -585,13 +585,13 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                 nName = reinterpret_cast<const UINT*>(meshData + usedSize);
                 usedSize += sizeof(UINT);
                 if (dataSize < usedSize)
-                    throw std::exception("End of file");
+                    throw std::runtime_error("End of file");
 
                 auto boneName = reinterpret_cast<const wchar_t*>(meshData + usedSize);
 
                 usedSize += sizeof(wchar_t)*(*nName);
                 if (dataSize < usedSize)
-                    throw std::exception("End of file");
+                    throw std::runtime_error("End of file");
 
                 // TODO - What to do with bone name?
                 boneName;
@@ -600,7 +600,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                 auto bones = reinterpret_cast<const VSD3DStarter::Bone*>(meshData + usedSize);
                 usedSize += sizeof(VSD3DStarter::Bone);
                 if (dataSize < usedSize)
-                    throw std::exception("End of file");
+                    throw std::runtime_error("End of file");
 
                 // TODO - What to do with bone data?
                 bones;
@@ -610,7 +610,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             auto nClips = reinterpret_cast<const UINT*>(meshData + usedSize);
             usedSize += sizeof(UINT);
             if (dataSize < usedSize)
-                throw std::exception("End of file");
+                throw std::runtime_error("End of file");
 
             for (UINT j = 0; j < *nClips; ++j)
             {
@@ -618,13 +618,13 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                 nName = reinterpret_cast<const UINT*>(meshData + usedSize);
                 usedSize += sizeof(UINT);
                 if (dataSize < usedSize)
-                    throw std::exception("End of file");
+                    throw std::runtime_error("End of file");
 
                 auto clipName = reinterpret_cast<const wchar_t*>(meshData + usedSize);
 
                 usedSize += sizeof(wchar_t)*(*nName);
                 if (dataSize < usedSize)
-                    throw std::exception("End of file");
+                    throw std::runtime_error("End of file");
 
                 // TODO - What to do with clip name?
                 clipName;
@@ -632,15 +632,15 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                 auto clip = reinterpret_cast<const VSD3DStarter::Clip*>(meshData + usedSize);
                 usedSize += sizeof(VSD3DStarter::Clip);
                 if (dataSize < usedSize)
-                    throw std::exception("End of file");
+                    throw std::runtime_error("End of file");
 
                 if (!clip->keys)
-                    throw std::exception("Keyframes missing in clip");
+                    throw std::runtime_error("Keyframes missing in clip");
 
                 auto keys = reinterpret_cast<const VSD3DStarter::Keyframe*>(meshData + usedSize);
                 usedSize += sizeof(VSD3DStarter::Keyframe) * clip->keys;
                 if (dataSize < usedSize)
-                    throw std::exception("End of file");
+                    throw std::runtime_error("End of file");
 
                 // TODO - What to do with keys and clip->StartTime, clip->EndTime?
                 keys;
@@ -666,12 +666,12 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             uint64_t sizeInBytes = uint64_t(stride) * uint64_t(nVerts);
 
             if (sizeInBytes > UINT32_MAX)
-                throw std::exception("VB too large");
+                throw std::runtime_error("VB too large");
 
             if (!(flags & ModelLoader_AllowLargeModels))
             {
                 if (sizeInBytes > uint64_t(D3D11_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u))
-                    throw std::exception("VB too large for DirectX 11");
+                    throw std::runtime_error("VB too large for DirectX 11");
             }
 
             size_t bytes = static_cast<size_t>(sizeInBytes);
@@ -737,7 +737,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
 
                         if ((sm.IndexBufferIndex >= *nIBs)
                             || (sm.MaterialIndex >= materials.size()))
-                            throw std::exception("Invalid submesh found\n");
+                            throw std::out_of_range("Invalid submesh found\n");
 
                         XMMATRIX uvTransform = XMLoadFloat4x4(&materials[sm.MaterialIndex].pMaterial->UVTransform);
 
@@ -750,7 +750,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                             size_t v = ib[q];
 
                             if (v >= nVerts)
-                                throw std::exception("Invalid index found\n");
+                                throw std::out_of_range("Invalid index found\n");
 
                             auto verts = reinterpret_cast<VertexPositionNormalTangentColorTexture*>(temp.get() + (v * stride));
                             if (visited[v] == UINT(-1))
@@ -860,7 +860,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             if ((sm.IndexBufferIndex >= *nIBs)
                 || (sm.VertexBufferIndex >= *nVBs)
                 || (sm.MaterialIndex >= materials.size()))
-                throw std::exception("Invalid submesh found\n");
+                throw std::out_of_range("Invalid submesh found\n");
 
             auto& mat = materials[sm.MaterialIndex];
 
@@ -903,7 +903,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
     {
         DebugTrace("ERROR: CreateFromCMO failed (%08X) loading '%ls'\n",
             static_cast<unsigned int>(hr), szFileName);
-        throw std::exception("CreateFromCMO");
+        throw std::runtime_error("CreateFromCMO");
     }
 
     auto model = CreateFromCMO(device, data.get(), dataSize, fxFactory, flags);

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
     ModelLoaderFlags flags)
 {
     if (!InitOnceExecuteOnce(&g_InitOnce, InitializeDecl, nullptr, nullptr))
-        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "InitOnceExecuteOnce");
+        throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "InitOnceExecuteOnce");
 
     if (!device || !meshData)
         throw std::invalid_argument("Device and meshData cannot be null");

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -67,7 +67,7 @@ public:
     {
         if (s_mouse)
         {
-            throw std::exception("Mouse is a singleton");
+            throw std::logic_error("Mouse is a singleton");
         }
 
         s_mouse = this;
@@ -86,7 +86,7 @@ public:
         mScrollWheelValue.reset(CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mScrollWheelValue)
         {
-            throw std::exception("CreateEventEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
     }
 
@@ -121,7 +121,7 @@ public:
 
         DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
         if (result == WAIT_FAILED)
-            throw std::exception("WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
 
         if (result == WAIT_OBJECT_0)
         {
@@ -205,7 +205,7 @@ public:
         CURSORINFO info = { sizeof(CURSORINFO), 0, nullptr, {} };
         if (!GetCursorInfo(&info))
         {
-            throw std::exception("GetCursorInfo");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "GetCursorInfo");
         }
 
         bool isvisible = (info.flags & CURSOR_SHOWING) != 0;
@@ -270,7 +270,7 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
 
     DWORD result = WaitForSingleObjectEx(pImpl->mScrollWheelValue.get(), 0, FALSE);
     if (result == WAIT_FAILED)
-        throw std::exception("WaitForSingleObjectEx");
+        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
 
     if (result == WAIT_OBJECT_0)
     {
@@ -445,7 +445,7 @@ public:
     {
         if (s_mouse)
         {
-            throw std::exception("Mouse is a singleton");
+            throw std::logic_error("Mouse is a singleton");
         }
 
         s_mouse = this;
@@ -459,7 +459,7 @@ public:
             || !mAbsoluteMode
             || !mRelativeMode)
         {
-            throw std::exception("CreateEventEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
     }
 
@@ -481,7 +481,7 @@ public:
 
         DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
         if (result == WAIT_FAILED)
-            throw std::exception("WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
 
         if (result == WAIT_OBJECT_0)
         {
@@ -493,7 +493,7 @@ public:
             result = WaitForSingleObjectEx(mRelativeRead.get(), 0, FALSE);
 
             if (result == WAIT_FAILED)
-                throw std::exception("WaitForSingleObjectEx");
+                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
 
             if (result == WAIT_OBJECT_0)
             {
@@ -528,7 +528,7 @@ public:
         tme.dwHoverTime = 1;
         if (!TrackMouseEvent(&tme))
         {
-            throw std::exception("TrackMouseEvent");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "TrackMouseEvent");
         }
     }
 
@@ -557,7 +557,7 @@ public:
         CURSORINFO info = { sizeof(CURSORINFO), 0, nullptr, {} };
         if (!GetCursorInfo(&info))
         {
-            throw std::exception("GetCursorInfo");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "GetCursorInfo");
         }
 
         bool isvisible = (info.flags & CURSOR_SHOWING) != 0;
@@ -581,7 +581,7 @@ public:
         Rid.hwndTarget = window;
         if (!RegisterRawInputDevices(&Rid, 1, sizeof(RAWINPUTDEVICE)))
         {
-            throw std::exception("RegisterRawInputDevices");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "RegisterRawInputDevices");
         }
 
         mWindow = window;
@@ -705,7 +705,7 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
         break;
 
         case WAIT_FAILED:
-            throw std::exception("WaitForMultipleObjectsEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForMultipleObjectsEx");
     }
 
     switch (message)
@@ -743,7 +743,7 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
                 UINT resultData = GetRawInputData(reinterpret_cast<HRAWINPUT>(lParam), RID_INPUT, &raw, &rawSize, sizeof(RAWINPUTHEADER));
                 if (resultData == UINT(-1))
                 {
-                    throw std::exception("GetRawInputData");
+                    throw std::runtime_error("GetRawInputData");
                 }
 
                 if (raw.header.dwType == RIM_TYPEMOUSE)
@@ -874,7 +874,7 @@ public:
     {
         if (s_mouse)
         {
-            throw std::exception("Mouse is a singleton");
+            throw std::logic_error("Mouse is a singleton");
         }
 
         s_mouse = this;
@@ -959,7 +959,7 @@ public:
     {
         if (s_mouse)
         {
-            throw std::exception("Mouse is a singleton");
+            throw std::logic_error("Mouse is a singleton");
         }
 
         s_mouse = this;
@@ -969,7 +969,7 @@ public:
         if (!mScrollWheelValue
             || !mRelativeRead)
         {
-            throw std::exception("CreateEventEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
         }
     }
 
@@ -986,7 +986,7 @@ public:
 
         DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
         if (result == WAIT_FAILED)
-            throw std::exception("WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
 
         if (result == WAIT_OBJECT_0)
         {
@@ -998,7 +998,7 @@ public:
             result = WaitForSingleObjectEx(mRelativeRead.get(), 0, FALSE);
 
             if (result == WAIT_FAILED)
-                throw std::exception("WaitForSingleObjectEx");
+                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
 
             if (result == WAIT_OBJECT_0)
             {
@@ -1462,7 +1462,7 @@ void Mouse::SetVisible(bool visible)
 Mouse& Mouse::Get()
 {
     if (!Impl::s_mouse || !Impl::s_mouse->mOwner)
-        throw std::exception("Mouse is a singleton");
+        throw std::logic_error("Mouse singleton not created");
 
     return *Impl::s_mouse->mOwner;
 }

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -86,7 +86,7 @@ public:
         mScrollWheelValue.reset(CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, EVENT_MODIFY_STATE | SYNCHRONIZE));
         if (!mScrollWheelValue)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
     }
 
@@ -121,7 +121,7 @@ public:
 
         DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
         if (result == WAIT_FAILED)
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
 
         if (result == WAIT_OBJECT_0)
         {
@@ -205,7 +205,7 @@ public:
         CURSORINFO info = { sizeof(CURSORINFO), 0, nullptr, {} };
         if (!GetCursorInfo(&info))
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "GetCursorInfo");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "GetCursorInfo");
         }
 
         bool isvisible = (info.flags & CURSOR_SHOWING) != 0;
@@ -270,7 +270,7 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
 
     DWORD result = WaitForSingleObjectEx(pImpl->mScrollWheelValue.get(), 0, FALSE);
     if (result == WAIT_FAILED)
-        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+        throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
 
     if (result == WAIT_OBJECT_0)
     {
@@ -459,7 +459,7 @@ public:
             || !mAbsoluteMode
             || !mRelativeMode)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
     }
 
@@ -481,7 +481,7 @@ public:
 
         DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
         if (result == WAIT_FAILED)
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
 
         if (result == WAIT_OBJECT_0)
         {
@@ -493,7 +493,7 @@ public:
             result = WaitForSingleObjectEx(mRelativeRead.get(), 0, FALSE);
 
             if (result == WAIT_FAILED)
-                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
 
             if (result == WAIT_OBJECT_0)
             {
@@ -528,7 +528,7 @@ public:
         tme.dwHoverTime = 1;
         if (!TrackMouseEvent(&tme))
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "TrackMouseEvent");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "TrackMouseEvent");
         }
     }
 
@@ -557,7 +557,7 @@ public:
         CURSORINFO info = { sizeof(CURSORINFO), 0, nullptr, {} };
         if (!GetCursorInfo(&info))
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "GetCursorInfo");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "GetCursorInfo");
         }
 
         bool isvisible = (info.flags & CURSOR_SHOWING) != 0;
@@ -581,7 +581,7 @@ public:
         Rid.hwndTarget = window;
         if (!RegisterRawInputDevices(&Rid, 1, sizeof(RAWINPUTDEVICE)))
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "RegisterRawInputDevices");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "RegisterRawInputDevices");
         }
 
         mWindow = window;
@@ -705,7 +705,7 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
         break;
 
         case WAIT_FAILED:
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForMultipleObjectsEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForMultipleObjectsEx");
     }
 
     switch (message)
@@ -969,7 +969,7 @@ public:
         if (!mScrollWheelValue
             || !mRelativeRead)
         {
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "CreateEventEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
         }
     }
 
@@ -986,7 +986,7 @@ public:
 
         DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
         if (result == WAIT_FAILED)
-            throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
 
         if (result == WAIT_OBJECT_0)
         {
@@ -998,7 +998,7 @@ public:
             result = WaitForSingleObjectEx(mRelativeRead.get(), 0, FALSE);
 
             if (result == WAIT_FAILED)
-                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "WaitForSingleObjectEx");
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
 
             if (result == WAIT_OBJECT_0)
             {

--- a/Src/NormalMapEffect.cpp
+++ b/Src/NormalMapEffect.cpp
@@ -181,7 +181,7 @@ NormalMapEffect::Impl::Impl(_In_ ID3D11Device* device)
 {
     if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
     {
-        throw std::exception("NormalMapEffect requires Feature Level 10.0 or later");
+        throw std::runtime_error("NormalMapEffect requires Feature Level 10.0 or later");
     }
 
     static_assert(static_cast<int>(std::size(EffectBase<NormalMapEffectTraits>::VertexShaderIndices)) == NormalMapEffectTraits::ShaderPermutationCount, "array/max mismatch");
@@ -388,7 +388,7 @@ void NormalMapEffect::SetLightingEnabled(bool value)
 {
     if (!value)
     {
-        throw std::exception("NormalMapEffect does not support turning off lighting");
+        throw std::invalid_argument("NormalMapEffect does not support turning off lighting");
     }
 }
 

--- a/Src/PBREffect.cpp
+++ b/Src/PBREffect.cpp
@@ -172,7 +172,7 @@ PBREffect::Impl::Impl(_In_ ID3D11Device* device)
 {
     if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
     {
-        throw std::exception("PBREffect requires Feature Level 10.0 or later");
+        throw std::runtime_error("PBREffect requires Feature Level 10.0 or later");
     }
 
     static_assert(static_cast<int>(std::size(EffectBase<PBREffectTraits>::VertexShaderIndices)) == PBREffectTraits::ShaderPermutationCount, "array/max mismatch");
@@ -366,7 +366,7 @@ void PBREffect::SetLightingEnabled(bool value)
 {
     if (!value)
     {
-        throw std::exception("PBREffect does not support turning off lighting");
+        throw std::invalid_argument("PBREffect does not support turning off lighting");
     }
 }
 

--- a/Src/PBREffectFactory.cpp
+++ b/Src/PBREffectFactory.cpp
@@ -127,7 +127,7 @@ _Use_decl_annotations_
 void PBREffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext* deviceContext, ID3D11ShaderResourceView** textureView)
 {
     if (!name || !textureView)
-        throw std::invalid_argument("PBREffectFactory");
+        throw std::invalid_argument("name and textureView parameters can't be null");
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
     UNREFERENCED_PARAMETER(deviceContext);

--- a/Src/PBREffectFactory.cpp
+++ b/Src/PBREffectFactory.cpp
@@ -155,7 +155,7 @@ void PBREffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCont
             if (!GetFileAttributesExW(fullName, GetFileExInfoStandard, &fileAttr))
             {
                 DebugTrace("ERROR: PBREffectFactory could not find texture file '%ls'\n", name);
-                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "PBREffectFactory::CreateTexture");
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "PBREffectFactory::CreateTexture");
             }
         }
 

--- a/Src/PBREffectFactory.cpp
+++ b/Src/PBREffectFactory.cpp
@@ -172,7 +172,7 @@ void PBREffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCont
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::runtime_error("CreateDDSTextureFromFile");
+                throw std::runtime_error("PBREffectFactory::CreateDDSTextureFromFile");
             }
         }
     #if !defined(_XBOX_ONE) || !defined(_TITLE)
@@ -187,7 +187,7 @@ void PBREffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCont
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::runtime_error("CreateWICTextureFromFile");
+                throw std::runtime_error("PBREffectFactory::CreateWICTextureFromFile");
             }
         }
     #endif
@@ -201,7 +201,7 @@ void PBREffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCont
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::runtime_error("CreateWICTextureFromFile");
+                throw std::runtime_error("PBREffectFactory::CreateWICTextureFromFile");
             }
         }
 

--- a/Src/PBREffectFactory.cpp
+++ b/Src/PBREffectFactory.cpp
@@ -127,7 +127,7 @@ _Use_decl_annotations_
 void PBREffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext* deviceContext, ID3D11ShaderResourceView** textureView)
 {
     if (!name || !textureView)
-        throw std::exception("invalid arguments");
+        throw std::invalid_argument("PBREffectFactory");
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
     UNREFERENCED_PARAMETER(deviceContext);
@@ -155,7 +155,7 @@ void PBREffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCont
             if (!GetFileAttributesExW(fullName, GetFileExInfoStandard, &fileAttr))
             {
                 DebugTrace("ERROR: PBREffectFactory could not find texture file '%ls'\n", name);
-                throw std::exception("CreateTexture");
+                throw std::system_error(std::error_code(GetLastError(), std::system_category()), "PBREffectFactory::CreateTexture");
             }
         }
 
@@ -172,7 +172,7 @@ void PBREffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCont
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::exception("CreateDDSTextureFromFile");
+                throw std::runtime_error("CreateDDSTextureFromFile");
             }
         }
     #if !defined(_XBOX_ONE) || !defined(_TITLE)
@@ -187,7 +187,7 @@ void PBREffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCont
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::exception("CreateWICTextureFromFile");
+                throw std::runtime_error("CreateWICTextureFromFile");
             }
         }
     #endif
@@ -201,7 +201,7 @@ void PBREffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCont
             {
                 DebugTrace("ERROR: CreateWICTextureFromFile failed (%08X) for '%ls'\n",
                     static_cast<unsigned int>(hr), fullName);
-                throw std::exception("CreateWICTextureFromFile");
+                throw std::runtime_error("CreateWICTextureFromFile");
             }
         }
 

--- a/Src/PlatformHelpers.h
+++ b/Src/PlatformHelpers.h
@@ -31,7 +31,7 @@ namespace DirectX
     public:
         com_exception(HRESULT hr) noexcept : result(hr) {}
 
-        const char* what() const override
+        const char* what() const noexcept override
         {
             static char s_str[64] = {};
             sprintf_s(s_str, "Failure with HRESULT of %08X", static_cast<unsigned int>(result));

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -269,10 +269,10 @@ void PrimitiveBatchBase::Impl::Draw(D3D11_PRIMITIVE_TOPOLOGY topology, bool isIn
         throw std::invalid_argument("Indices cannot be null");
 
     if (indexCount >= mMaxIndices)
-        throw std::invalid_argument("Too many indices");
+        throw std::out_of_range("Too many indices");
 
     if (vertexCount >= mMaxVertices)
-        throw std::invalid_argument("Too many vertices");
+        throw std::out_of_range("Too many vertices");
 
     if (!mInBeginEndPair)
         throw std::logic_error("Begin must be called before Draw");

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -180,7 +180,7 @@ PrimitiveBatchBase::Impl::Impl(_In_ ID3D11DeviceContext* deviceContext, size_t m
 void PrimitiveBatchBase::Impl::Begin()
 {
     if (mInBeginEndPair)
-        throw std::runtime_error("Cannot nest Begin calls");
+        throw std::logic_error("Cannot nest Begin calls");
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
     mDeviceContext->IASetIndexBuffer(nullptr, DXGI_FORMAT_UNKNOWN, 0);
@@ -214,7 +214,7 @@ void PrimitiveBatchBase::Impl::Begin()
 void PrimitiveBatchBase::Impl::End()
 {
     if (!mInBeginEndPair)
-        throw std::runtime_error("Begin must be called before End");
+        throw std::logic_error("Begin must be called before End");
 
     FlushBatch();
 
@@ -266,7 +266,7 @@ _Use_decl_annotations_
 void PrimitiveBatchBase::Impl::Draw(D3D11_PRIMITIVE_TOPOLOGY topology, bool isIndexed, uint16_t const* indices, size_t indexCount, size_t vertexCount, void** pMappedVertices)
 {
     if (isIndexed && !indices)
-        throw std::runtime_error("Indices cannot be null");
+        throw std::invalid_argument("Indices cannot be null");
 
     if (indexCount >= mMaxIndices)
         throw std::invalid_argument("Too many indices");
@@ -275,7 +275,7 @@ void PrimitiveBatchBase::Impl::Draw(D3D11_PRIMITIVE_TOPOLOGY topology, bool isIn
         throw std::invalid_argument("Too many vertices");
 
     if (!mInBeginEndPair)
-        throw std::runtime_error("Begin must be called before Draw");
+        throw std::logic_error("Begin must be called before Draw");
 
     // Can we merge this primitive in with an existing batch, or must we flush first?
     bool wrapIndexBuffer = (mCurrentIndex + indexCount > mMaxIndices);

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -130,20 +130,20 @@ PrimitiveBatchBase::Impl::Impl(_In_ ID3D11DeviceContext* deviceContext, size_t m
     deviceContext->GetDevice(&device);
 
     if (!maxVertices)
-        throw std::exception("maxVertices must be greater than 0");
+        throw std::invalid_argument("maxVertices must be greater than 0");
 
     if (vertexSize > D3D11_REQ_MULTI_ELEMENT_STRUCTURE_SIZE_IN_BYTES)
-        throw std::exception("Vertex size is too large for DirectX 11");
+        throw std::invalid_argument("Vertex size is too large for DirectX 11");
 
     uint64_t ibBytes = uint64_t(maxIndices) * sizeof(uint16_t);
     if (ibBytes > uint64_t(D3D11_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u)
         || ibBytes > UINT32_MAX)
-        throw std::exception("IB too large for DirectX 11");
+        throw std::invalid_argument("IB too large for DirectX 11");
 
     uint64_t vbBytes = uint64_t(maxVertices) * uint64_t(vertexSize);
     if (vbBytes > uint64_t(D3D11_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM * 1024u * 1024u)
         || vbBytes > UINT32_MAX)
-        throw std::exception("VB too large for DirectX 11");
+        throw std::invalid_argument("VB too large for DirectX 11");
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
     ThrowIfFailed(deviceContext->QueryInterface(IID_GRAPHICS_PPV_ARGS(mDeviceContext.GetAddressOf())));
@@ -180,7 +180,7 @@ PrimitiveBatchBase::Impl::Impl(_In_ ID3D11DeviceContext* deviceContext, size_t m
 void PrimitiveBatchBase::Impl::Begin()
 {
     if (mInBeginEndPair)
-        throw std::exception("Cannot nest Begin calls");
+        throw std::runtime_error("Cannot nest Begin calls");
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
     mDeviceContext->IASetIndexBuffer(nullptr, DXGI_FORMAT_UNKNOWN, 0);
@@ -214,7 +214,7 @@ void PrimitiveBatchBase::Impl::Begin()
 void PrimitiveBatchBase::Impl::End()
 {
     if (!mInBeginEndPair)
-        throw std::exception("Begin must be called before End");
+        throw std::runtime_error("Begin must be called before End");
 
     FlushBatch();
 
@@ -266,16 +266,16 @@ _Use_decl_annotations_
 void PrimitiveBatchBase::Impl::Draw(D3D11_PRIMITIVE_TOPOLOGY topology, bool isIndexed, uint16_t const* indices, size_t indexCount, size_t vertexCount, void** pMappedVertices)
 {
     if (isIndexed && !indices)
-        throw std::exception("Indices cannot be null");
+        throw std::runtime_error("Indices cannot be null");
 
     if (indexCount >= mMaxIndices)
-        throw std::exception("Too many indices");
+        throw std::invalid_argument("Too many indices");
 
     if (vertexCount >= mMaxVertices)
-        throw std::exception("Too many vertices");
+        throw std::invalid_argument("Too many vertices");
 
     if (!mInBeginEndPair)
-        throw std::exception("Begin must be called before Draw");
+        throw std::runtime_error("Begin must be called before Draw");
 
     // Can we merge this primitive in with an existing batch, or must we flush first?
     bool wrapIndexBuffer = (mCurrentIndex + indexCount > mMaxIndices);

--- a/Src/SkinnedEffect.cpp
+++ b/Src/SkinnedEffect.cpp
@@ -599,7 +599,7 @@ void SkinnedEffect::SetWeightsPerVertex(int value)
         (value != 2) &&
         (value != 4))
     {
-        throw std::out_of_range("WeightsPerVertex must be 1, 2, or 4");
+        throw std::invalid_argument("WeightsPerVertex must be 1, 2, or 4");
     }
 
     pImpl->weightsPerVertex = value;

--- a/Src/SkinnedEffect.cpp
+++ b/Src/SkinnedEffect.cpp
@@ -499,7 +499,7 @@ void SkinnedEffect::SetLightingEnabled(bool value)
 {
     if (!value)
     {
-        throw std::exception("SkinnedEffect does not support turning off lighting");
+        throw std::invalid_argument("SkinnedEffect does not support turning off lighting");
     }
 }
 

--- a/Src/SkinnedEffect.cpp
+++ b/Src/SkinnedEffect.cpp
@@ -609,7 +609,7 @@ void SkinnedEffect::SetWeightsPerVertex(int value)
 void SkinnedEffect::SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count)
 {
     if (count > MaxBones)
-        throw std::out_of_range("count parameter out of range");
+        throw std::invalid_argument("count parameter exceeds MaxBones");
 
     auto boneConstant = pImpl->constants.bones;
 

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -393,7 +393,7 @@ void XM_CALLCONV SpriteBatch::Impl::Begin(SpriteSortMode sortMode,
     FXMMATRIX transformMatrix)
 {
     if (mInBeginEndPair)
-        throw std::runtime_error("Cannot nest Begin calls on a single SpriteBatch");
+        throw std::logic_error("Cannot nest Begin calls on a single SpriteBatch");
 
     mSortMode = sortMode;
     mBlendState = blendState;
@@ -407,7 +407,7 @@ void XM_CALLCONV SpriteBatch::Impl::Begin(SpriteSortMode sortMode,
     {
         // If we are in immediate mode, set device state ready for drawing.
         if (mContextResources->inImmediateMode)
-            throw std::runtime_error("Only one SpriteBatch at a time can use SpriteSortMode_Immediate");
+            throw std::logic_error("Only one SpriteBatch at a time can use SpriteSortMode_Immediate");
 
         PrepareForRendering();
 
@@ -422,7 +422,7 @@ void XM_CALLCONV SpriteBatch::Impl::Begin(SpriteSortMode sortMode,
 void SpriteBatch::Impl::End()
 {
     if (!mInBeginEndPair)
-        throw std::runtime_error("Begin must be called before End");
+        throw std::logic_error("Begin must be called before End");
 
     if (mSortMode == SpriteSortMode_Immediate)
     {
@@ -433,7 +433,7 @@ void SpriteBatch::Impl::End()
     {
         // Draw the queued sprites now.
         if (mContextResources->inImmediateMode)
-            throw std::runtime_error("Cannot end one SpriteBatch while another is using SpriteSortMode_Immediate");
+            throw std::logic_error("Cannot end one SpriteBatch while another is using SpriteSortMode_Immediate");
 
         PrepareForRendering();
         FlushBatch();
@@ -460,7 +460,7 @@ void XM_CALLCONV SpriteBatch::Impl::Draw(ID3D11ShaderResourceView* texture,
         throw std::invalid_argument("Texture cannot be null");
 
     if (!mInBeginEndPair)
-        throw std::runtime_error("Begin must be called before Draw");
+        throw std::logic_error("Begin must be called before Draw");
 
     // Get a pointer to the output sprite.
     if (mSpriteQueueCount >= mSpriteQueueArraySize)
@@ -934,7 +934,7 @@ XMVECTOR SpriteBatch::Impl::GetTextureSize(_In_ ID3D11ShaderResourceView* textur
     
     if (FAILED(resource.As(&texture2D)))
     {
-        throw std::runtime_error("SpriteBatch can only draw Texture2D resources");
+        throw std::invalid_argument("SpriteBatch can only draw Texture2D resources");
     }
 
     // Query the texture size.

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -393,7 +393,7 @@ void XM_CALLCONV SpriteBatch::Impl::Begin(SpriteSortMode sortMode,
     FXMMATRIX transformMatrix)
 {
     if (mInBeginEndPair)
-        throw std::exception("Cannot nest Begin calls on a single SpriteBatch");
+        throw std::runtime_error("Cannot nest Begin calls on a single SpriteBatch");
 
     mSortMode = sortMode;
     mBlendState = blendState;
@@ -407,7 +407,7 @@ void XM_CALLCONV SpriteBatch::Impl::Begin(SpriteSortMode sortMode,
     {
         // If we are in immediate mode, set device state ready for drawing.
         if (mContextResources->inImmediateMode)
-            throw std::exception("Only one SpriteBatch at a time can use SpriteSortMode_Immediate");
+            throw std::runtime_error("Only one SpriteBatch at a time can use SpriteSortMode_Immediate");
 
         PrepareForRendering();
 
@@ -422,7 +422,7 @@ void XM_CALLCONV SpriteBatch::Impl::Begin(SpriteSortMode sortMode,
 void SpriteBatch::Impl::End()
 {
     if (!mInBeginEndPair)
-        throw std::exception("Begin must be called before End");
+        throw std::runtime_error("Begin must be called before End");
 
     if (mSortMode == SpriteSortMode_Immediate)
     {
@@ -433,7 +433,7 @@ void SpriteBatch::Impl::End()
     {
         // Draw the queued sprites now.
         if (mContextResources->inImmediateMode)
-            throw std::exception("Cannot end one SpriteBatch while another is using SpriteSortMode_Immediate");
+            throw std::runtime_error("Cannot end one SpriteBatch while another is using SpriteSortMode_Immediate");
 
         PrepareForRendering();
         FlushBatch();
@@ -457,10 +457,10 @@ void XM_CALLCONV SpriteBatch::Impl::Draw(ID3D11ShaderResourceView* texture,
     unsigned int flags)
 {
     if (!texture)
-        throw std::exception("Texture cannot be null");
+        throw std::invalid_argument("Texture cannot be null");
 
     if (!mInBeginEndPair)
-        throw std::exception("Begin must be called before Draw");
+        throw std::runtime_error("Begin must be called before Draw");
 
     // Get a pointer to the output sprite.
     if (mSpriteQueueCount >= mSpriteQueueArraySize)
@@ -934,7 +934,7 @@ XMVECTOR SpriteBatch::Impl::GetTextureSize(_In_ ID3D11ShaderResourceView* textur
     
     if (FAILED(resource.As(&texture2D)))
     {
-        throw std::exception("SpriteBatch can only draw Texture2D resources");
+        throw std::runtime_error("SpriteBatch can only draw Texture2D resources");
     }
 
     // Query the texture size.
@@ -961,7 +961,7 @@ XMMATRIX SpriteBatch::Impl::GetViewportTransform(_In_ ID3D11DeviceContext* devic
         deviceContext->RSGetViewports(&viewportCount, &mViewPort);
 
         if (viewportCount != 1)
-            throw std::exception("No viewport is set");
+            throw std::runtime_error("No viewport is set");
     }
 
     // Compute the matrix.

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -356,7 +356,7 @@ const wchar_t* SpriteFont::Impl::ConvertUTF8(_In_z_ const char *text) noexcept(f
     if (!result)
     {
         DebugTrace("ERROR: MultiByteToWideChar failed with error %u.\n", GetLastError());
-        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "MultiByteToWideChar");
+        throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "MultiByteToWideChar");
     }
 
     return utfBuffer.get();

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -103,7 +103,7 @@ SpriteFont::Impl::Impl(
         if (reader->Read<uint8_t>() != *magic)
         {
             DebugTrace("ERROR: SpriteFont provided with an invalid .spritefont file\n");
-            throw std::exception("Not a MakeSpriteFont output binary");
+            throw std::runtime_error("Not a MakeSpriteFont output binary");
         }
     }
 
@@ -170,7 +170,7 @@ SpriteFont::Impl::Impl(
 {
     if (!std::is_sorted(iglyphs, iglyphs + glyphCount))
     {
-        throw std::exception("Glyphs must be in ascending codepoint order");
+        throw std::runtime_error("Glyphs must be in ascending codepoint order");
     }
 
     glyphsIndex.reserve(glyphs.size());
@@ -226,7 +226,7 @@ SpriteFont::Glyph const* SpriteFont::Impl::FindGlyph(wchar_t character) const
     }
 
     DebugTrace("ERROR: SpriteFont encountered a character not in the font (%u, %C), and no default glyph was provided\n", character, character);
-    throw std::exception("Character not in font");
+    throw std::runtime_error("Character not in font");
 }
 
 
@@ -356,7 +356,7 @@ const wchar_t* SpriteFont::Impl::ConvertUTF8(_In_z_ const char *text) noexcept(f
     if (!result)
     {
         DebugTrace("ERROR: MultiByteToWideChar failed with error %u.\n", GetLastError());
-        throw std::exception("MultiByteToWideChar");
+        throw std::system_error(std::error_code(GetLastError(), std::system_category()), "MultiByteToWideChar");
     }
 
     return utfBuffer.get();

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -391,7 +391,7 @@ void ToneMapPostProcess::Process(
 void ToneMapPostProcess::SetOperator(Operator op)
 {
     if (op >= Operator_Max)
-        throw std::out_of_range("Tonemap operator not defined");
+        throw std::invalid_argument("Tonemap operator not defined");
 
     pImpl->op = op;
 }
@@ -400,7 +400,7 @@ void ToneMapPostProcess::SetOperator(Operator op)
 void ToneMapPostProcess::SetTransferFunction(TransferFunction func)
 {
     if (func >= TransferFunction_Max)
-        throw std::out_of_range("Electro-optical transfer function not defined");
+        throw std::invalid_argument("Electro-optical transfer function not defined");
 
     pImpl->func = func;
 }

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -263,7 +263,7 @@ ToneMapPostProcess::Impl::Impl(_In_ ID3D11Device* device)
 {
     if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
     {
-        throw std::exception("ToneMapPostProcess requires Feature Level 10.0 or later");
+        throw std::runtime_error("ToneMapPostProcess requires Feature Level 10.0 or later");
     }
 
     SetDebugObjectName(mConstantBuffer.GetBuffer(), "ToneMapPostProcess");

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -122,6 +122,7 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <type_traits>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
The ctor for ``std::exception`` that takes a 'what' string is a MSVC extension. This PR updates the code to use derived classes for improved portability.

* ``std::invalid_arguments`` for E_INVALIDARG-like exceptions
* ``std::system_error`` for Win32 APIs that report via GetLastError()
* ``std::logic_error`` for usage problems like missing proper Begin()/End()
* ``std::out_of_range`` in a few specific places
* ``std::runtime_error`` otherwise
