### PR TITLE
DebugEffect, NormalMapEffect, PBREffect updated with instancing support

### DIFF
--- a/DirectXTK_Desktop_2017_Win7.sln
+++ b/DirectXTK_Desktop_2017_Win7.sln
@@ -11,6 +11,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MakeSpriteFont", "MakeSprit
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "xwbtool_Desktop_2017", "XWBTool\xwbtool_Desktop_2017.vcxproj", "{C7AB4186-54B2-4244-A533-77494763EA1D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3B5CBECC-6784-4190-BFCC-A26F43DDA61A}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,16 +26,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x64.ActiveCfg = Debug|x64
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x64.Build.0 = Debug|x64
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x86.ActiveCfg = Debug|Win32
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x86.Build.0 = Debug|Win32
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|Any CPU.ActiveCfg = Release|Win32
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x64.ActiveCfg = Release|x64
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x64.Build.0 = Release|x64
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x86.ActiveCfg = Release|Win32
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x86.Build.0 = Release|Win32
 		{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}.Debug|Any CPU.ActiveCfg = Debug|Win32
 		{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}.Debug|x64.ActiveCfg = Debug|x64
 		{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}.Debug|x64.Build.0 = Debug|x64
@@ -41,6 +36,16 @@ Global
 		{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}.Release|x64.Build.0 = Release|x64
 		{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}.Release|x86.ActiveCfg = Release|Win32
 		{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}.Release|x86.Build.0 = Release|Win32
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x64.ActiveCfg = Debug|x64
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x64.Build.0 = Debug|x64
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x86.ActiveCfg = Debug|Win32
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x86.Build.0 = Debug|Win32
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|Any CPU.ActiveCfg = Release|Win32
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x64.ActiveCfg = Release|x64
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x64.Build.0 = Release|x64
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x86.ActiveCfg = Release|Win32
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x86.Build.0 = Release|Win32
 		{7329B02D-C504-482A-A156-181D48CE493C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7329B02D-C504-482A-A156-181D48CE493C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7329B02D-C504-482A-A156-181D48CE493C}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/DirectXTK_Desktop_2019_Win7.sln
+++ b/DirectXTK_Desktop_2019_Win7.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
-VisualStudioVersion = 15.0.28307.1000
+VisualStudioVersion = 16.0.31507.150
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DirectXTK_Desktop_2019", "DirectXTK_Desktop_2019.vcxproj", "{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}"
 EndProject
@@ -10,6 +10,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MakeSpriteFont", "MakeSpriteFont\MakeSpriteFont.csproj", "{7329B02D-C504-482A-A156-181D48CE493C}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "xwbtool_Desktop_2019", "XWBTool\xwbtool_Desktop_2019.vcxproj", "{C7AB4186-54B2-4244-A533-77494763EA1D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{71F16217-C381-4317-9EC0-8B5EE77ED330}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,16 +26,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x64.ActiveCfg = Debug|x64
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x64.Build.0 = Debug|x64
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x86.ActiveCfg = Debug|Win32
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x86.Build.0 = Debug|Win32
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|Any CPU.ActiveCfg = Release|Win32
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x64.ActiveCfg = Release|x64
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x64.Build.0 = Release|x64
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x86.ActiveCfg = Release|Win32
-		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x86.Build.0 = Release|Win32
 		{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}.Debug|Any CPU.ActiveCfg = Debug|Win32
 		{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}.Debug|x64.ActiveCfg = Debug|x64
 		{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}.Debug|x64.Build.0 = Debug|x64
