### PR TITLE
Updated pimpl pattern for default move ctors/ops/dtors

### DIFF
--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1149,19 +1149,9 @@ AudioEngine::AudioEngine(
 }
 
 
-// Move constructor.
-AudioEngine::AudioEngine(AudioEngine&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-AudioEngine& AudioEngine::operator= (AudioEngine&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
+// Move ctor/operator.
+AudioEngine::AudioEngine(AudioEngine&&) noexcept = default;
+AudioEngine& AudioEngine::operator= (AudioEngine&&) noexcept = default;
 
 
 // Public destructor.

--- a/Audio/DynamicSoundEffectInstance.cpp
+++ b/Audio/DynamicSoundEffectInstance.cpp
@@ -252,25 +252,9 @@ DynamicSoundEffectInstance::DynamicSoundEffectInstance(
 }
 
 
-// Move constructor.
-DynamicSoundEffectInstance::DynamicSoundEffectInstance(DynamicSoundEffectInstance&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-DynamicSoundEffectInstance& DynamicSoundEffectInstance::operator= (DynamicSoundEffectInstance&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-DynamicSoundEffectInstance::~DynamicSoundEffectInstance()
-{
-}
+DynamicSoundEffectInstance::DynamicSoundEffectInstance(DynamicSoundEffectInstance&&) noexcept = default;
+DynamicSoundEffectInstance& DynamicSoundEffectInstance::operator= (DynamicSoundEffectInstance&&) noexcept = default;
+DynamicSoundEffectInstance::~DynamicSoundEffectInstance() = default;
 
 
 // Public methods.

--- a/Audio/SoundEffect.cpp
+++ b/Audio/SoundEffect.cpp
@@ -455,25 +455,9 @@ SoundEffect::SoundEffect(AudioEngine* engine, std::unique_ptr<uint8_t[]>& wavDat
 #endif
 
 
-// Move constructor.
-SoundEffect::SoundEffect(SoundEffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-SoundEffect& SoundEffect::operator= (SoundEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-SoundEffect::~SoundEffect()
-{
-}
+SoundEffect::SoundEffect(SoundEffect&&) noexcept = default;
+SoundEffect& SoundEffect::operator= (SoundEffect&&) noexcept = default;
+SoundEffect::~SoundEffect() = default;
 
 
 // Public methods.

--- a/Audio/SoundEffectInstance.cpp
+++ b/Audio/SoundEffectInstance.cpp
@@ -238,19 +238,9 @@ SoundEffectInstance::SoundEffectInstance(AudioEngine* engine, WaveBank* waveBank
 }
 
 
-// Move constructor.
-SoundEffectInstance::SoundEffectInstance(SoundEffectInstance&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-SoundEffectInstance& SoundEffectInstance::operator= (SoundEffectInstance&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
+// Move ctor/operator.
+SoundEffectInstance::SoundEffectInstance(SoundEffectInstance&&) noexcept = default;
+SoundEffectInstance& SoundEffectInstance::operator= (SoundEffectInstance&&) noexcept = default;
 
 
 // Public destructor.

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -749,19 +749,9 @@ SoundStreamInstance::SoundStreamInstance(AudioEngine* engine, WaveBank* waveBank
 }
 
 
-// Move constructor.
-SoundStreamInstance::SoundStreamInstance(SoundStreamInstance&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-SoundStreamInstance& SoundStreamInstance::operator= (SoundStreamInstance&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
+// Move ctor/operator.
+SoundStreamInstance::SoundStreamInstance(SoundStreamInstance&&) noexcept = default;
+SoundStreamInstance& SoundStreamInstance::operator= (SoundStreamInstance&&) noexcept = default;
 
 
 // Public destructor.

--- a/Audio/WaveBank.cpp
+++ b/Audio/WaveBank.cpp
@@ -278,25 +278,9 @@ WaveBank::WaveBank(AudioEngine* engine, const wchar_t* wbFileName)
 }
 
 
-// Move constructor.
-WaveBank::WaveBank(WaveBank&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-WaveBank& WaveBank::operator= (WaveBank&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-WaveBank::~WaveBank()
-{
-}
+WaveBank::WaveBank(WaveBank&&) noexcept = default;
+WaveBank& WaveBank::operator= (WaveBank&&) noexcept = default;
+WaveBank::~WaveBank() = default;
 
 
 // Public methods (one-shots)

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -207,8 +207,8 @@ namespace DirectX
             _In_opt_z_ const wchar_t* deviceId = nullptr,
             AUDIO_STREAM_CATEGORY category = AudioCategory_GameEffects) noexcept(false);
 
-        AudioEngine(AudioEngine&& moveFrom) noexcept;
-        AudioEngine& operator= (AudioEngine&& moveFrom) noexcept;
+        AudioEngine(AudioEngine&&) noexcept;
+        AudioEngine& operator= (AudioEngine&&) noexcept;
 
         AudioEngine(AudioEngine const&) = delete;
         AudioEngine& operator= (AudioEngine const&) = delete;
@@ -306,8 +306,8 @@ namespace DirectX
     public:
         WaveBank(_In_ AudioEngine* engine, _In_z_ const wchar_t* wbFileName);
 
-        WaveBank(WaveBank&& moveFrom) noexcept;
-        WaveBank& operator= (WaveBank&& moveFrom) noexcept;
+        WaveBank(WaveBank&&) noexcept;
+        WaveBank& operator= (WaveBank&&) noexcept;
 
         WaveBank(WaveBank const&) = delete;
         WaveBank& operator= (WaveBank const&) = delete;
@@ -388,8 +388,8 @@ namespace DirectX
 
 #endif
 
-        SoundEffect(SoundEffect&& moveFrom) noexcept;
-        SoundEffect& operator= (SoundEffect&& moveFrom) noexcept;
+        SoundEffect(SoundEffect&&) noexcept;
+        SoundEffect& operator= (SoundEffect&&) noexcept;
 
         SoundEffect(SoundEffect const&) = delete;
         SoundEffect& operator= (SoundEffect const&) = delete;
@@ -613,8 +613,8 @@ namespace DirectX
     class SoundEffectInstance
     {
     public:
-        SoundEffectInstance(SoundEffectInstance&& moveFrom) noexcept;
-        SoundEffectInstance& operator= (SoundEffectInstance&& moveFrom) noexcept;
+        SoundEffectInstance(SoundEffectInstance&&) noexcept;
+        SoundEffectInstance& operator= (SoundEffectInstance&&) noexcept;
 
         SoundEffectInstance(SoundEffectInstance const&) = delete;
         SoundEffectInstance& operator= (SoundEffectInstance const&) = delete;
@@ -659,8 +659,8 @@ namespace DirectX
     class SoundStreamInstance
     {
     public:
-        SoundStreamInstance(SoundStreamInstance&& moveFrom) noexcept;
-        SoundStreamInstance& operator= (SoundStreamInstance&& moveFrom) noexcept;
+        SoundStreamInstance(SoundStreamInstance&&) noexcept;
+        SoundStreamInstance& operator= (SoundStreamInstance&&) noexcept;
 
         SoundStreamInstance(SoundStreamInstance const&) = delete;
         SoundStreamInstance& operator= (SoundStreamInstance const&) = delete;
@@ -707,8 +707,9 @@ namespace DirectX
             _In_opt_ std::function<void __cdecl(DynamicSoundEffectInstance*)> bufferNeeded,
             int sampleRate, int channels, int sampleBits = 16,
             SOUND_EFFECT_INSTANCE_FLAGS flags = SoundEffectInstance_Default);
-        DynamicSoundEffectInstance(DynamicSoundEffectInstance&& moveFrom) noexcept;
-        DynamicSoundEffectInstance& operator= (DynamicSoundEffectInstance&& moveFrom) noexcept;
+
+        DynamicSoundEffectInstance(DynamicSoundEffectInstance&&) noexcept;
+        DynamicSoundEffectInstance& operator= (DynamicSoundEffectInstance&&) noexcept;
 
         DynamicSoundEffectInstance(DynamicSoundEffectInstance const&) = delete;
         DynamicSoundEffectInstance& operator= (DynamicSoundEffectInstance const&) = delete;

--- a/Inc/CommonStates.h
+++ b/Inc/CommonStates.h
@@ -24,8 +24,9 @@ namespace DirectX
     {
     public:
         explicit CommonStates(_In_ ID3D11Device* device);
-        CommonStates(CommonStates&& moveFrom) noexcept;
-        CommonStates& operator= (CommonStates&& moveFrom) noexcept;
+
+        CommonStates(CommonStates&&) noexcept;
+        CommonStates& operator= (CommonStates&&) noexcept;
 
         CommonStates(CommonStates const&) = delete;
         CommonStates& operator= (CommonStates const&) = delete;

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -33,15 +33,14 @@ namespace DirectX
         IEffect(const IEffect&) = delete;
         IEffect& operator=(const IEffect&) = delete;
 
-        IEffect(IEffect&&) = delete;
-        IEffect& operator=(IEffect&&) = delete;
-
         virtual void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) = 0;
 
         virtual void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) = 0;
 
     protected:
         IEffect() = default;
+        IEffect(IEffect&&) = default;
+        IEffect& operator=(IEffect&&) = default;
     };
 
 
@@ -54,9 +53,6 @@ namespace DirectX
         IEffectMatrices(const IEffectMatrices&) = delete;
         IEffectMatrices& operator=(const IEffectMatrices&) = delete;
 
-        IEffectMatrices(IEffectMatrices&&) = delete;
-        IEffectMatrices& operator=(IEffectMatrices&&) = delete;
-
         virtual void XM_CALLCONV SetWorld(FXMMATRIX value) = 0;
         virtual void XM_CALLCONV SetView(FXMMATRIX value) = 0;
         virtual void XM_CALLCONV SetProjection(FXMMATRIX value) = 0;
@@ -64,6 +60,8 @@ namespace DirectX
 
     protected:
         IEffectMatrices() = default;
+        IEffectMatrices(IEffectMatrices&&) = default;
+        IEffectMatrices& operator=(IEffectMatrices&&) = default;
     };
 
 
@@ -75,9 +73,6 @@ namespace DirectX
 
         IEffectLights(const IEffectLights&) = delete;
         IEffectLights& operator=(const IEffectLights&) = delete;
-
-        IEffectLights(IEffectLights&&) = delete;
-        IEffectLights& operator=(IEffectLights&&) = delete;
 
         virtual void __cdecl SetLightingEnabled(bool value) = 0;
         virtual void __cdecl SetPerPixelLighting(bool value) = 0;
@@ -94,6 +89,8 @@ namespace DirectX
 
     protected:
         IEffectLights() = default;
+        IEffectLights(IEffectLights&&) = default;
+        IEffectLights& operator=(IEffectLights&&) = default;
     };
 
 
@@ -106,9 +103,6 @@ namespace DirectX
         IEffectFog(const IEffectFog&) = delete;
         IEffectFog& operator=(const IEffectFog&) = delete;
 
-        IEffectFog(IEffectFog&&) = delete;
-        IEffectFog& operator=(IEffectFog&&) = delete;
-
         virtual void __cdecl SetFogEnabled(bool value) = 0;
         virtual void __cdecl SetFogStart(float value) = 0;
         virtual void __cdecl SetFogEnd(float value) = 0;
@@ -116,6 +110,8 @@ namespace DirectX
 
     protected:
         IEffectFog() = default;
+        IEffectFog(IEffectFog&&) = default;
+        IEffectFog& operator=(IEffectFog&&) = default;
     };
 
 
@@ -128,9 +124,6 @@ namespace DirectX
         IEffectSkinning(const IEffectSkinning&) = delete;
         IEffectSkinning& operator=(const IEffectSkinning&) = delete;
 
-        IEffectSkinning(IEffectSkinning&&) = delete;
-        IEffectSkinning& operator=(IEffectSkinning&&) = delete;
-
         virtual void __cdecl SetWeightsPerVertex(int value) = 0;
         virtual void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) = 0;
         virtual void __cdecl ResetBoneTransforms() = 0;
@@ -139,6 +132,8 @@ namespace DirectX
 
     protected:
         IEffectSkinning() = default;
+        IEffectSkinning(IEffectSkinning&&) = default;
+        IEffectSkinning& operator=(IEffectSkinning&&) = default;
     };
 
     //----------------------------------------------------------------------------------
@@ -147,8 +142,9 @@ namespace DirectX
     {
     public:
         explicit BasicEffect(_In_ ID3D11Device* device);
-        BasicEffect(BasicEffect&& moveFrom) noexcept;
-        BasicEffect& operator= (BasicEffect&& moveFrom) noexcept;
+
+        BasicEffect(BasicEffect&&) noexcept;
+        BasicEffect& operator= (BasicEffect&&) noexcept;
 
         BasicEffect(BasicEffect const&) = delete;
         BasicEffect& operator= (BasicEffect const&) = delete;
@@ -217,8 +213,9 @@ namespace DirectX
     {
     public:
         explicit AlphaTestEffect(_In_ ID3D11Device* device);
-        AlphaTestEffect(AlphaTestEffect&& moveFrom) noexcept;
-        AlphaTestEffect& operator= (AlphaTestEffect&& moveFrom) noexcept;
+
+        AlphaTestEffect(AlphaTestEffect&&) noexcept;
+        AlphaTestEffect& operator= (AlphaTestEffect&&) noexcept;
 
         AlphaTestEffect(AlphaTestEffect const&) = delete;
         AlphaTestEffect& operator= (AlphaTestEffect const&) = delete;
@@ -271,8 +268,9 @@ namespace DirectX
     {
     public:
         explicit DualTextureEffect(_In_ ID3D11Device* device);
-        DualTextureEffect(DualTextureEffect&& moveFrom) noexcept;
-        DualTextureEffect& operator= (DualTextureEffect&& moveFrom) noexcept;
+
+        DualTextureEffect(DualTextureEffect&&) noexcept;
+        DualTextureEffect& operator= (DualTextureEffect&&) noexcept;
 
         DualTextureEffect(DualTextureEffect const&) = delete;
         DualTextureEffect& operator= (DualTextureEffect const&) = delete;
@@ -329,8 +327,9 @@ namespace DirectX
         };
 
         explicit EnvironmentMapEffect(_In_ ID3D11Device* device);
-        EnvironmentMapEffect(EnvironmentMapEffect&& moveFrom) noexcept;
-        EnvironmentMapEffect& operator= (EnvironmentMapEffect&& moveFrom) noexcept;
+
+        EnvironmentMapEffect(EnvironmentMapEffect&&) noexcept;
+        EnvironmentMapEffect& operator= (EnvironmentMapEffect&&) noexcept;
 
         EnvironmentMapEffect(EnvironmentMapEffect const&) = delete;
         EnvironmentMapEffect& operator= (EnvironmentMapEffect const&) = delete;
@@ -401,8 +400,9 @@ namespace DirectX
     {
     public:
         explicit SkinnedEffect(_In_ ID3D11Device* device);
-        SkinnedEffect(SkinnedEffect&& moveFrom) noexcept;
-        SkinnedEffect& operator= (SkinnedEffect&& moveFrom) noexcept;
+
+        SkinnedEffect(SkinnedEffect&&) noexcept;
+        SkinnedEffect& operator= (SkinnedEffect&&) noexcept;
 
         SkinnedEffect(SkinnedEffect const&) = delete;
         SkinnedEffect& operator= (SkinnedEffect const&) = delete;
@@ -474,8 +474,9 @@ namespace DirectX
     public:
         explicit DGSLEffect(_In_ ID3D11Device* device, _In_opt_ ID3D11PixelShader* pixelShader = nullptr,
                             _In_ bool enableSkinning = false);
-        DGSLEffect(DGSLEffect&& moveFrom) noexcept;
-        DGSLEffect& operator= (DGSLEffect&& moveFrom) noexcept;
+
+        DGSLEffect(DGSLEffect&&) noexcept;
+        DGSLEffect& operator= (DGSLEffect&&) noexcept;
 
         DGSLEffect(DGSLEffect const&) = delete;
         DGSLEffect& operator= (DGSLEffect const&) = delete;
@@ -553,8 +554,9 @@ namespace DirectX
     {
     public:
         explicit NormalMapEffect(_In_ ID3D11Device* device);
-        NormalMapEffect(NormalMapEffect&& moveFrom) noexcept;
-        NormalMapEffect& operator= (NormalMapEffect&& moveFrom) noexcept;
+
+        NormalMapEffect(NormalMapEffect&&) noexcept;
+        NormalMapEffect& operator= (NormalMapEffect&&) noexcept;
 
         NormalMapEffect(NormalMapEffect const&) = delete;
         NormalMapEffect& operator= (NormalMapEffect const&) = delete;
@@ -628,8 +630,9 @@ namespace DirectX
     {
     public:
         explicit PBREffect(_In_ ID3D11Device* device);
-        PBREffect(PBREffect&& moveFrom) noexcept;
-        PBREffect& operator= (PBREffect&& moveFrom) noexcept;
+
+        PBREffect(PBREffect&&) noexcept;
+        PBREffect& operator= (PBREffect&&) noexcept;
 
         PBREffect(PBREffect const&) = delete;
         PBREffect& operator= (PBREffect const&) = delete;
@@ -716,8 +719,9 @@ namespace DirectX
         };
 
         explicit DebugEffect(_In_ ID3D11Device* device);
-        DebugEffect(DebugEffect&& moveFrom) noexcept;
-        DebugEffect& operator= (DebugEffect&& moveFrom) noexcept;
+
+        DebugEffect(DebugEffect&&) noexcept;
+        DebugEffect& operator= (DebugEffect&&) noexcept;
 
         DebugEffect(DebugEffect const&) = delete;
         DebugEffect& operator= (DebugEffect const&) = delete;
@@ -766,9 +770,6 @@ namespace DirectX
         IEffectFactory(const IEffectFactory&) = delete;
         IEffectFactory& operator=(const IEffectFactory&) = delete;
 
-        IEffectFactory(IEffectFactory&&) = delete;
-        IEffectFactory& operator=(IEffectFactory&&) = delete;
-
         struct EffectInfo
         {
             const wchar_t*      name;
@@ -814,6 +815,8 @@ namespace DirectX
 
     protected:
         IEffectFactory() = default;
+        IEffectFactory(IEffectFactory&&) = default;
+        IEffectFactory& operator=(IEffectFactory&&) = default;
     };
 
 
@@ -822,8 +825,9 @@ namespace DirectX
     {
     public:
         explicit EffectFactory(_In_ ID3D11Device* device);
-        EffectFactory(EffectFactory&& moveFrom) noexcept;
-        EffectFactory& operator= (EffectFactory&& moveFrom) noexcept;
+
+        EffectFactory(EffectFactory&&) noexcept;
+        EffectFactory& operator= (EffectFactory&&) noexcept;
 
         EffectFactory(EffectFactory const&) = delete;
         EffectFactory& operator= (EffectFactory const&) = delete;
@@ -860,8 +864,9 @@ namespace DirectX
     {
     public:
         explicit PBREffectFactory(_In_ ID3D11Device* device);
-        PBREffectFactory(PBREffectFactory&& moveFrom) noexcept;
-        PBREffectFactory& operator= (PBREffectFactory&& moveFrom) noexcept;
+
+        PBREffectFactory(PBREffectFactory&&) noexcept;
+        PBREffectFactory& operator= (PBREffectFactory&&) noexcept;
 
         PBREffectFactory(PBREffectFactory const&) = delete;
         PBREffectFactory& operator= (PBREffectFactory const&) = delete;
@@ -897,8 +902,9 @@ namespace DirectX
     {
     public:
         explicit DGSLEffectFactory(_In_ ID3D11Device* device);
-        DGSLEffectFactory(DGSLEffectFactory&& moveFrom) noexcept;
-        DGSLEffectFactory& operator= (DGSLEffectFactory&& moveFrom) noexcept;
+
+        DGSLEffectFactory(DGSLEffectFactory&&) noexcept;
+        DGSLEffectFactory& operator= (DGSLEffectFactory&&) noexcept;
 
         DGSLEffectFactory(DGSLEffectFactory const&) = delete;
         DGSLEffectFactory& operator= (DGSLEffectFactory const&) = delete;

--- a/Inc/GamePad.h
+++ b/Inc/GamePad.h
@@ -46,8 +46,9 @@ namespace DirectX
     {
     public:
         GamePad() noexcept(false);
-        GamePad(GamePad&& moveFrom) noexcept;
-        GamePad& operator= (GamePad&& moveFrom) noexcept;
+
+        GamePad(GamePad&&) noexcept;
+        GamePad& operator= (GamePad&&) noexcept;
 
         GamePad(GamePad const&) = delete;
         GamePad& operator=(GamePad const&) = delete;

--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -29,8 +29,9 @@ namespace DirectX
     #else
         GraphicsMemory(_In_ ID3D11Device* device, unsigned int backBufferCount = 2);
     #endif
-        GraphicsMemory(GraphicsMemory&& moveFrom) noexcept;
-        GraphicsMemory& operator= (GraphicsMemory&& moveFrom) noexcept;
+
+        GraphicsMemory(GraphicsMemory&&) noexcept;
+        GraphicsMemory& operator= (GraphicsMemory&&) noexcept;
 
         GraphicsMemory(GraphicsMemory const&) = delete;
         GraphicsMemory& operator=(GraphicsMemory const&) = delete;

--- a/Inc/Keyboard.h
+++ b/Inc/Keyboard.h
@@ -29,8 +29,9 @@ namespace DirectX
     {
     public:
         Keyboard() noexcept(false);
-        Keyboard(Keyboard&& moveFrom) noexcept;
-        Keyboard& operator= (Keyboard&& moveFrom) noexcept;
+
+        Keyboard(Keyboard&&) noexcept;
+        Keyboard& operator= (Keyboard&&) noexcept;
 
         Keyboard(Keyboard const&) = delete;
         Keyboard& operator=(Keyboard const&) = delete;

--- a/Inc/Mouse.h
+++ b/Inc/Mouse.h
@@ -28,8 +28,9 @@ namespace DirectX
     {
     public:
         Mouse() noexcept(false);
-        Mouse(Mouse&& moveFrom) noexcept;
-        Mouse& operator= (Mouse&& moveFrom) noexcept;
+
+        Mouse(Mouse&&) noexcept;
+        Mouse& operator= (Mouse&&) noexcept;
 
         Mouse(Mouse const&) = delete;
         Mouse& operator=(Mouse const&) = delete;

--- a/Inc/PostProcess.h
+++ b/Inc/PostProcess.h
@@ -33,14 +33,13 @@ namespace DirectX
         IPostProcess(const IPostProcess&) = delete;
         IPostProcess& operator=(const IPostProcess&) = delete;
 
-        IPostProcess(IPostProcess&&) = delete;
-        IPostProcess& operator=(IPostProcess&&) = delete;
-
         virtual void __cdecl Process(_In_ ID3D11DeviceContext* deviceContext,
             _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) = 0;
 
     protected:
         IPostProcess() = default;
+        IPostProcess(IPostProcess&&) = default;
+        IPostProcess& operator=(IPostProcess&&) = default;
     };
 
 
@@ -63,8 +62,9 @@ namespace DirectX
         };
 
         explicit BasicPostProcess(_In_ ID3D11Device* device);
-        BasicPostProcess(BasicPostProcess&& moveFrom) noexcept;
-        BasicPostProcess& operator= (BasicPostProcess&& moveFrom) noexcept;
+
+        BasicPostProcess(BasicPostProcess&&) noexcept;
+        BasicPostProcess& operator= (BasicPostProcess&&) noexcept;
 
         BasicPostProcess(BasicPostProcess const&) = delete;
         BasicPostProcess& operator= (BasicPostProcess const&) = delete;
@@ -112,8 +112,9 @@ namespace DirectX
         };
 
         explicit DualPostProcess(_In_ ID3D11Device* device);
-        DualPostProcess(DualPostProcess&& moveFrom) noexcept;
-        DualPostProcess& operator= (DualPostProcess&& moveFrom) noexcept;
+
+        DualPostProcess(DualPostProcess&&) noexcept;
+        DualPostProcess& operator= (DualPostProcess&&) noexcept;
 
         DualPostProcess(DualPostProcess const&) = delete;
         DualPostProcess& operator= (DualPostProcess const&) = delete;
@@ -178,8 +179,9 @@ namespace DirectX
         };
 
         explicit ToneMapPostProcess(_In_ ID3D11Device* device);
-        ToneMapPostProcess(ToneMapPostProcess&& moveFrom) noexcept;
-        ToneMapPostProcess& operator= (ToneMapPostProcess&& moveFrom) noexcept;
+
+        ToneMapPostProcess(ToneMapPostProcess&&) noexcept;
+        ToneMapPostProcess& operator= (ToneMapPostProcess&&) noexcept;
 
         ToneMapPostProcess(ToneMapPostProcess const&) = delete;
         ToneMapPostProcess& operator= (ToneMapPostProcess const&) = delete;

--- a/Inc/PrimitiveBatch.h
+++ b/Inc/PrimitiveBatch.h
@@ -31,8 +31,9 @@ namespace DirectX
         {
         protected:
             PrimitiveBatchBase(_In_ ID3D11DeviceContext* deviceContext, size_t maxIndices, size_t maxVertices, size_t vertexSize);
-            PrimitiveBatchBase(PrimitiveBatchBase&& moveFrom) noexcept;
-            PrimitiveBatchBase& operator= (PrimitiveBatchBase&& moveFrom) noexcept;
+
+            PrimitiveBatchBase(PrimitiveBatchBase&&) noexcept;
+            PrimitiveBatchBase& operator= (PrimitiveBatchBase&&) noexcept;
 
             PrimitiveBatchBase(PrimitiveBatchBase const&) = delete;
             PrimitiveBatchBase& operator= (PrimitiveBatchBase const&) = delete;
@@ -68,15 +69,8 @@ namespace DirectX
             : PrimitiveBatchBase(deviceContext, maxIndices, maxVertices, sizeof(TVertex))
         { }
 
-        PrimitiveBatch(PrimitiveBatch&& moveFrom) noexcept
-            : PrimitiveBatchBase(std::move(moveFrom))
-        { }
-
-        PrimitiveBatch& operator= (PrimitiveBatch&& moveFrom) noexcept
-        {
-            PrimitiveBatchBase::operator=(std::move(moveFrom));
-            return *this;
-        }
+        PrimitiveBatch(PrimitiveBatch&&) = default;
+        PrimitiveBatch& operator= (PrimitiveBatch&&) = default;
 
         PrimitiveBatch(PrimitiveBatch const&) = delete;
         PrimitiveBatch& operator= (PrimitiveBatch const&) = delete;

--- a/Inc/SpriteBatch.h
+++ b/Inc/SpriteBatch.h
@@ -49,8 +49,9 @@ namespace DirectX
     {
     public:
         explicit SpriteBatch(_In_ ID3D11DeviceContext* deviceContext);
-        SpriteBatch(SpriteBatch&& moveFrom) noexcept;
-        SpriteBatch& operator= (SpriteBatch&& moveFrom) noexcept;
+
+        SpriteBatch(SpriteBatch&&) noexcept;
+        SpriteBatch& operator= (SpriteBatch&&) noexcept;
 
         SpriteBatch(SpriteBatch const&) = delete;
         SpriteBatch& operator= (SpriteBatch const&) = delete;

--- a/Inc/SpriteFont.h
+++ b/Inc/SpriteFont.h
@@ -25,8 +25,8 @@ namespace DirectX
         SpriteFont(_In_ ID3D11Device* device, _In_reads_bytes_(dataSize) uint8_t const* dataBlob, _In_ size_t dataSize, bool forceSRGB = false);
         SpriteFont(_In_ ID3D11ShaderResourceView* texture, _In_reads_(glyphCount) Glyph const* glyphs, _In_ size_t glyphCount, _In_ float lineSpacing);
 
-        SpriteFont(SpriteFont&& moveFrom) noexcept;
-        SpriteFont& operator= (SpriteFont&& moveFrom) noexcept;
+        SpriteFont(SpriteFont&&) noexcept;
+        SpriteFont& operator= (SpriteFont&&) noexcept;
 
         SpriteFont(SpriteFont const&) = delete;
         SpriteFont& operator= (SpriteFont const&) = delete;

--- a/Src/AlphaTestEffect.cpp
+++ b/Src/AlphaTestEffect.cpp
@@ -288,7 +288,7 @@ AlphaTestEffect::AlphaTestEffect(_In_ ID3D11Device* device)
 
 AlphaTestEffect::AlphaTestEffect(AlphaTestEffect&&) noexcept = default;
 AlphaTestEffect& AlphaTestEffect::operator= (AlphaTestEffect&&) noexcept = default;
-AlphaTestEffect::~AlphaTestEffect() noexcept = default;
+AlphaTestEffect::~AlphaTestEffect() = default;
 
 
 // IEffect methods.

--- a/Src/AlphaTestEffect.cpp
+++ b/Src/AlphaTestEffect.cpp
@@ -286,25 +286,9 @@ AlphaTestEffect::AlphaTestEffect(_In_ ID3D11Device* device)
 }
 
 
-// Move constructor.
-AlphaTestEffect::AlphaTestEffect(AlphaTestEffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-AlphaTestEffect& AlphaTestEffect::operator= (AlphaTestEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-AlphaTestEffect::~AlphaTestEffect()
-{
-}
+AlphaTestEffect::AlphaTestEffect(AlphaTestEffect&&) noexcept = default;
+AlphaTestEffect& AlphaTestEffect::operator= (AlphaTestEffect&&) noexcept = default;
+AlphaTestEffect::~AlphaTestEffect() noexcept = default;
 
 
 // IEffect methods.

--- a/Src/BasicEffect.cpp
+++ b/Src/BasicEffect.cpp
@@ -482,25 +482,9 @@ BasicEffect::BasicEffect(_In_ ID3D11Device* device)
 }
 
 
-// Move constructor.
-BasicEffect::BasicEffect(BasicEffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-BasicEffect& BasicEffect::operator= (BasicEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-BasicEffect::~BasicEffect()
-{
-}
+BasicEffect::BasicEffect(BasicEffect&&) noexcept = default;
+BasicEffect& BasicEffect::operator= (BasicEffect&&) noexcept = default;
+BasicEffect::~BasicEffect() noexcept = default;
 
 
 // IEffect methods.

--- a/Src/BasicEffect.cpp
+++ b/Src/BasicEffect.cpp
@@ -484,7 +484,7 @@ BasicEffect::BasicEffect(_In_ ID3D11Device* device)
 
 BasicEffect::BasicEffect(BasicEffect&&) noexcept = default;
 BasicEffect& BasicEffect::operator= (BasicEffect&&) noexcept = default;
-BasicEffect::~BasicEffect() noexcept = default;
+BasicEffect::~BasicEffect() = default;
 
 
 // IEffect methods.

--- a/Src/BasicPostProcess.cpp
+++ b/Src/BasicPostProcess.cpp
@@ -476,25 +476,9 @@ BasicPostProcess::BasicPostProcess(_In_ ID3D11Device* device)
 }
 
 
-// Move constructor.
-BasicPostProcess::BasicPostProcess(BasicPostProcess&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-BasicPostProcess& BasicPostProcess::operator= (BasicPostProcess&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-BasicPostProcess::~BasicPostProcess()
-{
-}
+BasicPostProcess::BasicPostProcess(BasicPostProcess&&) noexcept = default;
+BasicPostProcess& BasicPostProcess::operator= (BasicPostProcess&&) noexcept = default;
+BasicPostProcess::~BasicPostProcess() noexcept = default;
 
 
 // IPostProcess methods.

--- a/Src/BasicPostProcess.cpp
+++ b/Src/BasicPostProcess.cpp
@@ -478,7 +478,7 @@ BasicPostProcess::BasicPostProcess(_In_ ID3D11Device* device)
 
 BasicPostProcess::BasicPostProcess(BasicPostProcess&&) noexcept = default;
 BasicPostProcess& BasicPostProcess::operator= (BasicPostProcess&&) noexcept = default;
-BasicPostProcess::~BasicPostProcess() noexcept = default;
+BasicPostProcess::~BasicPostProcess() = default;
 
 
 // IPostProcess methods.

--- a/Src/CommonStates.cpp
+++ b/Src/CommonStates.cpp
@@ -171,25 +171,9 @@ CommonStates::CommonStates(_In_ ID3D11Device* device)
 }
 
 
-// Move constructor.
-CommonStates::CommonStates(CommonStates&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-CommonStates& CommonStates::operator= (CommonStates&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-CommonStates::~CommonStates()
-{
-}
+CommonStates::CommonStates(CommonStates&&) noexcept = default;
+CommonStates& CommonStates::operator= (CommonStates&&) noexcept = default;
+CommonStates::~CommonStates() noexcept = default;
 
 
 //--------------------------------------------------------------------------------------

--- a/Src/CommonStates.cpp
+++ b/Src/CommonStates.cpp
@@ -173,7 +173,7 @@ CommonStates::CommonStates(_In_ ID3D11Device* device)
 
 CommonStates::CommonStates(CommonStates&&) noexcept = default;
 CommonStates& CommonStates::operator= (CommonStates&&) noexcept = default;
-CommonStates::~CommonStates() noexcept = default;
+CommonStates::~CommonStates() = default;
 
 
 //--------------------------------------------------------------------------------------

--- a/Src/DGSLEffect.cpp
+++ b/Src/DGSLEffect.cpp
@@ -590,22 +590,9 @@ DGSLEffect::DGSLEffect(_In_ ID3D11Device* device, _In_opt_ ID3D11PixelShader* pi
 }
 
 
-DGSLEffect::DGSLEffect(DGSLEffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-DGSLEffect& DGSLEffect::operator= (DGSLEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-DGSLEffect::~DGSLEffect()
-{
-}
+DGSLEffect::DGSLEffect(DGSLEffect&&) noexcept = default;
+DGSLEffect& DGSLEffect::operator= (DGSLEffect&&) noexcept = default;
+DGSLEffect::~DGSLEffect() noexcept = default;
 
 
 // IEffect methods.

--- a/Src/DGSLEffect.cpp
+++ b/Src/DGSLEffect.cpp
@@ -592,7 +592,7 @@ DGSLEffect::DGSLEffect(_In_ ID3D11Device* device, _In_opt_ ID3D11PixelShader* pi
 
 DGSLEffect::DGSLEffect(DGSLEffect&&) noexcept = default;
 DGSLEffect& DGSLEffect::operator= (DGSLEffect&&) noexcept = default;
-DGSLEffect::~DGSLEffect() noexcept = default;
+DGSLEffect::~DGSLEffect() = default;
 
 
 // IEffect methods.

--- a/Src/DGSLEffectFactory.cpp
+++ b/Src/DGSLEffectFactory.cpp
@@ -522,21 +522,10 @@ DGSLEffectFactory::DGSLEffectFactory(_In_ ID3D11Device* device)
 {
 }
 
-DGSLEffectFactory::~DGSLEffectFactory()
-{
-}
 
-
-DGSLEffectFactory::DGSLEffectFactory(DGSLEffectFactory&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-DGSLEffectFactory& DGSLEffectFactory::operator= (DGSLEffectFactory&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
+DGSLEffectFactory::DGSLEffectFactory(DGSLEffectFactory&&) noexcept = default;
+DGSLEffectFactory& DGSLEffectFactory::operator= (DGSLEffectFactory&&) noexcept = default;
+DGSLEffectFactory::~DGSLEffectFactory() noexcept = default;
 
 
 // IEffectFactory methods

--- a/Src/DGSLEffectFactory.cpp
+++ b/Src/DGSLEffectFactory.cpp
@@ -525,7 +525,7 @@ DGSLEffectFactory::DGSLEffectFactory(_In_ ID3D11Device* device)
 
 DGSLEffectFactory::DGSLEffectFactory(DGSLEffectFactory&&) noexcept = default;
 DGSLEffectFactory& DGSLEffectFactory::operator= (DGSLEffectFactory&&) noexcept = default;
-DGSLEffectFactory::~DGSLEffectFactory() noexcept = default;
+DGSLEffectFactory::~DGSLEffectFactory() = default;
 
 
 // IEffectFactory methods

--- a/Src/DebugEffect.cpp
+++ b/Src/DebugEffect.cpp
@@ -304,7 +304,7 @@ DebugEffect::DebugEffect(_In_ ID3D11Device* device)
 
 DebugEffect::DebugEffect(DebugEffect&&) noexcept = default;
 DebugEffect& DebugEffect::operator= (DebugEffect&&) noexcept = default;
-DebugEffect::~DebugEffect() noexcept = default;
+DebugEffect::~DebugEffect() = default;
 
 
 // IEffect methods.

--- a/Src/DebugEffect.cpp
+++ b/Src/DebugEffect.cpp
@@ -302,25 +302,9 @@ DebugEffect::DebugEffect(_In_ ID3D11Device* device)
 }
 
 
-// Move constructor.
-DebugEffect::DebugEffect(DebugEffect&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-DebugEffect& DebugEffect::operator= (DebugEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-DebugEffect::~DebugEffect()
-{
-}
+DebugEffect::DebugEffect(DebugEffect&&) noexcept = default;
+DebugEffect& DebugEffect::operator= (DebugEffect&&) noexcept = default;
+DebugEffect::~DebugEffect() noexcept = default;
 
 
 // IEffect methods.

--- a/Src/DualPostProcess.cpp
+++ b/Src/DualPostProcess.cpp
@@ -276,7 +276,7 @@ DualPostProcess::DualPostProcess(_In_ ID3D11Device* device)
 
 DualPostProcess::DualPostProcess(DualPostProcess&&) noexcept = default;
 DualPostProcess& DualPostProcess::operator= (DualPostProcess&&) noexcept = default;
-DualPostProcess::~DualPostProcess() noexcept = default;
+DualPostProcess::~DualPostProcess() = default;
 
 
 // IPostProcess methods.

--- a/Src/DualPostProcess.cpp
+++ b/Src/DualPostProcess.cpp
@@ -274,25 +274,9 @@ DualPostProcess::DualPostProcess(_In_ ID3D11Device* device)
 }
 
 
-// Move constructor.
-DualPostProcess::DualPostProcess(DualPostProcess&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-DualPostProcess& DualPostProcess::operator= (DualPostProcess&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-DualPostProcess::~DualPostProcess()
-{
-}
+DualPostProcess::DualPostProcess(DualPostProcess&&) noexcept = default;
+DualPostProcess& DualPostProcess::operator= (DualPostProcess&&) noexcept = default;
+DualPostProcess::~DualPostProcess() noexcept = default;
 
 
 // IPostProcess methods.

--- a/Src/DualTextureEffect.cpp
+++ b/Src/DualTextureEffect.cpp
@@ -190,7 +190,7 @@ DualTextureEffect::DualTextureEffect(_In_ ID3D11Device* device)
 
 DualTextureEffect::DualTextureEffect(DualTextureEffect&&) noexcept = default;
 DualTextureEffect& DualTextureEffect::operator= (DualTextureEffect&&) noexcept = default;
-DualTextureEffect::~DualTextureEffect() noexcept = default;
+DualTextureEffect::~DualTextureEffect() = default;
 
 
 // IEffect methods.

--- a/Src/DualTextureEffect.cpp
+++ b/Src/DualTextureEffect.cpp
@@ -188,25 +188,9 @@ DualTextureEffect::DualTextureEffect(_In_ ID3D11Device* device)
 }
 
 
-// Move constructor.
-DualTextureEffect::DualTextureEffect(DualTextureEffect&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-DualTextureEffect& DualTextureEffect::operator= (DualTextureEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-DualTextureEffect::~DualTextureEffect()
-{
-}
+DualTextureEffect::DualTextureEffect(DualTextureEffect&&) noexcept = default;
+DualTextureEffect& DualTextureEffect::operator= (DualTextureEffect&&) noexcept = default;
+DualTextureEffect::~DualTextureEffect() noexcept = default;
 
 
 // IEffect methods.

--- a/Src/EffectCommon.h
+++ b/Src/EffectCommon.h
@@ -157,6 +157,11 @@ namespace DirectX
             SetDebugObjectName(mConstantBuffer.GetBuffer(), "Effect");
         }
 
+        EffectBase(EffectBase&&) = default;
+        EffectBase& operator= (EffectBase&&) = default;
+
+        EffectBase(EffectBase const&) = delete;
+        EffectBase& operator= (EffectBase const&) = delete;
 
         // Fields.
         typename Traits::ConstantBufferType constants;

--- a/Src/EffectFactory.cpp
+++ b/Src/EffectFactory.cpp
@@ -466,21 +466,11 @@ EffectFactory::EffectFactory(_In_ ID3D11Device* device)
 {
 }
 
-EffectFactory::~EffectFactory()
-{
-}
 
+EffectFactory::EffectFactory(EffectFactory&&) noexcept = default;
+EffectFactory& EffectFactory::operator= (EffectFactory&&) noexcept = default;
+EffectFactory::~EffectFactory() noexcept = default;
 
-EffectFactory::EffectFactory(EffectFactory&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-EffectFactory& EffectFactory::operator= (EffectFactory&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
 
 _Use_decl_annotations_
 std::shared_ptr<IEffect> EffectFactory::CreateEffect(const EffectInfo& info, ID3D11DeviceContext* deviceContext)

--- a/Src/EffectFactory.cpp
+++ b/Src/EffectFactory.cpp
@@ -469,7 +469,7 @@ EffectFactory::EffectFactory(_In_ ID3D11Device* device)
 
 EffectFactory::EffectFactory(EffectFactory&&) noexcept = default;
 EffectFactory& EffectFactory::operator= (EffectFactory&&) noexcept = default;
-EffectFactory::~EffectFactory() noexcept = default;
+EffectFactory::~EffectFactory() = default;
 
 
 _Use_decl_annotations_

--- a/Src/EnvironmentMapEffect.cpp
+++ b/Src/EnvironmentMapEffect.cpp
@@ -467,7 +467,7 @@ EnvironmentMapEffect::EnvironmentMapEffect(_In_ ID3D11Device* device)
 
 EnvironmentMapEffect::EnvironmentMapEffect(EnvironmentMapEffect&&) noexcept = default;
 EnvironmentMapEffect& EnvironmentMapEffect::operator= (EnvironmentMapEffect&&) noexcept = default;
-EnvironmentMapEffect::~EnvironmentMapEffect() noexcept = default;
+EnvironmentMapEffect::~EnvironmentMapEffect() = default;
 
 
 // IEffect methods.

--- a/Src/EnvironmentMapEffect.cpp
+++ b/Src/EnvironmentMapEffect.cpp
@@ -465,25 +465,9 @@ EnvironmentMapEffect::EnvironmentMapEffect(_In_ ID3D11Device* device)
 }
 
 
-// Move constructor.
-EnvironmentMapEffect::EnvironmentMapEffect(EnvironmentMapEffect&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-EnvironmentMapEffect& EnvironmentMapEffect::operator= (EnvironmentMapEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-EnvironmentMapEffect::~EnvironmentMapEffect()
-{
-}
+EnvironmentMapEffect::EnvironmentMapEffect(EnvironmentMapEffect&&) noexcept = default;
+EnvironmentMapEffect& EnvironmentMapEffect::operator= (EnvironmentMapEffect&&) noexcept = default;
+EnvironmentMapEffect::~EnvironmentMapEffect() noexcept = default;
 
 
 // IEffect methods.

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -117,8 +117,8 @@ public:
             &mDeviceToken));
     }
 
-    Impl(Impl&&) noexcept = default;
-    Impl& operator= (Impl&&) noexcept = default;
+    Impl(Impl&&) = default;
+    Impl& operator= (Impl&&) = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -441,8 +441,8 @@ public:
         ScanGamePads();
     }
 
-    Impl(Impl&&) noexcept = default;
-    Impl& operator= (Impl&&) noexcept = default;
+    Impl(Impl&&) = default;
+    Impl& operator= (Impl&&) = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -1606,7 +1606,7 @@ GamePad& GamePad::operator= (GamePad&& moveFrom) noexcept
 
 
 // Public destructor.
-GamePad::~GamePad() noexcept = default;
+GamePad::~GamePad() = default;
 
 
 GamePad::State GamePad::GetState(int player, DeadZone deadZoneMode)

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -117,8 +117,8 @@ public:
             &mDeviceToken));
     }
 
-    Impl(Impl&&) = default;
-    Impl& operator= (Impl&&) = default;
+    Impl(Impl&&) noexcept = default;
+    Impl& operator= (Impl&&) noexcept = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -441,8 +441,8 @@ public:
         ScanGamePads();
     }
 
-    Impl(Impl&&) = default;
-    Impl& operator= (Impl&&) = default;
+    Impl(Impl&&) noexcept = default;
+    Impl& operator= (Impl&&) noexcept = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -1606,9 +1606,7 @@ GamePad& GamePad::operator= (GamePad&& moveFrom) noexcept
 
 
 // Public destructor.
-GamePad::~GamePad()
-{
-}
+GamePad::~GamePad() noexcept = default;
 
 
 GamePad::State GamePad::GetState(int player, DeadZone deadZoneMode)

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -228,8 +228,8 @@ public:
         s_graphicsMemory = this;
     }
 
-    Impl(Impl&&) = default;
-    Impl& operator= (Impl&&) = default;
+    Impl(Impl&&) noexcept = default;
+    Impl& operator= (Impl&&) noexcept = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -301,9 +301,7 @@ GraphicsMemory& GraphicsMemory::operator= (GraphicsMemory&& moveFrom) noexcept
 
 
 // Public destructor.
-GraphicsMemory::~GraphicsMemory()
-{
-}
+GraphicsMemory::~GraphicsMemory() noexcept = default;
 
 
 void* GraphicsMemory::Allocate(_In_opt_ ID3D11DeviceContext* context, size_t size, int alignment)

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -228,8 +228,8 @@ public:
         s_graphicsMemory = this;
     }
 
-    Impl(Impl&&) noexcept = default;
-    Impl& operator= (Impl&&) noexcept = default;
+    Impl(Impl&&) = default;
+    Impl& operator= (Impl&&) = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -301,7 +301,7 @@ GraphicsMemory& GraphicsMemory::operator= (GraphicsMemory&& moveFrom) noexcept
 
 
 // Public destructor.
-GraphicsMemory::~GraphicsMemory() noexcept = default;
+GraphicsMemory::~GraphicsMemory() = default;
 
 
 void* GraphicsMemory::Allocate(_In_opt_ ID3D11DeviceContext* context, size_t size, int alignment)

--- a/Src/Keyboard.cpp
+++ b/Src/Keyboard.cpp
@@ -84,8 +84,8 @@ public:
             &mDeviceToken));
     }
 
-    Impl(Impl&&) noexcept = default;
-    Impl& operator= (Impl&&) noexcept = default;
+    Impl(Impl&&) = default;
+    Impl& operator= (Impl&&) = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -215,8 +215,8 @@ public:
         s_keyboard = this;
     }
 
-    Impl(Impl&&) noexcept = default;
-    Impl& operator= (Impl&&) noexcept = default;
+    Impl(Impl&&) = default;
+    Impl& operator= (Impl&&) = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -576,7 +576,7 @@ Keyboard& Keyboard::operator= (Keyboard&& moveFrom) noexcept
 
 
 // Public destructor.
-Keyboard::~Keyboard() noexcept = default;
+Keyboard::~Keyboard() = default;
 
 
 Keyboard::State Keyboard::GetState() const

--- a/Src/Keyboard.cpp
+++ b/Src/Keyboard.cpp
@@ -84,8 +84,8 @@ public:
             &mDeviceToken));
     }
 
-    Impl(Impl&&) = default;
-    Impl& operator= (Impl&&) = default;
+    Impl(Impl&&) noexcept = default;
+    Impl& operator= (Impl&&) noexcept = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -215,8 +215,8 @@ public:
         s_keyboard = this;
     }
 
-    Impl(Impl&&) = default;
-    Impl& operator= (Impl&&) = default;
+    Impl(Impl&&) noexcept = default;
+    Impl& operator= (Impl&&) noexcept = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -576,9 +576,7 @@ Keyboard& Keyboard::operator= (Keyboard&& moveFrom) noexcept
 
 
 // Public destructor.
-Keyboard::~Keyboard()
-{
-}
+Keyboard::~Keyboard() noexcept = default;
 
 
 Keyboard::State Keyboard::GetState() const

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -90,8 +90,8 @@ public:
         }
     }
 
-    Impl(Impl&&) noexcept = default;
-    Impl& operator= (Impl&&) noexcept = default;
+    Impl(Impl&&) = default;
+    Impl& operator= (Impl&&) = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -463,8 +463,8 @@ public:
         }
     }
 
-    Impl(Impl&&) noexcept = default;
-    Impl& operator= (Impl&&) noexcept = default;
+    Impl(Impl&&) = default;
+    Impl& operator= (Impl&&) = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -1419,7 +1419,7 @@ Mouse& Mouse::operator= (Mouse&& moveFrom) noexcept
 
 
 // Public destructor.
-Mouse::~Mouse() noexcept = default;
+Mouse::~Mouse() = default;
 
 
 Mouse::State Mouse::GetState() const

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -90,8 +90,8 @@ public:
         }
     }
 
-    Impl(Impl&&) = default;
-    Impl& operator= (Impl&&) = default;
+    Impl(Impl&&) noexcept = default;
+    Impl& operator= (Impl&&) noexcept = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -463,8 +463,8 @@ public:
         }
     }
 
-    Impl(Impl&&) = default;
-    Impl& operator= (Impl&&) = default;
+    Impl(Impl&&) noexcept = default;
+    Impl& operator= (Impl&&) noexcept = default;
 
     Impl(Impl const&) = delete;
     Impl& operator= (Impl const&) = delete;
@@ -1419,9 +1419,7 @@ Mouse& Mouse::operator= (Mouse&& moveFrom) noexcept
 
 
 // Public destructor.
-Mouse::~Mouse()
-{
-}
+Mouse::~Mouse() noexcept = default;
 
 
 Mouse::State Mouse::GetState() const

--- a/Src/NormalMapEffect.cpp
+++ b/Src/NormalMapEffect.cpp
@@ -326,7 +326,7 @@ NormalMapEffect::NormalMapEffect(_In_ ID3D11Device* device)
 
 NormalMapEffect::NormalMapEffect(NormalMapEffect&&) noexcept = default;
 NormalMapEffect& NormalMapEffect::operator= (NormalMapEffect&&) noexcept = default;
-NormalMapEffect::~NormalMapEffect() noexcept = default;
+NormalMapEffect::~NormalMapEffect() = default;
 
 
 // IEffect methods.

--- a/Src/NormalMapEffect.cpp
+++ b/Src/NormalMapEffect.cpp
@@ -324,25 +324,9 @@ NormalMapEffect::NormalMapEffect(_In_ ID3D11Device* device)
 }
 
 
