### PR TITLE
Adding ModelBone support for transform hierarchies

### DIFF
--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -49,8 +49,6 @@ namespace DirectX
         ModelLoader_MaterialColorsSRGB  = 0x4,
         ModelLoader_AllowLargeModels    = 0x8,
         ModelLoader_IncludeBones        = 0x10,
-        ModelLoader_IncludeInfluences   = 0x20,
-        ModelLoader_IncludeSkeleton     = 0x30,
     };
 
     //----------------------------------------------------------------------------------

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -48,7 +48,7 @@ namespace DirectX
         ModelLoader_PremultipledAlpha   = 0x2,
         ModelLoader_MaterialColorsSRGB  = 0x4,
         ModelLoader_AllowLargeModels    = 0x8,
-        ModelLoader_IncludeFrames       = 0x10,
+        ModelLoader_IncludeBones        = 0x10,
         ModelLoader_IncludeInfluences   = 0x20,
         ModelLoader_IncludeSkeleton     = 0x30,
     };
@@ -247,7 +247,7 @@ namespace DirectX
         // Compute bone positions based on heirarchy using boneMatrices
         void XM_CALLCONV CopyAbsoluteBoneTransformsTo(size_t nbones, _Out_writes_(nbones) XMMATRIX* boneTransforms);
 
-        // Set bone matrices to a new set of local tansforms
+        // Set bone matrices to a set of local tansforms
         void CopyBoneTransformsFrom(size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms);
 
         // Notify model that effects, parts list, or mesh list has changed

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -214,6 +214,7 @@ namespace DirectX
         ModelMesh::Collection       meshes;
         ModelBone::Collection       bones;
         ModelBone::TransformArray   boneMatrices;
+        ModelBone::TransformArray   invBindPoseMatrices;
         std::wstring                name;
 
         // Draw all the meshes in the model
@@ -273,12 +274,14 @@ namespace DirectX
             _In_ ID3D11Device* device,
             _In_reads_bytes_(dataSize) const uint8_t* meshData, size_t dataSize,
             _In_ IEffectFactory& fxFactory,
-            ModelLoaderFlags flags = ModelLoader_CounterClockwise);
+            ModelLoaderFlags flags = ModelLoader_CounterClockwise,
+            _Out_opt_ size_t* clipsOffset = nullptr);
         static std::unique_ptr<Model> __cdecl CreateFromCMO(
             _In_ ID3D11Device* device,
             _In_z_ const wchar_t* szFileName,
             _In_ IEffectFactory& fxFactory,
-            ModelLoaderFlags flags = ModelLoader_CounterClockwise);
+            ModelLoaderFlags flags = ModelLoader_CounterClockwise,
+            _Out_opt_ size_t* clipsOffset = nullptr);
 
         // Loads a model from a DirectX SDK .SDKMESH file
         static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -173,10 +173,11 @@ namespace DirectX
             bool alpha = false,
             _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
+        // Draw the mesh using skinning
         void XM_CALLCONV DrawSkinned(
             _In_ ID3D11DeviceContext* deviceContext,
             size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
-            CXMMATRIX view, CXMMATRIX projection,
+            FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
             bool alpha = false,
             _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
     };
@@ -210,25 +211,29 @@ namespace DirectX
             bool wireframe = false,
             _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
-        // Draw all the meshes using model bones.
+        // Draw all the meshes using model bones
         void XM_CALLCONV Draw(
             _In_ ID3D11DeviceContext* deviceContext,
             const CommonStates& states,
-            size_t nbones, _In_reads_opt_(nbones) const XMMATRIX* boneTransforms,
-            CXMMATRIX view, CXMMATRIX projection,
+            size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
+            FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
             bool wireframe = false,
             _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
-        // Draw all the meshes using skinning.
+        // Draw all the meshes using skinning
         void XM_CALLCONV DrawSkinned(
             _In_ ID3D11DeviceContext* deviceContext,
             const CommonStates& states,
             size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
-            CXMMATRIX view, CXMMATRIX projection,
+            FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
             bool wireframe = false,
             _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
-        // TODO - Helpers for working with bones/boneMatrices
+        // Compute bone positions based on heirarchy using boneMatrices
+        void XM_CALLCONV CopyAbsoluteBoneTransformsTo(size_t nbones, _Out_writes_(nbones) XMMATRIX* boneTransforms);
+
+        // Set bone matrices to a new set of local tansforms
+        void CopyBoneTransformsFrom(size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms);
 
         // Notify model that effects, parts list, or mesh list has changed
         void __cdecl Modified() noexcept { mEffectCache.clear(); }
@@ -274,6 +279,9 @@ namespace DirectX
 
     private:
         std::set<IEffect*>  mEffectCache;
+
+        void XM_CALLCONV ComputeBones(uint32_t index, FXMMATRIX local,
+            size_t nbones, _Inout_updates_(nbones) XMMATRIX* boneTransforms, size_t& visited);
     };
 
 #ifdef __clang__

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -206,8 +206,8 @@ namespace DirectX
         Model(Model&&) = default;
         Model& operator= (Model&&) = default;
 
-        Model(Model const&) = default;
-        Model& operator= (Model const&) = default;
+        Model(Model const& other);
+        Model& operator= (Model const& rhs);
 
         virtual ~Model();
 

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -77,7 +77,7 @@ namespace DirectX
 
         using Collection = std::vector<ModelBone>;
 
-        static const uint32_t c_Invalid = uint32_t(-1);
+        static constexpr uint32_t c_Invalid = uint32_t(-1);
 
         struct aligned_deleter { void operator()(void* p) noexcept { _aligned_free(p); } };
 
@@ -275,13 +275,13 @@ namespace DirectX
             _In_reads_bytes_(dataSize) const uint8_t* meshData, size_t dataSize,
             _In_ IEffectFactory& fxFactory,
             ModelLoaderFlags flags = ModelLoader_CounterClockwise,
-            _Out_opt_ size_t* clipsOffset = nullptr);
+            _Out_opt_ size_t* animsOffset = nullptr);
         static std::unique_ptr<Model> __cdecl CreateFromCMO(
             _In_ ID3D11Device* device,
             _In_z_ const wchar_t* szFileName,
             _In_ IEffectFactory& fxFactory,
             ModelLoaderFlags flags = ModelLoader_CounterClockwise,
-            _Out_opt_ size_t* clipsOffset = nullptr);
+            _Out_opt_ size_t* animsOffset = nullptr);
 
         // Loads a model from a DirectX SDK .SDKMESH file
         static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -242,11 +242,25 @@ namespace DirectX
             bool wireframe = false,
             _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