@@ -41,6 +36,16 @@ Global
 		{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}.Release|x64.Build.0 = Release|x64
 		{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}.Release|x86.ActiveCfg = Release|Win32
 		{E0B52AE7-E160-4D32-BF3F-910B785E5A8E}.Release|x86.Build.0 = Release|Win32
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x64.ActiveCfg = Debug|x64
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x64.Build.0 = Debug|x64
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x86.ActiveCfg = Debug|Win32
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Debug|x86.Build.0 = Debug|Win32
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|Any CPU.ActiveCfg = Release|Win32
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x64.ActiveCfg = Release|x64
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x64.Build.0 = Release|x64
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x86.ActiveCfg = Release|Win32
+		{4F150A30-CECB-49D1-8283-6A3F57438CF5}.Release|x86.Build.0 = Release|Win32
 		{7329B02D-C504-482A-A156-181D48CE493C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7329B02D-C504-482A-A156-181D48CE493C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7329B02D-C504-482A-A156-181D48CE493C}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -746,6 +746,9 @@ namespace DirectX
         // Normal compression settings.
         void __cdecl SetBiasedVertexNormals(bool value);
 
+        // Instancing settings.
+        void __cdecl SetInstancingEnabled(bool value);
+
     private:
         // Private implementation.
         class Impl;

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -608,6 +608,9 @@ namespace DirectX
         // Normal compression settings.
         void __cdecl SetBiasedVertexNormals(bool value);
 
+        // Instancing settings.
+        void __cdecl SetInstancingEnabled(bool value);
+
     private:
         // Private implementation.
         class Impl;
@@ -676,6 +679,9 @@ namespace DirectX
 
         // Normal compression settings.
         void __cdecl SetBiasedVertexNormals(bool value);
+
+        // Instancing settings.
+        void __cdecl SetInstancingEnabled(bool value);
 
         // Velocity buffer settings.
         void __cdecl SetVelocityGeneration(bool value);

--- a/Inc/GeometricPrimitive.h
+++ b/Inc/GeometricPrimitive.h
@@ -77,6 +77,13 @@ namespace DirectX
             bool alpha = false, bool wireframe = false,
             _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
