### PR TITLE
ToneMapPostProcess updated with color rotation transform control

### DIFF
--- a/Inc/PostProcess.h
+++ b/Inc/PostProcess.h
@@ -172,9 +172,9 @@ namespace DirectX
         // Color Rotation Transform for HDR10
         enum ColorPrimaryRotation : unsigned int
         {
-            Default,            // Rec.709 to Rec.2020
-            DCI_P3,             // DCI-P3 to Rec.2020
-            DisplayP3,          // Rec.709 to Display-P3
+            RGB_HD,             // Rec.709 to Rec.2020 (the default)
+            DCI_P3_D65,         // DCI-P3-D65 (a.k.a Display-P3) to Rec.2020
+            DisplayP3Output,    // Rec.709 to DCI-P3-D65 (a.k.a Display-P3)
         };
 
         explicit ToneMapPostProcess(_In_ ID3D11Device* device);

--- a/Inc/PostProcess.h
+++ b/Inc/PostProcess.h
@@ -172,9 +172,9 @@ namespace DirectX
         // Color Rotation Transform for HDR10
         enum ColorPrimaryRotation : unsigned int
         {
-            RGB_HD,             // Rec.709 to Rec.2020 (the default)
-            DCI_P3_D65,         // DCI-P3-D65 (a.k.a Display-P3) to Rec.2020
-            DisplayP3Output,    // Rec.709 to DCI-P3-D65 (a.k.a Display-P3)
+            HDTV_to_UHDTV,       // Rec.709 to Rec.2020
+            DCI_P3_D65_to_UHDTV, // DCI-P3-D65 (a.k.a Display P3 or P3D65) to Rec.2020
+            HDTV_to_DCI_P3_D65,  // Rec.709 to DCI-P3-D65 (a.k.a Display P3 or P3D65)
         };
 
         explicit ToneMapPostProcess(_In_ ID3D11Device* device);

--- a/Inc/PostProcess.h
+++ b/Inc/PostProcess.h
@@ -169,6 +169,14 @@ namespace DirectX
             TransferFunction_Max
         };
 
+        // Color Rotation Transform for HDR10
+        enum ColorPrimaryRotation : unsigned int
+        {
+            Default,            // Rec.709 to Rec.2020
+            DCI_P3,             // DCI-P3 to Rec.2020
+            DisplayP3,          // Rec.709 to Display-P3
+        };
+
         explicit ToneMapPostProcess(_In_ ID3D11Device* device);
         ToneMapPostProcess(ToneMapPostProcess&& moveFrom) noexcept;
         ToneMapPostProcess& operator= (ToneMapPostProcess&& moveFrom) noexcept;
@@ -195,11 +203,15 @@ namespace DirectX
         // Properties
         void __cdecl SetHDRSourceTexture(_In_opt_ ID3D11ShaderResourceView* value);
 
+        // Sets the Color Rotation Transform for HDR10 signal output
+        void __cdecl SetColorRotation(ColorPrimaryRotation value);
+        void XM_CALLCONV SetColorRotation(FXMMATRIX value);
+
         // Sets exposure value for LDR tonemap operators
-        void SetExposure(float exposureValue);
+        void __cdecl SetExposure(float exposureValue);
 
         // Sets ST.2084 parameter for how bright white should be in nits
-        void SetST2084Parameter(float paperWhiteNits);
+        void __cdecl SetST2084Parameter(float paperWhiteNits);
 
     private:
         // Private implementation.

--- a/Src/Shaders/ToneMap.fx
+++ b/Src/Shaders/ToneMap.fx
@@ -9,8 +9,9 @@ sampler Sampler : register(s0);
 
 cbuffer Parameters : register(b0)
 {
-    float linearExposure : packoffset(c0.x);
-    float paperWhiteNits : packoffset(c0.y);
+    float linearExposure    : packoffset(c0.x);
+    float paperWhiteNits    : packoffset(c0.y);
+    float4x3 colorRotation  : packoffset(c1);
 };
 
 