-        // Compute bone positions based on heirarchy using boneMatrices
-        void XM_CALLCONV CopyAbsoluteBoneTransformsTo(size_t nbones, _Out_writes_(nbones) XMMATRIX* boneTransforms);
+        // Compute bone positions based on heirarchy and transform matrices
+        void __cdecl CopyAbsoluteBoneTransformsTo(
+            size_t nbones,
+            _Out_writes_(nbones) XMMATRIX* boneTransforms) const;
 
-        // Set bone matrices to a set of local tansforms
-        void CopyBoneTransformsFrom(size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms);
+        void __cdecl CopyAbsoluteBoneTransforms(
+            size_t nbones,
+            _In_reads_(nbones) const XMMATRIX* inBoneTransforms,
+            _Out_writes_(nbones) XMMATRIX* outBoneTransforms) const;
+
+        // Set bone matrices to a set of relative tansforms
+        void __cdecl CopyBoneTransformsFrom(
+            size_t nbones,
+            _In_reads_(nbones) const XMMATRIX* boneTransforms);
+
+        // Copies the relative bone matrices to a transform array
+        void __cdecl CopyBoneTransformsTo(
+            size_t nbones,
+            _Out_writes_(nbones) XMMATRIX* boneTransforms) const;
 
         // Notify model that effects, parts list, or mesh list has changed
         void __cdecl Modified() noexcept { mEffectCache.clear(); }
@@ -293,8 +307,11 @@ namespace DirectX
     private:
         std::set<IEffect*>  mEffectCache;
 
-        void XM_CALLCONV ComputeBones(uint32_t index, FXMMATRIX local,
-            size_t nbones, _Inout_updates_(nbones) XMMATRIX* boneTransforms, size_t& visited);
+        void XM_CALLCONV ComputeAbsolute(uint32_t index,
+            FXMMATRIX local, size_t nbones,
+            _In_reads_(nbones) const XMMATRIX* inBoneTransforms,
+            _Inout_updates_(nbones) XMMATRIX* outBoneTransforms,
+            size_t& visited) const;
     };
 
 #ifdef __clang__

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -58,21 +58,18 @@ namespace DirectX
         ModelBone() noexcept :
             parentIndex(c_Invalid),
             childIndex(c_Invalid),
-            siblingIndex(c_Invalid),
-            animIndex(c_Invalid)
+            siblingIndex(c_Invalid)
         {}
 
-        ModelBone(uint32_t parent, uint32_t child, uint32_t sibling, uint32_t anim) noexcept :
+        ModelBone(uint32_t parent, uint32_t child, uint32_t sibling) noexcept :
             parentIndex(parent),
             childIndex(child),
-            siblingIndex(sibling),
-            animIndex(anim)
+            siblingIndex(sibling)
         {}
 
         uint32_t            parentIndex;
         uint32_t            childIndex;
         uint32_t            siblingIndex;
-        uint32_t            animIndex;
         std::wstring        name;
 
         using Collection = std::vector<ModelBone>;

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -64,6 +64,13 @@ namespace DirectX
             animIndex(c_Invalid)
         {}
 
+        ModelBone(uint32_t parent, uint32_t child, uint32_t sibling, uint32_t anim) noexcept :
+            parentIndex(parent),
+            childIndex(child),
+            siblingIndex(sibling),
+            animIndex(anim)
+        {}
+
         uint32_t            parentIndex;
         uint32_t            childIndex;
         uint32_t            siblingIndex;
@@ -77,6 +84,14 @@ namespace DirectX
         struct aligned_deleter { void operator()(void* p) noexcept { _aligned_free(p); } };
 
         using TransformArray = std::unique_ptr<XMMATRIX[], aligned_deleter>;
+
+        static TransformArray MakeArray(size_t count)
+        {
+            void* temp = _aligned_malloc(sizeof(XMMATRIX) * count, 16);
+            if (!temp)
+                throw std::bad_alloc();
+            return TransformArray(static_cast<XMMATRIX*>(temp));
+        }
     };
 
 

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -187,6 +187,14 @@ namespace DirectX
             bool alpha = false,
             _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