+        void __cdecl DrawInstanced(_In_ IEffect* effect,
+            _In_ ID3D11InputLayout* inputLayout,
+            uint32_t instanceCount,
+            bool alpha = false, bool wireframe = false,
+            uint32_t startInstanceLocation = 0,
+            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+
        // Create input layout for drawing with a custom effect.
         void __cdecl CreateInputLayout(_In_ IEffect* effect, _Outptr_ ID3D11InputLayout** inputLayout) const;
 

--- a/Src/DebugEffect.cpp
+++ b/Src/DebugEffect.cpp
@@ -61,10 +61,16 @@ namespace
 {
 #if defined(_XBOX_ONE) && defined(_TITLE)
     #include "Shaders/Compiled/XboxOneDebugEffect_VSDebug.inc"
+    #include "Shaders/Compiled/XboxOneDebugEffect_VSDebugInst.inc"
+
     #include "Shaders/Compiled/XboxOneDebugEffect_VSDebugVc.inc"
+    #include "Shaders/Compiled/XboxOneDebugEffect_VSDebugVcInst.inc"
 
     #include "Shaders/Compiled/XboxOneDebugEffect_VSDebugBn.inc"
+    #include "Shaders/Compiled/XboxOneDebugEffect_VSDebugBnInst.inc"
+
     #include "Shaders/Compiled/XboxOneDebugEffect_VSDebugVcBn.inc"
+    #include "Shaders/Compiled/XboxOneDebugEffect_VSDebugVcBnInst.inc"
 
     #include "Shaders/Compiled/XboxOneDebugEffect_PSHemiAmbient.inc"
     #include "Shaders/Compiled/XboxOneDebugEffect_PSRGBNormals.inc"

--- a/Src/NormalMapEffect.cpp
+++ b/Src/NormalMapEffect.cpp
@@ -42,9 +42,9 @@ struct NormalMapEffectTraits
 {
     using ConstantBufferType = NormalMapEffectConstants;
 
-    static constexpr int VertexShaderCount = 4;
+    static constexpr int VertexShaderCount = 8;
     static constexpr int PixelShaderCount = 4;
-    static constexpr int ShaderPermutationCount = 16;
+    static constexpr int ShaderPermutationCount = 32;
 };
 
 
@@ -59,6 +59,7 @@ public:
 
     bool vertexColorEnabled;
     bool biasedVertexNormals;
+    bool instancing;
   
     EffectLights lights;
 
@@ -73,10 +74,16 @@ namespace
 {
 #if defined(_XBOX_ONE) && defined(_TITLE)
     #include "Shaders/Compiled/XboxOneNormalMapEffect_VSNormalPixelLightingTx.inc"
+    #include "Shaders/Compiled/XboxOneNormalMapEffect_VSNormalPixelLightingTxInst.inc"
+
     #include "Shaders/Compiled/XboxOneNormalMapEffect_VSNormalPixelLightingTxVc.inc"
+    #include "Shaders/Compiled/XboxOneNormalMapEffect_VSNormalPixelLightingTxVcInst.inc"
 
     #include "Shaders/Compiled/XboxOneNormalMapEffect_VSNormalPixelLightingTxBn.inc"
+    #include "Shaders/Compiled/XboxOneNormalMapEffect_VSNormalPixelLightingTxBnInst.inc"
+
     #include "Shaders/Compiled/XboxOneNormalMapEffect_VSNormalPixelLightingTxVcBn.inc"
+    #include "Shaders/Compiled/XboxOneNormalMapEffect_VSNormalPixelLightingTxVcBnInst.inc"
 
     #include "Shaders/Compiled/XboxOneNormalMapEffect_PSNormalPixelLightingTx.inc"
     #include "Shaders/Compiled/XboxOneNormalMapEffect_PSNormalPixelLightingTxNoFog.inc"
@@ -84,10 +91,16 @@ namespace
     #include "Shaders/Compiled/XboxOneNormalMapEffect_PSNormalPixelLightingTxNoFogSpec.inc"
 #else    
     #include "Shaders/Compiled/NormalMapEffect_VSNormalPixelLightingTx.inc"
+    #include "Shaders/Compiled/NormalMapEffect_VSNormalPixelLightingTxInst.inc"
+
     #include "Shaders/Compiled/NormalMapEffect_VSNormalPixelLightingTxVc.inc"
+    #include "Shaders/Compiled/NormalMapEffect_VSNormalPixelLightingTxVcInst.inc"
 
     #include "Shaders/Compiled/NormalMapEffect_VSNormalPixelLightingTxBn.inc"
+    #include "Shaders/Compiled/NormalMapEffect_VSNormalPixelLightingTxBnInst.inc"
+
     #include "Shaders/Compiled/NormalMapEffect_VSNormalPixelLightingTxVcBn.inc"
+    #include "Shaders/Compiled/NormalMapEffect_VSNormalPixelLightingTxVcBnInst.inc"
 
     #include "Shaders/Compiled/NormalMapEffect_PSNormalPixelLightingTx.inc"
     #include "Shaders/Compiled/NormalMapEffect_PSNormalPixelLightingTxNoFog.inc"
@@ -100,11 +113,17 @@ namespace
 template<>
 const ShaderBytecode EffectBase<NormalMapEffectTraits>::VertexShaderBytecode[] =
 {    
-    { NormalMapEffect_VSNormalPixelLightingTx,     sizeof(NormalMapEffect_VSNormalPixelLightingTx)     },
-    { NormalMapEffect_VSNormalPixelLightingTxVc,   sizeof(NormalMapEffect_VSNormalPixelLightingTxVc)   },
+    { NormalMapEffect_VSNormalPixelLightingTx,         sizeof(NormalMapEffect_VSNormalPixelLightingTx)         },
+    { NormalMapEffect_VSNormalPixelLightingTxVc,       sizeof(NormalMapEffect_VSNormalPixelLightingTxVc)       },
 
-    { NormalMapEffect_VSNormalPixelLightingTxBn,   sizeof(NormalMapEffect_VSNormalPixelLightingTxBn)   },
-    { NormalMapEffect_VSNormalPixelLightingTxVcBn, sizeof(NormalMapEffect_VSNormalPixelLightingTxVcBn) },
+    { NormalMapEffect_VSNormalPixelLightingTxBn,       sizeof(NormalMapEffect_VSNormalPixelLightingTxBn)       },
+    { NormalMapEffect_VSNormalPixelLightingTxVcBn,     sizeof(NormalMapEffect_VSNormalPixelLightingTxVcBn)     },
+
+    { NormalMapEffect_VSNormalPixelLightingTxInst,     sizeof(NormalMapEffect_VSNormalPixelLightingTxInst)     },
+    { NormalMapEffect_VSNormalPixelLightingTxVcInst,   sizeof(NormalMapEffect_VSNormalPixelLightingTxVcInst)   },
+
+    { NormalMapEffect_VSNormalPixelLightingTxBnInst,   sizeof(NormalMapEffect_VSNormalPixelLightingTxBnInst)   },
+    { NormalMapEffect_VSNormalPixelLightingTxVcBnInst, sizeof(NormalMapEffect_VSNormalPixelLightingTxVcBnInst) },
 };
 
 
@@ -130,6 +149,26 @@ const int EffectBase<NormalMapEffectTraits>::VertexShaderIndices[] =
     2,      // pixel lighting (biased vertex normal) + texture, no fog or specular
     3,      // pixel lighting (biased vertex normal) + texture + vertex color, no specular
     3,      // pixel lighting (biased vertex normal) + texture + vertex color, no fog or specular
+
+    4,      // instancing + pixel lighting + texture
+    4,      // instancing + pixel lighting + texture, no fog
+    5,      // instancing + pixel lighting + texture + vertex color
+    5,      // instancing + pixel lighting + texture + vertex color, no fog
+
+    4,      // instancing + pixel lighting + texture, no specular
+    4,      // instancing + pixel lighting + texture, no fog or specular
+    5,      // instancing + pixel lighting + texture + vertex color, no specular
+    5,      // instancing + pixel lighting + texture + vertex color, no fog or specular
+
+    6,      // instancing + pixel lighting (biased vertex normal) + texture
+    6,      // instancing + pixel lighting (biased vertex normal) + texture, no fog
+    7,      // instancing + pixel lighting (biased vertex normal) + texture + vertex color
+    7,      // instancing + pixel lighting (biased vertex normal) + texture + vertex color, no fog
+
+    6,      // instancing + pixel lighting (biased vertex normal) + texture, no specular
+    6,      // instancing + pixel lighting (biased vertex normal) + texture, no fog or specular
+    7,      // instancing + pixel lighting (biased vertex normal) + texture + vertex color, no specular
+    7,      // instancing + pixel lighting (biased vertex normal) + texture + vertex color, no fog or specular
 };
 
 
@@ -165,6 +204,26 @@ const int EffectBase<NormalMapEffectTraits>::PixelShaderIndices[] =
     3,      // pixel lighting (biased vertex normal) + texture, no fog or specular
     2,      // pixel lighting (biased vertex normal) + texture + vertex color, no specular
     3,      // pixel lighting (biased vertex normal) + texture + vertex color, no fog or specular
+
+    0,      // instancing + pixel lighting + texture
+    1,      // instancing + pixel lighting + texture, no fog
+    0,      // instancing + pixel lighting + texture + vertex color
+    1,      // instancing + pixel lighting + texture + vertex color, no fog
+
+    2,      // instancing + pixel lighting + texture, no specular
+    3,      // instancing + pixel lighting + texture, no fog or specular
+    2,      // instancing + pixel lighting + texture + vertex color, no specular
+    3,      // instancing + pixel lighting + texture + vertex color, no fog or specular
+
+    0,      // instancing + pixel lighting (biased vertex normal) + texture
+    1,      // instancing + pixel lighting (biased vertex normal) + texture, no fog
+    0,      // instancing + pixel lighting (biased vertex normal) + texture + vertex color
+    1,      // instancing + pixel lighting (biased vertex normal) + texture + vertex color, no fog
+
+    2,      // instancing + pixel lighting (biased vertex normal) + texture, no specular
+    3,      // instancing + pixel lighting (biased vertex normal) + texture, no fog or specular
+    2,      // instancing + pixel lighting (biased vertex normal) + texture + vertex color, no specular
+    3,      // instancing + pixel lighting (biased vertex normal) + texture + vertex color, no fog or specular
 };
 
 
@@ -177,7 +236,8 @@ SharedResourcePool<ID3D11Device*, EffectBase<NormalMapEffectTraits>::DeviceResou
 NormalMapEffect::Impl::Impl(_In_ ID3D11Device* device)
     : EffectBase(device),
     vertexColorEnabled(false),
-    biasedVertexNormals(false)
+    biasedVertexNormals(false),
+    instancing(false)
 {
     if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
     {
@@ -219,6 +279,12 @@ int NormalMapEffect::Impl::GetCurrentShaderPermutation() const noexcept
     {
         // Compressed normals need to be scaled and biased in the vertex shader.
         permutation += 8;
+    }
+
+    if (instancing)
+    {
+        // Vertex shader needs to use vertex matrix transform.
+        permutation += 16;
     }
 
     return permutation;
@@ -504,4 +570,11 @@ void NormalMapEffect::SetSpecularTexture(_In_opt_ ID3D11ShaderResourceView* valu
 void NormalMapEffect::SetBiasedVertexNormals(bool value)
 {
     pImpl->biasedVertexNormals = value;
+}
+
+
+// Instancing settings.
+void NormalMapEffect::SetInstancingEnabled(bool value)
+{
+    pImpl->instancing = value;
 }

--- a/Src/Shaders/CompileShaders.cmd
+++ b/Src/Shaders/CompileShaders.cmd
@@ -170,14 +170,21 @@ call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxBn
 call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxVc
 call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxVcBn
 
+call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxInst
+call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxBnInst
+call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxVcInst
+call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxVcBnInst
+
 call :CompileShaderSM4%1 NormalMapEffect ps PSNormalPixelLightingTx
 call :CompileShaderSM4%1 NormalMapEffect ps PSNormalPixelLightingTxNoFog
 call :CompileShaderSM4%1 NormalMapEffect ps PSNormalPixelLightingTxNoSpec
 call :CompileShaderSM4%1 NormalMapEffect ps PSNormalPixelLightingTxNoFogSpec
 
 call :CompileShaderSM4%1 PBREffect vs VSConstant
+call :CompileShaderSM4%1 PBREffect vs VSConstantInst
 call :CompileShaderSM4%1 PBREffect vs VSConstantVelocity
 call :CompileShaderSM4%1 PBREffect vs VSConstantBn
+call :CompileShaderSM4%1 PBREffect vs VSConstantBnInst
 call :CompileShaderSM4%1 PBREffect vs VSConstantVelocityBn
 
 call :CompileShaderSM4%1 PBREffect ps PSConstant

--- a/Src/Shaders/CompileShaders.cmd
+++ b/Src/Shaders/CompileShaders.cmd
@@ -198,6 +198,11 @@ call :CompileShaderSM4%1 DebugEffect vs VSDebugBn
 call :CompileShaderSM4%1 DebugEffect vs VSDebugVc
 call :CompileShaderSM4%1 DebugEffect vs VSDebugVcBn
 
+call :CompileShaderSM4%1 DebugEffect vs VSDebugInst
+call :CompileShaderSM4%1 DebugEffect vs VSDebugBnInst
+call :CompileShaderSM4%1 DebugEffect vs VSDebugVcInst
+call :CompileShaderSM4%1 DebugEffect vs VSDebugVcBnInst
+
 call :CompileShaderSM4%1 DebugEffect ps PSHemiAmbient
 call :CompileShaderSM4%1 DebugEffect ps PSRGBNormals
 call :CompileShaderSM4%1 DebugEffect ps PSRGBTangents

--- a/Src/Shaders/DebugEffect.fx
+++ b/Src/Shaders/DebugEffect.fx
@@ -82,6 +82,76 @@ VSOutputPixelLightingTx VSDebugVcBn(VSInputNmTxVc vin)
 }
 
 
+// Vertex shader: instancing
+VSOutputPixelLightingTx VSDebugInst(VSInputNmTxInst vin)
+{
+    VSOutputPixelLightingTx vout;
+
+    CommonInstancing inst = ComputeCommonInstancing(vin.Position, vin.Normal, vin.Transform);
+
+    vout.PositionPS = mul(inst.Position, WorldViewProj);
+    vout.PositionWS = float4(mul(inst.Position, World).xyz, 1);
+    vout.NormalWS = normalize(mul(inst.Normal, WorldInverseTranspose));
+    vout.Diffuse = float4(1, 1, 1, Alpha);
+    vout.TexCoord = vin.TexCoord;
+
+    return vout;
+}
+
+VSOutputPixelLightingTx VSDebugBnInst(VSInputNmTxInst vin)
+{
+    VSOutputPixelLightingTx vout;
+
+    float3 normal = BiasX2(vin.Normal);
+
+    CommonInstancing inst = ComputeCommonInstancing(vin.Position, normal, vin.Transform);
+
+    vout.PositionPS = mul(inst.Position, WorldViewProj);
+    vout.PositionWS = float4(mul(inst.Position, World).xyz, 1);
+    vout.NormalWS = normalize(mul(inst.Normal, WorldInverseTranspose));
+    vout.Diffuse = float4(1, 1, 1, Alpha);
+    vout.TexCoord = vin.TexCoord;
+
+    return vout;
+}
+
+
+// Vertex shader: vertex color + instancing
+VSOutputPixelLightingTx VSDebugVcInst(VSInputNmTxVcInst vin)
+{
+    VSOutputPixelLightingTx vout;
+
+    CommonInstancing inst = ComputeCommonInstancing(vin.Position, vin.Normal, vin.Transform);
+
+    vout.PositionPS = mul(inst.Position, WorldViewProj);
+    vout.PositionWS = float4(mul(inst.Position, World).xyz, 1);
+    vout.NormalWS = normalize(mul(inst.Normal, WorldInverseTranspose));
+    vout.Diffuse.rgb = vin.Color.rgb;
+    vout.Diffuse.a = vin.Color.a * Alpha;
+    vout.TexCoord = vin.TexCoord;
+
+    return vout;
+}
+
+VSOutputPixelLightingTx VSDebugVcBnInst(VSInputNmTxVcInst vin)
+{
+    VSOutputPixelLightingTx vout;
+
+    float3 normal = BiasX2(vin.Normal);
+
+    CommonInstancing inst = ComputeCommonInstancing(vin.Position, normal, vin.Transform);
+
+    vout.PositionPS = mul(inst.Position, WorldViewProj);
+    vout.PositionWS = float4(mul(inst.Position, World).xyz, 1);
+    vout.NormalWS = normalize(mul(inst.Normal, WorldInverseTranspose));
+    vout.Diffuse.rgb = vin.Color.rgb;
+    vout.Diffuse.a = vin.Color.a * Alpha;
+    vout.TexCoord = vin.TexCoord;
+
+    return vout;
+}
+
+
 // Pixel shader: default
 float3 CalcHemiAmbient(float3 normal, float3 color)
 {

--- a/Src/Shaders/NormalMapEffect.fx
+++ b/Src/Shaders/NormalMapEffect.fx
@@ -99,6 +99,77 @@ VSOutputPixelLightingTx VSNormalPixelLightingTxVcBn(VSInputNmTxVc vin)
     return vout;
 }
 
+
+// Vertex shader: pixel lighting + texture + instancing.
+VSOutputPixelLightingTx VSNormalPixelLightingTxInst(VSInputNmTxInst vin)
+{
+    VSOutputPixelLightingTx vout;
+
+    CommonInstancing inst = ComputeCommonInstancing(vin.Position, vin.Normal, vin.Transform);
+
+    CommonVSOutputPixelLighting cout = ComputeCommonVSOutputPixelLighting(inst.Position, inst.Normal);
+    SetCommonVSOutputParamsPixelLighting;
+
+    vout.Diffuse = float4(1, 1, 1, DiffuseColor.a);
+    vout.TexCoord = vin.TexCoord;
+
+    return vout;
+}
+
+VSOutputPixelLightingTx VSNormalPixelLightingTxBnInst(VSInputNmTxInst vin)
+{
+    VSOutputPixelLightingTx vout;
+
+    float3 normal = BiasX2(vin.Normal);
+
+    CommonInstancing inst = ComputeCommonInstancing(vin.Position, normal, vin.Transform);
+
+    CommonVSOutputPixelLighting cout = ComputeCommonVSOutputPixelLighting(inst.Position, inst.Normal);
+    SetCommonVSOutputParamsPixelLighting;
+
+    vout.Diffuse = float4(1, 1, 1, DiffuseColor.a);
+    vout.TexCoord = vin.TexCoord;
+
+    return vout;
+}
+
+
+// Vertex shader: pixel lighting + texture + vertex color + instancing.
+VSOutputPixelLightingTx VSNormalPixelLightingTxVcInst(VSInputNmTxVcInst vin)
+{
+    VSOutputPixelLightingTx vout;
+
+    CommonInstancing inst = ComputeCommonInstancing(vin.Position, vin.Normal, vin.Transform);
+
+    CommonVSOutputPixelLighting cout = ComputeCommonVSOutputPixelLighting(inst.Position, inst.Normal);
+    SetCommonVSOutputParamsPixelLighting;
+
+    vout.Diffuse.rgb = vin.Color.rgb;
+    vout.Diffuse.a = vin.Color.a * DiffuseColor.a;
+    vout.TexCoord = vin.TexCoord;
+
+    return vout;
+}
+
+VSOutputPixelLightingTx VSNormalPixelLightingTxVcBnInst(VSInputNmTxVcInst vin)
+{
+    VSOutputPixelLightingTx vout;
+
+    float3 normal = BiasX2(vin.Normal);
+
+    CommonInstancing inst = ComputeCommonInstancing(vin.Position, normal, vin.Transform);
+
+    CommonVSOutputPixelLighting cout = ComputeCommonVSOutputPixelLighting(inst.Position, inst.Normal);
+    SetCommonVSOutputParamsPixelLighting;
+
+    vout.Diffuse.rgb = vin.Color.rgb;
+    vout.Diffuse.a = vin.Color.a * DiffuseColor.a;
+    vout.TexCoord = vin.TexCoord;
+
+    return vout;
+}
+
+
 // Pixel shader: pixel lighting + texture + no fog
 float4 PSNormalPixelLightingTxNoFog(PSInputPixelLightingTx pin) : SV_Target0
 {
@@ -121,6 +192,7 @@ float4 PSNormalPixelLightingTxNoFog(PSInputPixelLightingTx pin) : SV_Target0
 
     return color;
 }
+
 
 // Pixel shader: pixel lighting + texture
 float4 PSNormalPixelLightingTx(PSInputPixelLightingTx pin) : SV_Target0
@@ -168,6 +240,7 @@ float4 PSNormalPixelLightingTxNoFogSpec(PSInputPixelLightingTx pin) : SV_Target0
 
     return color;
 }
+
 
 // Pixel shader: pixel lighting + texture + no specular
 float4 PSNormalPixelLightingTxNoSpec(PSInputPixelLightingTx pin) : SV_Target0

--- a/Src/Shaders/PBREffect.fx
+++ b/Src/Shaders/PBREffect.fx
@@ -62,6 +62,25 @@ VSOutputPixelLightingTx VSConstant(VSInputNmTx vin)
 }
 
 
+// Vertex shader: pbr + instancing
+VSOutputPixelLightingTx VSConstantInst(VSInputNmTxInst vin)
+{
+    VSOutputPixelLightingTx vout;
+
+    CommonInstancing inst = ComputeCommonInstancing(vin.Position, vin.Normal, vin.Transform);
+
+    CommonVSOutputPixelLighting cout = ComputeCommonVSOutputPixelLighting(inst.Position, inst.Normal);
+
+    vout.PositionPS = cout.Pos_ps;
+    vout.PositionWS = float4(cout.Pos_ws, 1);
+    vout.NormalWS = cout.Normal_ws;
+    vout.Diffuse = float4(ConstantAlbedo, Alpha);
+    vout.TexCoord = vin.TexCoord;
+
+    return vout;
+}
+
+
 // Vertex shader: pbr + velocity
 VSOut_Velocity VSConstantVelocity(VSInputNmTx vin)
 {
@@ -88,6 +107,27 @@ VSOutputPixelLightingTx VSConstantBn(VSInputNmTx vin)
     float3 normal = BiasX2(vin.Normal);
 
     CommonVSOutputPixelLighting cout = ComputeCommonVSOutputPixelLighting(vin.Position, normal);
+
+    vout.PositionPS = cout.Pos_ps;
+    vout.PositionWS = float4(cout.Pos_ws, 1);
+    vout.NormalWS = cout.Normal_ws;
+    vout.Diffuse = float4(ConstantAlbedo, Alpha);
+    vout.TexCoord = vin.TexCoord;
+
+    return vout;
+}
+
+
+// Vertex shader: pbr + instancing (biased normal)
+VSOutputPixelLightingTx VSConstantBnInst(VSInputNmTxInst vin)
+{
+    VSOutputPixelLightingTx vout;
+
+    float3 normal = BiasX2(vin.Normal);
+
+    CommonInstancing inst = ComputeCommonInstancing(vin.Position, normal, vin.Transform);
+
+    CommonVSOutputPixelLighting cout = ComputeCommonVSOutputPixelLighting(inst.Position, inst.Normal);
 
     vout.PositionPS = cout.Pos_ps;
     vout.PositionWS = float4(cout.Pos_ws, 1);

--- a/Src/Shaders/Structures.fxh
+++ b/Src/Shaders/Structures.fxh
@@ -61,6 +61,23 @@ struct VSInputNmTxVc
     float4 Color    : COLOR;
 };
 
+struct VSInputNmTxInst
+{
+    float4 Position    : SV_Position;
+    float3 Normal      : NORMAL;
+    float2 TexCoord    : TEXCOORD0;
+    float4x3 Transform : InstMatrix;
+};
+
+struct VSInputNmTxVcInst
+{
+    float4 Position    : SV_Position;
+    float3 Normal      : NORMAL;
+    float2 TexCoord    : TEXCOORD0;
+    float4 Color       : COLOR;
+    float4x3 Transform : InstMatrix;
+};
+
 struct VSInputTx2
 {
     float4 Position  : SV_Position;

--- a/Src/Shaders/Utilities.fxh
+++ b/Src/Shaders/Utilities.fxh
@@ -102,3 +102,22 @@ float3 ToneMapACESFilmic(float3 x)
     float e = 0.14f;
     return saturate((x*(a*x+b))/(x*(c*x+d)+e));
 }
+
+
+// Instancing
+struct CommonInstancing
+{
+    float4 Position;
+    float3 Normal;
+};
+
+
+CommonInstancing ComputeCommonInstancing(float4 position, float3 normal, float4x3 itransform)
+{
+    CommonInstancing vout;
+
+    vout.Position = float4(mul(position, itransform), position.w);
+    vout.Normal = mul(normal, (float3x3)itransform);
+
+    return vout;
+}


### PR DESCRIPTION
* DebugEffect, NormalMapEffect, PBREffect updated to support instancing using a XMFLOAT3X4 transform in the vertex data.

* Added DrawInstanced method to GeometricPrimitive

> These effects all require Direct3D Feature Level 10.0 or better as they build with Shader Model 4.0, and all such devices support hardware instancing.