@@ -116,7 +117,7 @@ float4 PSACESFilmic_SRGB(VSInputTx pin) : SV_Target0
 float3 HDR10(float3 color)
 {
     // Rotate from Rec.709 to Rec.2020 primaries
-    float3 rgb = mul(from709to2020, color);
+    float3 rgb = mul((float3x3)colorRotation, color);
 
     // ST.2084 spec defines max nits as 10,000 nits
     float3 normalized = rgb * paperWhiteNits / 10000.f;

--- a/Src/Shaders/ToneMap.fx
+++ b/Src/Shaders/ToneMap.fx
@@ -117,7 +117,7 @@ float4 PSACESFilmic_SRGB(VSInputTx pin) : SV_Target0
 float3 HDR10(float3 color)
 {
     // Rotate from Rec.709 to Rec.2020 primaries
-    float3 rgb = mul((float3x3)colorRotation, color);
+    float3 rgb = mul(color, (float3x3)colorRotation);
 
     // ST.2084 spec defines max nits as 10,000 nits
     float3 normalized = rgb * paperWhiteNits / 10000.f;

--- a/Src/Shaders/Utilities.fxh
+++ b/Src/Shaders/Utilities.fxh
@@ -68,15 +68,6 @@ float3 SRGBToLinearEst(float3 srgb)
 // https://en.wikipedia.org/wiki/High-dynamic-range_video#HDR10
 
 
-// Color rotation matrix to rotate Rec.709 color primaries into Rec.2020
-static const float3x3 from709to2020 =
-{
-    { 0.6274040f, 0.3292820f, 0.0433136f },
-    { 0.0690970f, 0.9195400f, 0.0113612f },
-    { 0.0163916f, 0.0880132f, 0.8955950f }
-};
-
-
 // Apply the ST.2084 curve to normalized linear values and outputs normalized non-linear values
 float3 LinearToST2084(float3 normalizedLinearValue)
 {

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -44,22 +44,24 @@ namespace
 
     static_assert((sizeof(ToneMapConstants) % 16) == 0, "CB size not padded correctly");
 
-    // Built-in color rotation matrices
-    constexpr float c_from709to2020[12] = // Rec.709 color primaries into Rec.2020
+    // HDTV to UHDTV (Rec.709 color primaries into Rec.2020)
+    constexpr float c_from709to2020[12] =
     {
           0.6274040f, 0.3292820f, 0.0433136f, 0.f,
           0.0690970f, 0.9195400f, 0.0113612f, 0.f,
           0.0163916f, 0.0880132f, 0.8955950f, 0.f,
     };
 
-    constexpr float c_fromDisplayP3to2020[12] = // DCI-P3-D65 color primaries into Rec.2020
+    // DCI-P3-D65 https://en.wikipedia.org/wiki/DCI-P3 to UHDTV (DCI-P3-D65 color primaries into Rec.2020)
+    constexpr float c_fromP3D65to2020[12] =
     {
            0.753845f,  0.198593f,  0.047562f, 0.f,
           0.0457456f,  0.941777f, 0.0124772f, 0.f,
         -0.00121055f, 0.0176041f,  0.983607f, 0.f,
     };
 
-    constexpr float c_from709toDisplayP3[12] = // Rec.709 color primaries into DCI-P3-D65
+    // HDTV to DCI-P3-D65 (a.k.a. Display P3 or P3D65)
+    constexpr float c_from709toP3D65[12] =
     {
         0.822461969f, 0.1775380f,        0.f, 0.f,
         0.033194199f, 0.9668058f,        0.f, 0.f,
@@ -289,7 +291,7 @@ ToneMapPostProcess::Impl::Impl(_In_ ID3D11Device* device)
         throw std::runtime_error("ToneMapPostProcess requires Feature Level 10.0 or later");
     }
 
-    memcpy(constants.colorRotation, c_from709to2020, sizeof(float) * 12);
+    memcpy(constants.colorRotation, c_from709to2020, std::size(c_from709to2020));
 
     SetDebugObjectName(mConstantBuffer.GetBuffer(), "ToneMapPostProcess");
 }
@@ -448,13 +450,11 @@ void ToneMapPostProcess::SetHDRSourceTexture(_In_opt_ ID3D11ShaderResourceView* 
 
 void ToneMapPostProcess::SetColorRotation(ColorPrimaryRotation value)
 {
-    constexpr size_t c_rotationSize = sizeof(float) * 12;
-
     switch (value)
     {
-    case DCI_P3_D65:        memcpy(pImpl->constants.colorRotation, c_fromDisplayP3to2020, c_rotationSize); break;
-    case DisplayP3Output:   memcpy(pImpl->constants.colorRotation, c_from709toDisplayP3, c_rotationSize); break;
-    default:                memcpy(pImpl->constants.colorRotation, c_from709to2020, c_rotationSize); break;
+    case DCI_P3_D65_to_UHDTV:   memcpy(pImpl->constants.colorRotation, c_fromP3D65to2020, std::size(c_fromP3D65to2020)); break;
+    case HDTV_to_DCI_P3_D65:    memcpy(pImpl->constants.colorRotation, c_from709toP3D65, std::size(c_from709toP3D65)); break;
+    default:                    memcpy(pImpl->constants.colorRotation, c_from709to2020, std::size(c_from709to2020)); break;
     }
 
     pImpl->SetDirtyFlag();

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -289,6 +289,8 @@ ToneMapPostProcess::Impl::Impl(_In_ ID3D11Device* device)
         throw std::runtime_error("ToneMapPostProcess requires Feature Level 10.0 or later");
     }
 
+    memcpy(constants.colorRotation, c_from709to2020, sizeof(float) * 12);
+
     SetDebugObjectName(mConstantBuffer.GetBuffer(), "ToneMapPostProcess");
 }
 

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -291,7 +291,7 @@ ToneMapPostProcess::Impl::Impl(_In_ ID3D11Device* device)
         throw std::runtime_error("ToneMapPostProcess requires Feature Level 10.0 or later");
     }
 
-    memcpy(constants.colorRotation, c_from709to2020, std::size(c_from709to2020));
+    memcpy(constants.colorRotation, c_from709to2020, sizeof(c_from709to2020));
 
     SetDebugObjectName(mConstantBuffer.GetBuffer(), "ToneMapPostProcess");
 }