-// Move constructor.
-NormalMapEffect::NormalMapEffect(NormalMapEffect&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-NormalMapEffect& NormalMapEffect::operator= (NormalMapEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-NormalMapEffect::~NormalMapEffect()
-{
-}
+NormalMapEffect::NormalMapEffect(NormalMapEffect&&) noexcept = default;
+NormalMapEffect& NormalMapEffect::operator= (NormalMapEffect&&) noexcept = default;
+NormalMapEffect::~NormalMapEffect() noexcept = default;
 
 
 // IEffect methods.

--- a/Src/PBREffect.cpp
+++ b/Src/PBREffect.cpp
@@ -329,7 +329,7 @@ PBREffect::PBREffect(_In_ ID3D11Device* device)
 
 PBREffect::PBREffect(PBREffect&&) noexcept = default;
 PBREffect& PBREffect::operator= (PBREffect&&) noexcept = default;
-PBREffect::~PBREffect() noexcept = default;
+PBREffect::~PBREffect() = default;
 
 
 // IEffect methods.

--- a/Src/PBREffect.cpp
+++ b/Src/PBREffect.cpp
@@ -327,25 +327,9 @@ PBREffect::PBREffect(_In_ ID3D11Device* device)
 }
 
 
-// Move constructor.
-PBREffect::PBREffect(PBREffect&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-PBREffect& PBREffect::operator= (PBREffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-PBREffect::~PBREffect()
-{
-}
+PBREffect::PBREffect(PBREffect&&) noexcept = default;
+PBREffect& PBREffect::operator= (PBREffect&&) noexcept = default;
+PBREffect::~PBREffect() noexcept = default;
 
 
 // IEffect methods.

--- a/Src/PBREffectFactory.cpp
+++ b/Src/PBREffectFactory.cpp
@@ -236,7 +236,7 @@ PBREffectFactory::PBREffectFactory(_In_ ID3D11Device* device)
 
 PBREffectFactory::PBREffectFactory(PBREffectFactory&&) noexcept = default;
 PBREffectFactory& PBREffectFactory::operator= (PBREffectFactory&&) noexcept = default;
-PBREffectFactory::~PBREffectFactory() noexcept = default;
+PBREffectFactory::~PBREffectFactory() = default;
 
 
 _Use_decl_annotations_

--- a/Src/PBREffectFactory.cpp
+++ b/Src/PBREffectFactory.cpp
@@ -233,21 +233,11 @@ PBREffectFactory::PBREffectFactory(_In_ ID3D11Device* device)
 {
 }
 
-PBREffectFactory::~PBREffectFactory()
-{
-}
 
+PBREffectFactory::PBREffectFactory(PBREffectFactory&&) noexcept = default;
+PBREffectFactory& PBREffectFactory::operator= (PBREffectFactory&&) noexcept = default;
+PBREffectFactory::~PBREffectFactory() noexcept = default;
 
-PBREffectFactory::PBREffectFactory(PBREffectFactory&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-PBREffectFactory& PBREffectFactory::operator= (PBREffectFactory&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
 
 _Use_decl_annotations_
 std::shared_ptr<IEffect> PBREffectFactory::CreateEffect(const EffectInfo& info, ID3D11DeviceContext* deviceContext)

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -427,7 +427,7 @@ PrimitiveBatchBase::PrimitiveBatchBase(_In_ ID3D11DeviceContext* deviceContext, 
 
 PrimitiveBatchBase::PrimitiveBatchBase(PrimitiveBatchBase&&) noexcept = default;
 PrimitiveBatchBase& PrimitiveBatchBase::operator= (PrimitiveBatchBase&&) noexcept = default;
-PrimitiveBatchBase::~PrimitiveBatchBase() noexcept = default;
+PrimitiveBatchBase::~PrimitiveBatchBase() = default;
 
 
 // Begin a primitive batch.

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -425,39 +425,26 @@ PrimitiveBatchBase::PrimitiveBatchBase(_In_ ID3D11DeviceContext* deviceContext, 
 }
 
 
-// Move constructor.
-PrimitiveBatchBase::PrimitiveBatchBase(PrimitiveBatchBase&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
+PrimitiveBatchBase::PrimitiveBatchBase(PrimitiveBatchBase&&) noexcept = default;
+PrimitiveBatchBase& PrimitiveBatchBase::operator= (PrimitiveBatchBase&&) noexcept = default;
+PrimitiveBatchBase::~PrimitiveBatchBase() noexcept = default;
 
 
-// Move assignment.
-PrimitiveBatchBase& PrimitiveBatchBase::operator= (PrimitiveBatchBase&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-PrimitiveBatchBase::~PrimitiveBatchBase()
-{
-}
-
-
+// Begin a primitive batch.
 void PrimitiveBatchBase::Begin()
 {
     pImpl->Begin();
 }
 
 
+// End/draw a primitive batch.
 void PrimitiveBatchBase::End()
 {
     pImpl->End();
 }
 
 
+// Custom draw method.
 _Use_decl_annotations_
 void PrimitiveBatchBase::Draw(D3D11_PRIMITIVE_TOPOLOGY topology, bool isIndexed, uint16_t const* indices, size_t indexCount, size_t vertexCount, void** pMappedVertices)
 {

--- a/Src/SkinnedEffect.cpp
+++ b/Src/SkinnedEffect.cpp
@@ -367,7 +367,7 @@ SkinnedEffect::SkinnedEffect(_In_ ID3D11Device* device)
 
 SkinnedEffect::SkinnedEffect(SkinnedEffect&&) noexcept = default;
 SkinnedEffect& SkinnedEffect::operator= (SkinnedEffect&&) noexcept = default;
-SkinnedEffect::~SkinnedEffect() noexcept = default;
+SkinnedEffect::~SkinnedEffect() = default;
 
 
 // IEffect methods.

--- a/Src/SkinnedEffect.cpp
+++ b/Src/SkinnedEffect.cpp
@@ -365,25 +365,9 @@ SkinnedEffect::SkinnedEffect(_In_ ID3D11Device* device)
 }
 
 
-// Move constructor.
-SkinnedEffect::SkinnedEffect(SkinnedEffect&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-SkinnedEffect& SkinnedEffect::operator= (SkinnedEffect&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-SkinnedEffect::~SkinnedEffect()
-{
-}
+SkinnedEffect::SkinnedEffect(SkinnedEffect&&) noexcept = default;
+SkinnedEffect& SkinnedEffect::operator= (SkinnedEffect&&) noexcept = default;
+SkinnedEffect::~SkinnedEffect() noexcept = default;
 
 
 // IEffect methods.

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -1016,25 +1016,9 @@ SpriteBatch::SpriteBatch(_In_ ID3D11DeviceContext* deviceContext)
 }
 
 
-// Move constructor.
-SpriteBatch::SpriteBatch(SpriteBatch&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-SpriteBatch& SpriteBatch::operator= (SpriteBatch&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-SpriteBatch::~SpriteBatch()
-{
-}
+SpriteBatch::SpriteBatch(SpriteBatch&&) noexcept = default;
+SpriteBatch& SpriteBatch::operator= (SpriteBatch&&) noexcept = default;
+SpriteBatch::~SpriteBatch() noexcept = default;
 
 
 _Use_decl_annotations_

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -1018,7 +1018,7 @@ SpriteBatch::SpriteBatch(_In_ ID3D11DeviceContext* deviceContext)
 
 SpriteBatch::SpriteBatch(SpriteBatch&&) noexcept = default;
 SpriteBatch& SpriteBatch::operator= (SpriteBatch&&) noexcept = default;
-SpriteBatch::~SpriteBatch() noexcept = default;
+SpriteBatch::~SpriteBatch() = default;
 
 
 _Use_decl_annotations_

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -391,25 +391,9 @@ SpriteFont::SpriteFont(ID3D11ShaderResourceView* texture, Glyph const* glyphs, s
 }
 
 
-// Move constructor.
-SpriteFont::SpriteFont(SpriteFont&& moveFrom) noexcept
-    : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-SpriteFont& SpriteFont::operator= (SpriteFont&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-SpriteFont::~SpriteFont()
-{
-}
+SpriteFont::SpriteFont(SpriteFont&&) noexcept = default;
+SpriteFont& SpriteFont::operator= (SpriteFont&&) noexcept = default;
+SpriteFont::~SpriteFont() noexcept = default;
 
 
 // Wide-character / UTF-16LE

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -393,7 +393,7 @@ SpriteFont::SpriteFont(ID3D11ShaderResourceView* texture, Glyph const* glyphs, s
 
 SpriteFont::SpriteFont(SpriteFont&&) noexcept = default;
 SpriteFont& SpriteFont::operator= (SpriteFont&&) noexcept = default;
-SpriteFont::~SpriteFont() noexcept = default;
+SpriteFont::~SpriteFont() = default;
 
 
 // Wide-character / UTF-16LE

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -386,7 +386,7 @@ ToneMapPostProcess::ToneMapPostProcess(_In_ ID3D11Device* device)
 
 ToneMapPostProcess::ToneMapPostProcess(ToneMapPostProcess&&) noexcept = default;
 ToneMapPostProcess& ToneMapPostProcess::operator= (ToneMapPostProcess&&) noexcept = default;
-ToneMapPostProcess::~ToneMapPostProcess() noexcept = default;
+ToneMapPostProcess::~ToneMapPostProcess() = default;
 
 
 // IPostProcess methods.

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -384,25 +384,9 @@ ToneMapPostProcess::ToneMapPostProcess(_In_ ID3D11Device* device)
 }
 
 
-// Move constructor.
-ToneMapPostProcess::ToneMapPostProcess(ToneMapPostProcess&& moveFrom) noexcept
-  : pImpl(std::move(moveFrom.pImpl))
-{
-}
-
-
-// Move assignment.
-ToneMapPostProcess& ToneMapPostProcess::operator= (ToneMapPostProcess&& moveFrom) noexcept
-{
-    pImpl = std::move(moveFrom.pImpl);
-    return *this;
-}
-
-
-// Public destructor.
-ToneMapPostProcess::~ToneMapPostProcess()
-{
-}
+ToneMapPostProcess::ToneMapPostProcess(ToneMapPostProcess&&) noexcept = default;
+ToneMapPostProcess& ToneMapPostProcess::operator= (ToneMapPostProcess&&) noexcept = default;
+ToneMapPostProcess::~ToneMapPostProcess() noexcept = default;
 
 
 // IPostProcess methods.


### PR DESCRIPTION
The pImpl code pattern used in this library dates back to VS 2013 which did not have support for ``=default`` or the auto-generation of move ctors/ops.

Care still needs to be taken due to pImpl, but the bodies of many of the functions can be replaced with ``=default``.