+        // Draw the mesh using model bones
+        void XM_CALLCONV Draw(
+            _In_ ID3D11DeviceContext* deviceContext,
+            size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
+            FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
+            bool alpha = false,
+            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+
         // Draw the mesh using skinning
         void XM_CALLCONV DrawSkinned(
             _In_ ID3D11DeviceContext* deviceContext,

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ This project may contain trademarks or logos for projects, products, or services
 
 The _DirectX Tool Kit_ is the work of Shawn Hargreaves and Chuck Walbourn, with contributions from Aaron Rodriguez Hernandez, and Dani Roman.
 
+Thanks to Shanon Drone for the SDKMESH file format.
+
 Thanks to Adrian Tsai for the geodesic sphere implementation.
 
 Thanks to Garrett Serack for his help in creating the NuGet packages for DirectX Tool Kit.

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -361,6 +361,43 @@ Model::~Model()
 {
 }
 
+Model::Model(Model const& other) :
+    meshes(other.meshes),
+    bones(other.bones),
+    name(other.name),
+    mEffectCache(other.mEffectCache)
+{
+    const size_t nbones = other.bones.size();
+    if (nbones > 0)
+    {
+        if (other.boneMatrices)
+        {
+            boneMatrices = ModelBone::MakeArray(nbones);
+            memcpy(boneMatrices.get(), other.boneMatrices.get(), sizeof(XMMATRIX) * nbones);
+        }
+        if (other.invBindPoseMatrices)
+        {
+            invBindPoseMatrices = ModelBone::MakeArray(nbones);
+            memcpy(invBindPoseMatrices.get(), other.invBindPoseMatrices.get(), sizeof(XMMATRIX) * nbones);
+        }
+    }
+}
+
+Model& Model::operator= (Model const& rhs)
+{
+    if (this != &rhs)
+    {
+        Model tmp(rhs);
+        std::swap(meshes, tmp.meshes);
+        std::swap(bones, tmp.bones);
+        std::swap(boneMatrices, tmp.boneMatrices);
+        std::swap(invBindPoseMatrices, tmp.invBindPoseMatrices);
+        std::swap(name, tmp.name);
+        std::swap(mEffectCache, tmp.mEffectCache);
+    }
+    return *this;
+}
+
 
 // Draw all meshes in model given worldViewProjection matrices (ignores any model bones).
 _Use_decl_annotations_

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -260,7 +260,8 @@ void XM_CALLCONV ModelMesh::Draw(
 _Use_decl_annotations_
 void XM_CALLCONV ModelMesh::DrawSkinned(
     ID3D11DeviceContext* deviceContext,
-    size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
+    size_t nbones,
+    const XMMATRIX* boneTransforms,
     FXMMATRIX world,
     CXMMATRIX view,
     CXMMATRIX projection,
@@ -493,7 +494,7 @@ void Model::CopyAbsoluteBoneTransformsTo(size_t nbones, XMMATRIX* boneTransforms
 
     if (nbones < bones.size())
     {
-        throw std::invalid_argument("Bone transforms is too small");
+        throw std::invalid_argument("Bone transforms array is too small");
     }
 
     if (bones.empty() || !boneMatrices)
@@ -519,7 +520,12 @@ void Model::CopyBoneTransformsFrom(size_t nbones, const XMMATRIX* boneTransforms
 
     if (nbones < bones.size())
     {
-        throw std::invalid_argument("Bone transforms is too small");
+        throw std::invalid_argument("Bone transforms array is too small");
+    }
+
+    if (bones.empty())
+    {
+        throw std::runtime_error("Model is missing bones");
     }
 
     if (!boneMatrices)

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -41,6 +41,7 @@ ModelMeshPart::~ModelMeshPart()
 }
 
 
+// Draws using a custom override effect.
 _Use_decl_annotations_
 void ModelMeshPart::Draw(
     ID3D11DeviceContext* deviceContext,
@@ -74,6 +75,7 @@ void ModelMeshPart::Draw(
 }
 
 
+// Draws using a custom override effect w/ instancing.
 _Use_decl_annotations_
 void ModelMeshPart::DrawInstanced(
     ID3D11DeviceContext* deviceContext,
@@ -111,6 +113,7 @@ void ModelMeshPart::DrawInstanced(
 }
 
 
+// Creates input layout for use with custom override effects.
 _Use_decl_annotations_
 void ModelMeshPart::CreateInputLayout(ID3D11Device* d3dDevice, IEffect* ieffect, ID3D11InputLayout** iinputLayout) const
 {
@@ -134,6 +137,7 @@ void ModelMeshPart::CreateInputLayout(ID3D11Device* d3dDevice, IEffect* ieffect,
 }
 
 
+// Assigns a new effect and re-generates input layout.
 _Use_decl_annotations_
 void ModelMeshPart::ModifyEffect(ID3D11Device* d3dDevice, std::shared_ptr<IEffect>& ieffect, bool isalpha)
 {
@@ -172,6 +176,7 @@ ModelMesh::~ModelMesh()
 }
 
 
+// Set render state for mesh part rendering.
 _Use_decl_annotations_
 void ModelMesh::PrepareForRendering(
     ID3D11DeviceContext* deviceContext,
@@ -224,6 +229,7 @@ void ModelMesh::PrepareForRendering(
 }
 
 
+// Draw mesh given worldViewProjection matrices.
 _Use_decl_annotations_
 void XM_CALLCONV ModelMesh::Draw(
     ID3D11DeviceContext* deviceContext,
@@ -257,6 +263,7 @@ void XM_CALLCONV ModelMesh::Draw(
 }
 
 
+// Draw mesh using skinning given bone transform array.
 _Use_decl_annotations_
 void XM_CALLCONV ModelMesh::DrawSkinned(
     ID3D11DeviceContext* deviceContext,
@@ -355,6 +362,7 @@ Model::~Model()
 }
 
 
+// Draw all meshes in model given worldViewProjection matrices (ignores any model bones).
 _Use_decl_annotations_
 void XM_CALLCONV Model::Draw(
     ID3D11DeviceContext* deviceContext,
@@ -391,6 +399,7 @@ void XM_CALLCONV Model::Draw(
 }
 
 
+// Draw all meshes in model using rigid-body animation given bone transform array.
 _Use_decl_annotations_
 void XM_CALLCONV Model::Draw(
     ID3D11DeviceContext* deviceContext,
@@ -440,6 +449,7 @@ void XM_CALLCONV Model::Draw(
 }
 
 
+// Draw all meshes in model using skinning given bone transform array.
 _Use_decl_annotations_
 void XM_CALLCONV Model::DrawSkinned(
     ID3D11DeviceContext* deviceContext,
@@ -453,7 +463,6 @@ void XM_CALLCONV Model::DrawSkinned(
     std::function<void()> setCustomState) const
 {
     assert(deviceContext != nullptr);
-    assert(boneTransforms != nullptr);
 
     if (!nbones || !boneTransforms)
     {
@@ -484,6 +493,7 @@ void XM_CALLCONV Model::DrawSkinned(
 }
 
 
+// Compute using bone hierarchy from model bone matrices to an array.
 _Use_decl_annotations_
 void Model::CopyAbsoluteBoneTransformsTo(
     size_t nbones,
@@ -512,6 +522,7 @@ void Model::CopyAbsoluteBoneTransformsTo(
 }
 
 
+// Compute using bone hierarchy from one array to another array.
 _Use_decl_annotations_
 void Model::CopyAbsoluteBoneTransforms(
     size_t nbones,
@@ -541,6 +552,7 @@ void Model::CopyAbsoluteBoneTransforms(
 }
 
 
+// Private helper for computing hierarchical transforms using bones via recursion.
 _Use_decl_annotations_
 void Model::ComputeAbsolute(
     uint32_t index,
@@ -555,7 +567,7 @@ void Model::ComputeAbsolute(
 
     assert(inBoneTransforms != nullptr && outBoneTransforms != nullptr);
 
-    ++visited;
+    ++visited; // Cycle detection safety!
     if (visited > bones.size())
     {
         DebugTrace("ERROR: Model::CopyAbsoluteBoneTransformsTo encountered a cycle in the bones!\n");
@@ -580,6 +592,7 @@ void Model::ComputeAbsolute(
 }
 
 
+// Copy the model bone matrices from an array.
 _Use_decl_annotations_
 void Model::CopyBoneTransformsFrom(size_t nbones, const XMMATRIX* boneTransforms)
 {
@@ -607,6 +620,7 @@ void Model::CopyBoneTransformsFrom(size_t nbones, const XMMATRIX* boneTransforms
 }
 
 
+// Copy the model bone matrices to an array.
 _Use_decl_annotations_
 void Model::CopyBoneTransformsTo(size_t nbones, XMMATRIX* boneTransforms) const
 {
@@ -629,6 +643,7 @@ void Model::CopyBoneTransformsTo(size_t nbones, XMMATRIX* boneTransforms) const
 }
 
 
+// Iterate through unique effect instances.
 void Model::UpdateEffects(_In_ std::function<void(IEffect*)> setEffect)
 {
     if (mEffectCache.empty())

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -363,30 +363,30 @@ void XM_CALLCONV ModelMesh::DrawSkinned(
             {
                 if (!temp)
                 {
-                    // Create temporary space on-demand
+                    // Create the influence mapped bones on-demand.
                     temp = ModelBone::MakeArray(IEffectSkinning::MaxBones);
-                }
 
-                size_t count = 0;
-                for (auto it : boneInfluences)
-                {
-                    ++count;
-                    if (count > IEffectSkinning::MaxBones)
+                    size_t count = 0;
+                    for (auto it : boneInfluences)
                     {
-                        throw std::runtime_error("Too many bones for skinning");
+                        ++count;
+                        if (count > IEffectSkinning::MaxBones)
+                        {
+                            throw std::runtime_error("Too many bones for skinning");
+                        }
+
+                        if (it >= nbones)
+                        {
+                            throw std::runtime_error("Invalid bone influence index");
+                        }
+
+                        temp[count - 1] = boneTransforms[it];
                     }
 
-                    if (it >= nbones)
-                    {
-                        throw std::runtime_error("Invalid bone influence index");
-                    }
-
-                    temp[count - 1] = boneTransforms[it];
+                    assert(count == boneInfluences.size());
                 }
 
-                assert(count == boneInfluences.size());
-
-                iskinning->SetBoneTransforms(temp.get(), count);
+                iskinning->SetBoneTransforms(temp.get(), boneInfluences.size());
             }
         }
         else if (imatrices)

--- a/Src/Model.cpp
+++ b/Src/Model.cpp
@@ -306,7 +306,7 @@ void XM_CALLCONV ModelMesh::DrawSkinned(
                 if (!temp)
                 {
                     // Create temporary space on-demand
-                    temp.reset(static_cast<XMMATRIX*>(_aligned_malloc(sizeof(XMMATRIX) * IEffectSkinning::MaxBones, 16)));
+                    temp = ModelBone::MakeArray(IEffectSkinning::MaxBones);
                 }
 
                 size_t count = 0;
@@ -524,9 +524,7 @@ void Model::CopyBoneTransformsFrom(size_t nbones, const XMMATRIX* boneTransforms
 
     if (!boneMatrices)
     {
-        boneMatrices.reset(static_cast<XMMATRIX*>(_aligned_malloc(sizeof(XMMATRIX) * bones.size(), 16)));
-        if (!boneMatrices)
-            throw std::bad_alloc();
+        boneMatrices = ModelBone::MakeArray(bones.size());
     }
 
     memcpy(boneMatrices.get(), boneTransforms, bones.size() * sizeof(XMMATRIX));

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -99,24 +99,24 @@ namespace VSD3DStarter
         DirectX::XMFLOAT4X4 UVTransform;
     };
 
-    const uint32_t MAX_TEXTURE = 8;
+    constexpr uint32_t MAX_TEXTURE = 8;
 
     struct SubMesh
     {
-        UINT MaterialIndex;
-        UINT IndexBufferIndex;
-        UINT VertexBufferIndex;
-        UINT StartIndex;
-        UINT PrimCount;
+        uint32_t MaterialIndex;
+        uint32_t IndexBufferIndex;
+        uint32_t VertexBufferIndex;
+        uint32_t StartIndex;
+        uint32_t PrimCount;
     };
 
-    const uint32_t NUM_BONE_INFLUENCES = 4;
+    constexpr uint32_t NUM_BONE_INFLUENCES = 4;
 
     static_assert(sizeof(VertexPositionNormalTangentColorTexture) == 52, "mismatch with CMO vertex type");
 
     struct SkinningVertex
     {
-        UINT boneIndex[NUM_BONE_INFLUENCES];
+        uint32_t boneIndex[NUM_BONE_INFLUENCES];
         float boneWeight[NUM_BONE_INFLUENCES];
     };
 
@@ -141,12 +141,12 @@ namespace VSD3DStarter
     {
         float StartTime;
         float EndTime;
-        UINT  keys;
+        uint32_t keys;
     };
 
     struct Keyframe
     {
-        UINT BoneIndex;
+        uint32_t BoneIndex;
         float Time;
         DirectX::XMFLOAT4X4 Transform;
     };
@@ -280,8 +280,8 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
     auto fxFactoryDGSL = dynamic_cast<DGSLEffectFactory*>(&fxFactory);
 
     // Meshes
-    auto nMesh = reinterpret_cast<const UINT*>(meshData);
-    size_t usedSize = sizeof(UINT);
+    auto nMesh = reinterpret_cast<const uint32_t*>(meshData);
+    size_t usedSize = sizeof(uint32_t);
     if (dataSize < usedSize)
         throw std::runtime_error("End of file");
 
@@ -290,11 +290,11 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
 
     auto model = std::make_unique<Model>();
 
-    for (UINT meshIndex = 0; meshIndex < *nMesh; ++meshIndex)
+    for (size_t meshIndex = 0; meshIndex < *nMesh; ++meshIndex)
     {
         // Mesh name
-        auto nName = reinterpret_cast<const UINT*>(meshData + usedSize);
-        usedSize += sizeof(UINT);
+        auto nName = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+        usedSize += sizeof(uint32_t);
         if (dataSize < usedSize)
             throw std::runtime_error("End of file");
 
@@ -310,20 +310,20 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         mesh->pmalpha = (flags & ModelLoader_PremultipledAlpha) != 0;
 
         // Materials
-        auto nMats = reinterpret_cast<const UINT*>(meshData + usedSize);
-        usedSize += sizeof(UINT);
+        auto nMats = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+        usedSize += sizeof(uint32_t);
         if (dataSize < usedSize)
             throw std::runtime_error("End of file");
 
         std::vector<MaterialRecordCMO> materials;
         materials.reserve(*nMats);
-        for (UINT j = 0; j < *nMats; ++j)
+        for (size_t j = 0; j < *nMats; ++j)
         {
             MaterialRecordCMO m;
 
             // Material name
-            nName = reinterpret_cast<const UINT*>(meshData + usedSize);
-            usedSize += sizeof(UINT);
+            nName = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+            usedSize += sizeof(uint32_t);
             if (dataSize < usedSize)
                 throw std::runtime_error("End of file");
 
@@ -344,8 +344,8 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             m.pMaterial = matSetting;
 
             // Pixel shader name
-            nName = reinterpret_cast<const UINT*>(meshData + usedSize);
-            usedSize += sizeof(UINT);
+            nName = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+            usedSize += sizeof(uint32_t);
             if (dataSize < usedSize)
                 throw std::runtime_error("End of file");
 
@@ -357,10 +357,10 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
 
             m.pixelShader.assign(psName, *nName);
 
-            for (UINT t = 0; t < VSD3DStarter::MAX_TEXTURE; ++t)
+            for (size_t t = 0; t < VSD3DStarter::MAX_TEXTURE; ++t)
             {
-                nName = reinterpret_cast<const UINT*>(meshData + usedSize);
-                usedSize += sizeof(UINT);
+                nName = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+                usedSize += sizeof(uint32_t);
                 if (dataSize < usedSize)
                     throw std::runtime_error("End of file");
 
@@ -394,8 +394,8 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             throw std::runtime_error("End of file");
 
         // Submeshes
-        auto nSubmesh = reinterpret_cast<const UINT*>(meshData + usedSize);
-        usedSize += sizeof(UINT);
+        auto nSubmesh = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+        usedSize += sizeof(uint32_t);
         if (dataSize < usedSize)
             throw std::runtime_error("End of file");
 
@@ -408,8 +408,8 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             throw std::runtime_error("End of file");
 
         // Index buffers
-        auto nIBs = reinterpret_cast<const UINT*>(meshData + usedSize);
-        usedSize += sizeof(UINT);
+        auto nIBs = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+        usedSize += sizeof(uint32_t);
         if (dataSize < usedSize)
             throw std::runtime_error("End of file");
 
@@ -428,10 +428,10 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         std::vector<ComPtr<ID3D11Buffer>> ibs;
         ibs.resize(*nIBs);
 
-        for (UINT j = 0; j < *nIBs; ++j)
+        for (size_t j = 0; j < *nIBs; ++j)
         {
-            auto nIndexes = reinterpret_cast<const UINT*>(meshData + usedSize);
-            usedSize += sizeof(UINT);
+            auto nIndexes = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+            usedSize += sizeof(uint32_t);
             if (dataSize < usedSize)
                 throw std::runtime_error("End of file");
 
@@ -479,8 +479,8 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         assert(ibs.size() == *nIBs);
 
         // Vertex buffers
-        auto nVBs = reinterpret_cast<const UINT*>(meshData + usedSize);
-        usedSize += sizeof(UINT);
+        auto nVBs = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+        usedSize += sizeof(uint32_t);
         if (dataSize < usedSize)
             throw std::runtime_error("End of file");
 
@@ -496,10 +496,10 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
 
         std::vector<VBData> vbData;
         vbData.reserve(*nVBs);
-        for (UINT j = 0; j < *nVBs; ++j)
+        for (size_t j = 0; j < *nVBs; ++j)
         {
-            auto nVerts = reinterpret_cast<const UINT*>(meshData + usedSize);
-            usedSize += sizeof(UINT);
+            auto nVerts = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+            usedSize += sizeof(uint32_t);
             if (dataSize < usedSize)
                 throw std::runtime_error("End of file");
 
@@ -523,8 +523,8 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         assert(vbData.size() == *nVBs);
 
         // Skinning vertex buffers
-        auto nSkinVBs = reinterpret_cast<const UINT*>(meshData + usedSize);
-        usedSize += sizeof(UINT);
+        auto nSkinVBs = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+        usedSize += sizeof(uint32_t);
         if (dataSize < usedSize)
             throw std::runtime_error("End of file");
 
@@ -533,10 +533,10 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             if (*nSkinVBs != *nVBs)
                 throw std::runtime_error("Number of VBs not equal to number of skin VBs");
 
-            for (UINT j = 0; j < *nSkinVBs; ++j)
+            for (size_t j = 0; j < *nSkinVBs; ++j)
             {
-                auto nVerts = reinterpret_cast<const UINT*>(meshData + usedSize);
-                usedSize += sizeof(UINT);
+                auto nVerts = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+                usedSize += sizeof(uint32_t);
                 if (dataSize < usedSize)
                     throw std::runtime_error("End of file");
 
@@ -576,8 +576,8 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         if (*bSkeleton && (flags & ModelLoader_IncludeBones))
         {
             // Bones
-            auto nBones = reinterpret_cast<const UINT*>(meshData + usedSize);
-            usedSize += sizeof(UINT);
+            auto nBones = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+            usedSize += sizeof(uint32_t);
             if (dataSize < usedSize)
                 throw std::runtime_error("End of file");
 
@@ -589,11 +589,11 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             auto transforms = ModelBone::MakeArray(*nBones);
             auto invTransforms = ModelBone::MakeArray(*nBones);
 
-            for (UINT j = 0; j < *nBones; ++j)
+            for (uint32_t j = 0; j < *nBones; ++j)
             {
                 // Bone name
-                nName = reinterpret_cast<const UINT*>(meshData + usedSize);
-                usedSize += sizeof(UINT);
+                nName = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+                usedSize += sizeof(uint32_t);
                 if (dataSize < usedSize)
                     throw std::runtime_error("End of file");
 
@@ -693,8 +693,8 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
 
                 size_t offset = usedSize;
 
-                auto nClips = reinterpret_cast<const UINT*>(meshData + usedSize);
-                usedSize += sizeof(UINT);
+                auto nClips = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+                usedSize += sizeof(uint32_t);
                 if (dataSize < usedSize)
                     throw std::runtime_error("End of file");
 
@@ -705,11 +705,11 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             }
 #if 0
             // TODO: Move this to another function.
-            for (UINT j = 0; j < *nClips; ++j)
+            for (size_t j = 0; j < *nClips; ++j)
             {
                 // Clip name
-                nName = reinterpret_cast<const UINT*>(meshData + usedSize);
-                usedSize += sizeof(UINT);
+                nName = reinterpret_cast<const uint32_t*>(meshData + usedSize);
+                usedSize += sizeof(uint32_t);
                 if (dataSize < usedSize)
                     throw std::runtime_error("End of file");
 
@@ -750,7 +750,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         const size_t stride = enableSkinning ? sizeof(VertexPositionNormalTangentColorTextureSkinning)
             : sizeof(VertexPositionNormalTangentColorTexture);
 
-        for (UINT j = 0; j < *nVBs; ++j)
+        for (size_t j = 0; j < *nVBs; ++j)
         {
             size_t nVerts = vbData[j].nVerts;
 
@@ -783,10 +783,10 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             }
             else
             {
-                auto temp = std::make_unique<uint8_t[]>(bytes + (sizeof(UINT) * nVerts));
+                auto temp = std::make_unique<uint8_t[]>(bytes + (sizeof(uint32_t) * nVerts));
 
-                auto visited = reinterpret_cast<UINT*>(temp.get() + bytes);
-                memset(visited, 0xff, sizeof(UINT) * nVerts);
+                auto visited = reinterpret_cast<uint32_t*>(temp.get() + bytes);
+                memset(visited, 0xff, sizeof(uint32_t) * nVerts);
 
                 assert(vbData[j].ptr != nullptr);
 
@@ -819,7 +819,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                 if (!fxFactoryDGSL)
                 {
                     // Need to fix up VB tex coords for UV transform which is not supported by basic effects
-                    for (UINT k = 0; k < *nSubmesh; ++k)
+                    for (size_t k = 0; k < *nSubmesh; ++k)
                     {
                         auto& sm = subMesh[k];
 
@@ -844,7 +844,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                                 throw std::out_of_range("Invalid index found\n");
 
                             auto verts = reinterpret_cast<VertexPositionNormalTangentColorTexture*>(temp.get() + (v * stride));
-                            if (visited[v] == UINT(-1))
+                            if (visited[v] == uint32_t(-1))
                             {
                                 visited[v] = sm.MaterialIndex;
 
@@ -944,7 +944,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         }
 
         // Build mesh parts
-        for (UINT j = 0; j < *nSubmesh; ++j)
+        for (size_t j = 0; j < *nSubmesh; ++j)
         {
             auto& sm = subMesh[j];
 

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -604,7 +604,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                 if (dataSize < usedSize)
                     throw std::runtime_error("End of file");
 
-                transforms[j] = XMLoadFloat4x4(&cmobones->LocalTransform);
+                transforms[j] = XMLoadFloat4x4(&cmobones->BindPos);
 
                 if (cmobones->ParentIndex < 0)
                 {

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -703,42 +703,6 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                     *animsOffset = offset;
                 }
             }
-#if 0
-            // TODO: Move this to another function.
-            for (size_t j = 0; j < *nClips; ++j)
-            {
-                // Clip name
-                nName = reinterpret_cast<const uint32_t*>(meshData + usedSize);
-                usedSize += sizeof(uint32_t);
-                if (dataSize < usedSize)
-                    throw std::runtime_error("End of file");
-
-                auto clipName = reinterpret_cast<const wchar_t*>(meshData + usedSize);
-
-                usedSize += sizeof(wchar_t)*(*nName);
-                if (dataSize < usedSize)
-                    throw std::runtime_error("End of file");
-
-                // TODO - What to do with clip name?
-                clipName;
-
-                auto clip = reinterpret_cast<const VSD3DStarter::Clip*>(meshData + usedSize);
-                usedSize += sizeof(VSD3DStarter::Clip);
-                if (dataSize < usedSize)
-                    throw std::runtime_error("End of file");
-
-                if (!clip->keys)
-                    throw std::runtime_error("Keyframes missing in clip");
-
-                auto keys = reinterpret_cast<const VSD3DStarter::Keyframe*>(meshData + usedSize);
-                usedSize += sizeof(VSD3DStarter::Keyframe) * clip->keys;
-                if (dataSize < usedSize)
-                    throw std::runtime_error("End of file");
-
-                // TODO - What to do with keys and clip->StartTime, clip->EndTime?
-                keys;
-            }
-#endif
         }
 
         bool enableSkinning = (*nSkinVBs) != 0;

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -23,7 +23,7 @@ using Microsoft::WRL::ComPtr;
 //--------------------------------------------------------------------------------------
 // .CMO files are built by Visual Studio 2012 and an example renderer is provided
 // in the VS Direct3D Starter Kit
-// http://code.msdn.microsoft.com/Visual-Studio-3D-Starter-455a15f1
+// http://aka.ms/vs3dkitwin
 //--------------------------------------------------------------------------------------
 
 namespace VSD3DStarter
@@ -566,8 +566,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         XMVECTOR max = XMVectorSet(extents->MaxX, extents->MaxY, extents->MaxZ, 0.f);
         BoundingBox::CreateFromPoints(mesh->boundingBox, min, max);
 
-    #if 0
-            // Animation data
+        // Animation data
         if (*bSkeleton)
         {
             // Bones
@@ -597,15 +596,16 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                 boneName;
 
                 // Bone settings
-                auto bones = reinterpret_cast<const VSD3DStarter::Bone*>(meshData + usedSize);
+                auto cmobones = reinterpret_cast<const VSD3DStarter::Bone*>(meshData + usedSize);
                 usedSize += sizeof(VSD3DStarter::Bone);
                 if (dataSize < usedSize)
                     throw std::runtime_error("End of file");
 
                 // TODO - What to do with bone data?
-                bones;
+                cmobones;
             }
 
+#if 0
             // Animation Clips
             auto nClips = reinterpret_cast<const UINT*>(meshData + usedSize);
             usedSize += sizeof(UINT);
@@ -645,10 +645,8 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                 // TODO - What to do with keys and clip->StartTime, clip->EndTime?
                 keys;
             }
-        }
-    #else
-        UNREFERENCED_PARAMETER(bSkeleton);
     #endif
+        }
 
         bool enableSkinning = (*nSkinVBs) != 0;
 

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -264,11 +264,11 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
     const uint8_t* meshData, size_t dataSize,
     IEffectFactory& fxFactory,
     ModelLoaderFlags flags,
-    size_t* clipsOffset)
+    size_t* animsOffset)
 {
-    if (clipsOffset)
+    if (animsOffset)
     {
-        *clipsOffset = 0;
+        *animsOffset = 0;
     }
 
     if (!InitOnceExecuteOnce(&g_InitOnce, InitializeDecl, nullptr, nullptr))
@@ -687,8 +687,10 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
             std::swap(model->invBindPoseMatrices, invTransforms);
 
             // Animation Clips
-            if (clipsOffset)
+            if (animsOffset)
             {
+                // Optional return for offset to start of animation clips in the CMO.
+
                 size_t offset = usedSize;
 
                 auto nClips = reinterpret_cast<const UINT*>(meshData + usedSize);
@@ -698,10 +700,11 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
 
                 if (*nClips > 0)
                 {
-                    *clipsOffset = offset;
+                    *animsOffset = offset;
                 }
             }
 #if 0
+            // TODO: Move this to another function.
             for (UINT j = 0; j < *nClips; ++j)
             {
                 // Clip name
@@ -983,11 +986,11 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
     const wchar_t* szFileName,
     IEffectFactory& fxFactory,
     ModelLoaderFlags flags,
-    size_t* clipsOffset)
+    size_t* animsOffset)
 {
-    if (clipsOffset)
+    if (animsOffset)
     {
-        *clipsOffset = 0;
+        *animsOffset = 0;
     }
 
     size_t dataSize = 0;
@@ -1000,7 +1003,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
         throw std::runtime_error("CreateFromCMO");
     }
 
-    auto model = CreateFromCMO(device, data.get(), dataSize, fxFactory, flags, clipsOffset);
+    auto model = CreateFromCMO(device, data.get(), dataSize, fxFactory, flags, animsOffset);
 
     model->name = szFileName;
 

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -741,7 +741,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         static_assert(DXUT::INVALID_FRAME == ModelBone::c_Invalid, "ModelBone invalid type mismatch");
         static_assert(DXUT::INVALID_ANIMATION_DATA == ModelBone::c_Invalid, "ModelBone invalid type mismatch");
 
-        std::vector<ModelBone> bones;
+        ModelBone::Collection bones;
         bones.reserve(header->NumFrames);
         auto transforms = ModelBone::MakeArray(header->NumFrames);
 

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -624,7 +624,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
                 || (dataSize < mh.FrameInfluenceOffset + uint64_t(mh.NumFrameInfluences) * sizeof(UINT)))
                 throw std::runtime_error("End of file");
 
-            if (flags & ModelLoader_IncludeInfluences)
+            if (flags & ModelLoader_IncludeBones)
             {
                 influences = reinterpret_cast<const UINT*>(meshData + mh.FrameInfluenceOffset);
             }

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -453,7 +453,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     {
         if (dataSize < header->FrameDataOffset
             || (dataSize < (header->FrameDataOffset + uint64_t(header->NumFrames) * sizeof(DXUT::SDKMESH_FRAME))))
-            throw std::exception("End of file");
+            throw std::runtime_error("End of file");
 
         if (flags & ModelLoader_IncludeBones)
         {
@@ -494,7 +494,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     materialFlags.resize(header->NumVertexBuffers);
 
     bool dec3nwarning = false;
-    for (UINT j = 0; j < header->NumVertexBuffers; ++j)
+    for (size_t j = 0; j < header->NumVertexBuffers; ++j)
     {
         auto& vh = vbArray[j];
 
@@ -556,7 +556,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     std::vector<ComPtr<ID3D11Buffer>> ibs;
     ibs.resize(header->NumIndexBuffers);
 
-    for (UINT j = 0; j < header->NumIndexBuffers; ++j)
+    for (size_t j = 0; j < header->NumIndexBuffers; ++j)
     {
         auto& ih = ibArray[j];
 
@@ -599,7 +599,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     auto model = std::make_unique<Model>();
     model->meshes.reserve(header->NumMeshes);
 
-    for (UINT meshIndex = 0; meshIndex < header->NumMeshes; ++meshIndex)
+    for (size_t meshIndex = 0; meshIndex < header->NumMeshes; ++meshIndex)
     {
         auto& mh = meshArray[meshIndex];
 
@@ -612,21 +612,21 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         // mh.NumVertexBuffers is sometimes not what you'd expect, so we skip validating it
 
         if (dataSize < mh.SubsetOffset
-            || (dataSize < mh.SubsetOffset + uint64_t(mh.NumSubsets) * sizeof(UINT)))
+            || (dataSize < mh.SubsetOffset + uint64_t(mh.NumSubsets) * sizeof(uint32_t)))
             throw std::runtime_error("End of file");
 
-        auto subsets = reinterpret_cast<const UINT*>(meshData + mh.SubsetOffset);
+        auto subsets = reinterpret_cast<const uint32_t*>(meshData + mh.SubsetOffset);
 
-        const UINT* influences = nullptr;
+        const uint32_t* influences = nullptr;
         if (mh.NumFrameInfluences > 0)
         {
             if (dataSize < mh.FrameInfluenceOffset
-                || (dataSize < mh.FrameInfluenceOffset + uint64_t(mh.NumFrameInfluences) * sizeof(UINT)))
+                || (dataSize < mh.FrameInfluenceOffset + uint64_t(mh.NumFrameInfluences) * sizeof(uint32_t)))
                 throw std::runtime_error("End of file");
 
             if (flags & ModelLoader_IncludeBones)
             {
-                influences = reinterpret_cast<const UINT*>(meshData + mh.FrameInfluenceOffset);
+                influences = reinterpret_cast<const uint32_t*>(meshData + mh.FrameInfluenceOffset);
             }
         }
 
@@ -645,12 +645,12 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         if (influences)
         {
             mesh->boneInfluences.resize(mh.NumFrameInfluences);
-            memcpy(mesh->boneInfluences.data(), influences, sizeof(UINT) * mh.NumFrameInfluences);
+            memcpy(mesh->boneInfluences.data(), influences, sizeof(uint32_t) * mh.NumFrameInfluences);
         }
 
         // Create subsets
         mesh->meshParts.reserve(mh.NumSubsets);
-        for (UINT j = 0; j < mh.NumSubsets; ++j)
+        for (size_t j = 0; j < mh.NumSubsets; ++j)
         {
             auto sIndex = subsets[j];
             if (sIndex >= header->NumTotalSubsets)

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -740,7 +740,6 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
     if (frameArray)
     {
         static_assert(DXUT::INVALID_FRAME == ModelBone::c_Invalid, "ModelBone invalid type mismatch");
-        static_assert(DXUT::INVALID_ANIMATION_DATA == ModelBone::c_Invalid, "ModelBone invalid type mismatch");
 
         ModelBone::Collection bones;
         bones.reserve(header->NumFrames);
@@ -751,8 +750,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
             ModelBone bone(
                 frameArray[j].ParentFrame,
                 frameArray[j].ChildFrame,
-                frameArray[j].SiblingFrame,
-                frameArray[j].AnimationDataIndex);
+                frameArray[j].SiblingFrame);
 
             wchar_t boneName[DXUT::MAX_FRAME_NAME] = {};
             ASCIIToWChar(boneName, frameArray[j].Name);

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -455,7 +455,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
             || (dataSize < (header->FrameDataOffset + uint64_t(header->NumFrames) * sizeof(DXUT::SDKMESH_FRAME))))
             throw std::exception("End of file");
 
-        if (flags & ModelLoader_IncludeFrames)
+        if (flags & ModelLoader_IncludeBones)
         {
             frameArray = reinterpret_cast<const DXUT::SDKMESH_FRAME*>(meshData + header->FrameDataOffset);
         }
@@ -736,6 +736,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         model->meshes.emplace_back(mesh);
     }
 
+    // Load model bones (if present and requested)
     if (frameArray)
     {
         static_assert(DXUT::INVALID_FRAME == ModelBone::c_Invalid, "ModelBone invalid type mismatch");

--- a/Src/PlatformHelpers.h
+++ b/Src/PlatformHelpers.h
@@ -75,8 +75,6 @@ namespace DirectX
     struct virtual_deleter { void operator()(void* p) noexcept { if (p) VirtualFree(p, 0, MEM_RELEASE); } };
 #endif
 
-    struct aligned_deleter { void operator()(void* p) noexcept { _aligned_free(p); } };
-
     struct handle_closer { void operator()(HANDLE h) noexcept { if (h) CloseHandle(h); } };
 
     using ScopedHandle = std::unique_ptr<void, handle_closer>;


### PR DESCRIPTION
Adds the **ModelBone** class to *DirectX Tool Kit*'s **Model** support, with loading from ``SDKMESH`` and ``CMO`` files.

* Includes the bone transforms and inverse bind pose transforms needed for both rigid-body and skinned animation.
* The ``ModelLoader_IncludeBones`` flag must be specified to have the loaders include the bone information if present.
* The CMO loader optionally returns the offset into the file where animation clips are located for later processing.

**ModelMeshPart** updated with optional bone index for rigid-body animation, and optional bone-influences for indirect vertex mapping for bones (used by ``SDKMESH``).

**Model** updated with **Draw** method overload for rigid-body transform drawing.

**Model** and **ModelMeshPart** updated with **DrawSkinned** method.

**Model** updated with **CopyAbsoluteBoneTransformsTo**, **CopyAbsoluteBoneTransforms**, **CopyBoneTransformsFrom**, and **CopyBoneTransformsTo** methods.

> This design differs from *XNA Game Studio* in two important ways. First, the bone tree is specified using the more complex ``SDKMESH`` design with parent, child, and sibling bone 'pointers' rather than relying on strict "content pipeline" sorting order. Second, there is no concept of a specific ``root`` bone in the Model, just that the '0th' bone is the "root" (i.e. has no parent).