@@ -452,9 +452,9 @@ void ToneMapPostProcess::SetColorRotation(ColorPrimaryRotation value)
 {
     switch (value)
     {
-    case DCI_P3_D65_to_UHDTV:   memcpy(pImpl->constants.colorRotation, c_fromP3D65to2020, std::size(c_fromP3D65to2020)); break;
-    case HDTV_to_DCI_P3_D65:    memcpy(pImpl->constants.colorRotation, c_from709toP3D65, std::size(c_from709toP3D65)); break;
-    default:                    memcpy(pImpl->constants.colorRotation, c_from709to2020, std::size(c_from709to2020)); break;
+    case DCI_P3_D65_to_UHDTV:   memcpy(pImpl->constants.colorRotation, c_fromP3D65to2020, sizeof(c_fromP3D65to2020)); break;
+    case HDTV_to_DCI_P3_D65:    memcpy(pImpl->constants.colorRotation, c_from709toP3D65, sizeof(c_from709toP3D65)); break;
+    default:                    memcpy(pImpl->constants.colorRotation, c_from709to2020, sizeof(c_from709to2020)); break;
     }
 
     pImpl->SetDirtyFlag();

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -452,9 +452,9 @@ void ToneMapPostProcess::SetColorRotation(ColorPrimaryRotation value)
 
     switch (value)
     {
-    case DCI_P3:         memcpy(&pImpl->constants.colorRotation, c_fromP3to2020, c_rotationSize); break;
-    case DisplayP3:      memcpy(&pImpl->constants.colorRotation, c_from709toDisplayP3, c_rotationSize); break;
-    default:             memcpy(&pImpl->constants.colorRotation, c_from709to2020, c_rotationSize); break;
+    case DCI_P3:         memcpy(pImpl->constants.colorRotation, c_fromP3to2020, c_rotationSize); break;
+    case DisplayP3:      memcpy(pImpl->constants.colorRotation, c_from709toDisplayP3, c_rotationSize); break;
+    default:             memcpy(pImpl->constants.colorRotation, c_from709to2020, c_rotationSize); break;
     }
 
     pImpl->SetDirtyFlag();

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -22,15 +22,15 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const constexpr int Dirty_ConstantBuffer  = 0x01;
-    const constexpr int Dirty_Parameters      = 0x02;
+    constexpr int Dirty_ConstantBuffer  = 0x01;
+    constexpr int Dirty_Parameters      = 0x02;
 
 #if defined(_XBOX_ONE) && defined(_TITLE)
-    const constexpr int PixelShaderCount = 15;
-    const constexpr int ShaderPermutationCount = 24;
+    constexpr int PixelShaderCount = 15;
+    constexpr int ShaderPermutationCount = 24;
 #else
-    const constexpr int PixelShaderCount = 9;
-    const constexpr int ShaderPermutationCount = 12;
+    constexpr int PixelShaderCount = 9;
+    constexpr int ShaderPermutationCount = 12;
 #endif
 
     // Constant buffer layout. Must match the shader!
@@ -44,7 +44,7 @@ namespace
 
     static_assert((sizeof(ToneMapConstants) % 16) == 0, "CB size not padded correctly");
 
-    // Built-in color rotation matricies (pretransposed)
+    // Built-in color rotation matrices
     constexpr float c_from709to2020[12] = // Rec.709 color primaries into Rec.2020
     {
           0.6274040f, 0.3292820f, 0.0433136f, 0.f,
@@ -52,14 +52,14 @@ namespace
           0.0163916f, 0.0880132f, 0.8955950f, 0.f,
     };
 
-    constexpr float c_fromP3to2020[12] = // DCI-P3 color primaries into Rec.2020
+    constexpr float c_fromDisplayP3to2020[12] = // DCI-P3-D65 color primaries into Rec.2020
     {
            0.753845f,  0.198593f,  0.047562f, 0.f,
           0.0457456f,  0.941777f, 0.0124772f, 0.f,
         -0.00121055f, 0.0176041f,  0.983607f, 0.f,
     };
 
-    constexpr float c_from709toDisplayP3[12] = // DCI-P3 with a D65 white point
+    constexpr float c_from709toDisplayP3[12] = // Rec.709 color primaries into DCI-P3-D65
     {
         0.822461969f, 0.1775380f,        0.f, 0.f,
         0.033194199f, 0.9668058f,        0.f, 0.f,
@@ -452,9 +452,9 @@ void ToneMapPostProcess::SetColorRotation(ColorPrimaryRotation value)
 
     switch (value)
     {
-    case DCI_P3:         memcpy(pImpl->constants.colorRotation, c_fromP3to2020, c_rotationSize); break;
-    case DisplayP3:      memcpy(pImpl->constants.colorRotation, c_from709toDisplayP3, c_rotationSize); break;
-    default:             memcpy(pImpl->constants.colorRotation, c_from709to2020, c_rotationSize); break;
+    case DCI_P3_D65:        memcpy(pImpl->constants.colorRotation, c_fromDisplayP3to2020, c_rotationSize); break;
+    case DisplayP3Output:   memcpy(pImpl->constants.colorRotation, c_from709toDisplayP3, c_rotationSize); break;
+    default:                memcpy(pImpl->constants.colorRotation, c_from709to2020, c_rotationSize); break;
     }
 
     pImpl->SetDirtyFlag();


### PR DESCRIPTION
Updated ToneMapPostProcess to allow dynamic control over the color primary rotation matrix used for HDR10 signal processing. It defaults to using the 'standard' Rec.709 to Rec.2020 color primary rotation just as before. This adds a ``SetColorRotation`` method with an overloads.