### PR TITLE
Add more Quaternion methods for SimpleMath

### DIFF
--- a/Inc/SimpleMath.h
+++ b/Inc/SimpleMath.h
@@ -714,7 +714,7 @@ namespace DirectX
             float Dot(const Quaternion& Q) const noexcept;
 
             void RotateTowards(const Quaternion& target, float maxAngle) noexcept;
-            void RotateTowards(const Quaternion& target, float maxAngle, Quaternion& result) const noexcept;
+            void __cdecl RotateTowards(const Quaternion& target, float maxAngle, Quaternion& result) const noexcept;
 
             // Computes rotation about y-axis (y), then x-axis (x), then z-axis (z)
             Vector3 ToEuler() const noexcept;
@@ -739,10 +739,10 @@ namespace DirectX
             static void Concatenate(const Quaternion& q1, const Quaternion& q2, Quaternion& result) noexcept;
             static Quaternion Concatenate(const Quaternion& q1, const Quaternion& q2) noexcept;
 
-            static void FromToRotation(const Vector3& fromDir, const Vector3& toDir, Quaternion& result) noexcept;
+            static void __cdecl FromToRotation(const Vector3& fromDir, const Vector3& toDir, Quaternion& result) noexcept;
             static Quaternion FromToRotation(const Vector3& fromDir, const Vector3& toDir) noexcept;
 
-            static void LookRotation(const Vector3& forward, const Vector3& up, Quaternion& result) noexcept;
+            static void __cdecl LookRotation(const Vector3& forward, const Vector3& up, Quaternion& result) noexcept;
             static Quaternion LookRotation(const Vector3& forward, const Vector3& up) noexcept;
 
             static float Angle(const Quaternion& q1, const Quaternion& q2) noexcept;

--- a/Inc/SimpleMath.h
+++ b/Inc/SimpleMath.h
@@ -714,6 +714,7 @@ namespace DirectX
             float Dot(const Quaternion& Q) const noexcept;
 
             void RotateTowards(const Quaternion& target, float maxAngle) noexcept;
+            void RotateTowards(const Quaternion& target, float maxAngle, Quaternion& result) const noexcept;
 
             // Computes rotation about y-axis (y), then x-axis (x), then z-axis (z)
             Vector3 ToEuler() const noexcept;
@@ -772,11 +773,11 @@ namespace DirectX
             Color(const XMFLOAT4& c) noexcept { this->x = c.x; this->y = c.y; this->z = c.z; this->w = c.w; }
             explicit Color(const XMVECTORF32& F) noexcept { this->x = F.f[0]; this->y = F.f[1]; this->z = F.f[2]; this->w = F.f[3]; }
 
+            // BGRA Direct3D 9 D3DCOLOR packed color
             explicit Color(const DirectX::PackedVector::XMCOLOR& Packed) noexcept;
-                // BGRA Direct3D 9 D3DCOLOR packed color
 
+            // RGBA XNA Game Studio packed color
             explicit Color(const DirectX::PackedVector::XMUBYTEN4& Packed) noexcept;
-                // RGBA XNA Game Studio packed color
 
             Color(const Color&) = default;
             Color& operator=(const Color&) = default;

--- a/Inc/SimpleMath.h
+++ b/Inc/SimpleMath.h
@@ -744,6 +744,8 @@ namespace DirectX
             static void LookRotation(const Vector3& forward, const Vector3& up, Quaternion& result) noexcept;
             static Quaternion LookRotation(const Vector3& forward, const Vector3& up) noexcept;
 
+            static float Angle(const Quaternion& q1, const Quaternion& q2) noexcept;
+
             // Constants
             static const Quaternion Identity;
         };

--- a/Inc/SimpleMath.h
+++ b/Inc/SimpleMath.h
@@ -713,6 +713,8 @@ namespace DirectX
 
             float Dot(const Quaternion& Q) const noexcept;
 
+            void RotateTowards(const Quaternion& target, float maxAngle) noexcept;
+
             // Computes rotation about y-axis (y), then x-axis (x), then z-axis (z)
             Vector3 ToEuler() const noexcept;
 
@@ -735,6 +737,12 @@ namespace DirectX
 
             static void Concatenate(const Quaternion& q1, const Quaternion& q2, Quaternion& result) noexcept;
             static Quaternion Concatenate(const Quaternion& q1, const Quaternion& q2) noexcept;
+
+            static void FromToRotation(const Vector3& fromDir, const Vector3& toDir, Quaternion& result) noexcept;
+            static Quaternion FromToRotation(const Vector3& fromDir, const Vector3& toDir) noexcept;
+
+            static void LookRotation(const Vector3& forward, const Vector3& up, Quaternion& result) noexcept;
+            static Quaternion LookRotation(const Vector3& forward, const Vector3& up) noexcept;
 
             // Constants
             static const Quaternion Identity;

--- a/Inc/SimpleMath.inl
+++ b/Inc/SimpleMath.inl
@@ -3297,7 +3297,7 @@ inline float Quaternion::Angle(const Quaternion& q1, const Quaternion& q2) noexc
 
     float w = XMVectorGetW(R);
     R = XMVector3Length(R);
-    return 2.f * atan2f(XMVectorGetW(R), w);
+    return 2.f * atan2f(XMVectorGetX(R), w);
 }
 
 

--- a/Inc/SimpleMath.inl
+++ b/Inc/SimpleMath.inl
@@ -3115,6 +3115,11 @@ inline float Quaternion::Dot(const Quaternion& q) const noexcept
     return XMVectorGetX(XMQuaternionDot(q1, q2));
 }
 
+inline void Quaternion::RotateTowards(const Quaternion& target, float maxAngle) noexcept
+{
+    RotateTowards(target, maxAngle, *this);
+}
+
 inline Vector3 Quaternion::ToEuler() const noexcept
 {
     float xx = x * x;
@@ -3293,11 +3298,12 @@ inline float Quaternion::Angle(const Quaternion& q1, const Quaternion& q2) noexc
     XMVECTOR Q0 = XMLoadFloat4(&q1);
     XMVECTOR Q1 = XMLoadFloat4(&q2);
 
+    // We can use the conjugate here instead of inverse assuming q1 & q2 are normalized.
     XMVECTOR R = XMQuaternionMultiply(XMQuaternionConjugate(Q0), Q1);
 
-    float w = XMVectorGetW(R);
+    float rs = XMVectorGetW(R);
     R = XMVector3Length(R);
-    return 2.f * atan2f(XMVectorGetX(R), w);
+    return 2.f * atan2f(XMVectorGetX(R), rs);
 }
 
 

--- a/Inc/SimpleMath.inl
+++ b/Inc/SimpleMath.inl
@@ -3273,6 +3273,19 @@ inline Quaternion Quaternion::Concatenate(const Quaternion& q1, const Quaternion
     return result;
 }
 
+inline Quaternion Quaternion::FromToRotation(const Vector3& fromDir, const Vector3& toDir) noexcept
+{
+    Quaternion result;
+    FromToRotation(fromDir, toDir, result);
+    return result;
+}
+
+inline Quaternion Quaternion::LookRotation(const Vector3& forward, const Vector3& up) noexcept
+{
+    Quaternion result;
+    LookRotation(forward, up, result);
+    return result;
+}
 
 /****************************************************************************
  *

--- a/Inc/SimpleMath.inl
+++ b/Inc/SimpleMath.inl
@@ -3287,6 +3287,17 @@ inline Quaternion Quaternion::LookRotation(const Vector3& forward, const Vector3
     return result;
 }
 
+inline float Angle(const Quaternion& q1, const Quaternion& q2) noexcept
+{
+    using namespace DirectX;
+    XMVECTOR Q0 = XMLoadFloat4(&q1);
+    XMVECTOR Q1 = XMLoadFloat4(&q2);
+
+    XMVECTOR R = XMQuaternionMultiply(XMQuaternionConjugate(Q0), Q1);
+    return 2.f * acosf(XMVectorGetW(R));
+}
+
+
 /****************************************************************************
  *
  * Color

--- a/Inc/SimpleMath.inl
+++ b/Inc/SimpleMath.inl
@@ -3294,7 +3294,10 @@ inline float Quaternion::Angle(const Quaternion& q1, const Quaternion& q2) noexc
     XMVECTOR Q1 = XMLoadFloat4(&q2);
 
     XMVECTOR R = XMQuaternionMultiply(XMQuaternionConjugate(Q0), Q1);
-    return 2.f * acosf(XMVectorGetW(R));
+
+    float w = XMVectorGetW(R);
+    R = XMVector3Length(R);
+    return 2.f * atan2f(XMVectorGetW(R), w);
 }
 
 

--- a/Inc/SimpleMath.inl
+++ b/Inc/SimpleMath.inl
@@ -3287,7 +3287,7 @@ inline Quaternion Quaternion::LookRotation(const Vector3& forward, const Vector3
     return result;
 }
 
-inline float Angle(const Quaternion& q1, const Quaternion& q2) noexcept
+inline float Quaternion::Angle(const Quaternion& q1, const Quaternion& q2) noexcept
 {
     using namespace DirectX;
     XMVECTOR Q0 = XMLoadFloat4(&q1);

--- a/Src/SimpleMath.cpp
+++ b/Src/SimpleMath.cpp
@@ -63,7 +63,7 @@ using namespace DirectX::SimpleMath;
  *
  ****************************************************************************/
 
-void Quaternion::RotateTowards(const Quaternion& target, float maxAngle, Quaternion& result) const noexcept
+void __cdecl Quaternion::RotateTowards(const Quaternion& target, float maxAngle, Quaternion& result) const noexcept
 {
     XMVECTOR T = XMLoadFloat4(this);
 
@@ -86,7 +86,7 @@ void Quaternion::RotateTowards(const Quaternion& target, float maxAngle, Quatern
     }
 }
 
-void Quaternion::FromToRotation(const Vector3& fromDir, const Vector3& toDir, Quaternion& result) noexcept
+void __cdecl Quaternion::FromToRotation(const Vector3& fromDir, const Vector3& toDir, Quaternion& result) noexcept
 {
     // Melax, "The Shortest Arc Quaternion", Game Programming Gems, Charles River Media (2000).
 
@@ -122,7 +122,7 @@ void Quaternion::FromToRotation(const Vector3& fromDir, const Vector3& toDir, Qu
     }
 }
 
-void Quaternion::LookRotation(const Vector3& forward, const Vector3& up, Quaternion& result) noexcept
+void __cdecl Quaternion::LookRotation(const Vector3& forward, const Vector3& up, Quaternion& result) noexcept
 {
     Quaternion q1;
     FromToRotation(Vector3::Forward, forward, q1);

--- a/Src/SimpleMath.cpp
+++ b/Src/SimpleMath.cpp
@@ -63,7 +63,7 @@ using namespace DirectX::SimpleMath;
  *
  ****************************************************************************/
 
-void __cdecl Quaternion::RotateTowards(const Quaternion& target, float maxAngle, Quaternion& result) const noexcept
+void Quaternion::RotateTowards(const Quaternion& target, float maxAngle, Quaternion& result) const noexcept
 {
     XMVECTOR T = XMLoadFloat4(this);
 
@@ -86,7 +86,7 @@ void __cdecl Quaternion::RotateTowards(const Quaternion& target, float maxAngle,
     }
 }
 
-void __cdecl Quaternion::FromToRotation(const Vector3& fromDir, const Vector3& toDir, Quaternion& result) noexcept
+void Quaternion::FromToRotation(const Vector3& fromDir, const Vector3& toDir, Quaternion& result) noexcept
 {
     // Melax, "The Shortest Arc Quaternion", Game Programming Gems, Charles River Media (2000).
 
@@ -122,7 +122,7 @@ void __cdecl Quaternion::FromToRotation(const Vector3& fromDir, const Vector3& t
     }
 }
 
-void __cdecl Quaternion::LookRotation(const Vector3& forward, const Vector3& up, Quaternion& result) noexcept
+void Quaternion::LookRotation(const Vector3& forward, const Vector3& up, Quaternion& result) noexcept
 {
     Quaternion q1;
     FromToRotation(Vector3::Forward, forward, q1);

--- a/Src/SimpleMath.cpp
+++ b/Src/SimpleMath.cpp
@@ -54,8 +54,92 @@ namespace DirectX
     }
 }
 
+using namespace DirectX;
+using namespace DirectX::SimpleMath;
 
 /****************************************************************************
+ *
+ * Quaternion
+ *
+ ****************************************************************************/
+
+void Quaternion::RotateTowards(const Quaternion& target, float maxAngle) noexcept
+{
+    XMVECTOR T = XMLoadFloat4(this);
+    XMVECTOR R = XMQuaternionMultiply(XMQuaternionConjugate(T), target);
+
+    float angle = 2.f * acosf(XMVectorGetW(R));
+    if (angle > maxAngle)
+    {
+        XMVECTOR delta = XMQuaternionRotationAxis(R, maxAngle);
+        XMVECTOR Q = XMQuaternionMultiply(delta, T);
+        XMStoreFloat4(this, Q);
+    }
+    else
+    {
+        // Don't overshoot.
+        *this = target;
+    }
+}
+
+void Quaternion::FromToRotation(const Vector3& fromDir, const Vector3& toDir, Quaternion& result) noexcept
+{
+    // Melax, "The Shortest Arc Quaternion", Game Programming Gems, Charles River Media (2000).
+
+    XMVECTOR F = XMVector3Normalize(fromDir);
+    XMVECTOR T = XMVector3Normalize(toDir);
+
+    float dot = XMVectorGetX(XMVector3Dot(F, T));
+    if (dot >= 1.f)
+    {
+        result = Identity;
+    }
+    else if (dot <= -1.f)
+    {
+        XMVECTOR axis = XMVector3Cross(F, Vector3::Right);
+        if (XMVector3NearEqual(XMVector3LengthSq(axis), g_XMZero, g_XMEpsilon))
+        {
+            axis = XMVector3Cross(F, Vector3::Up);
+        }
+
+        XMVECTOR Q = XMQuaternionRotationAxis(axis, XM_PI);
+        XMStoreFloat4(&result, Q);
+    }
+    else
+    {
+        XMVECTOR C = XMVector3Cross(F, T);
+        XMStoreFloat4(&result, C);
+
+        float s = sqrtf((1.f + dot) * 2.f);
+        result.x /= s;
+        result.y /= s;
+        result.z /= s;
+        result.w = s * 0.5f;
+    }
+}
+
+inline void Quaternion::LookRotation(const Vector3& forward, const Vector3& up, Quaternion& result) noexcept
+{
+    Quaternion q1;
+    FromToRotation(Vector3::Forward, forward, q1);
+
+    XMVECTOR C = XMVector3Cross(forward, up);
+    if (XMVector3NearEqual(XMVector3LengthSq(C), g_XMZero, g_XMEpsilon))
+    {
+        // forward and up are co-linear
+        result = q1;
+    }
+
+    XMVECTOR U = XMQuaternionMultiply(q1, Vector3::Up);
+
+    Quaternion q2;
+    FromToRotation(U, up, q2);
+
+    XMStoreFloat4(&result, XMQuaternionMultiply(q2, q1));
+}
+
+
+ /****************************************************************************
  *
  * Viewport
  *
@@ -82,7 +166,7 @@ static_assert(offsetof(DirectX::SimpleMath::Viewport, maxDepth) == offsetof(D3D1
 #endif
 
 #if defined(__dxgi1_2_h__) || defined(__d3d11_x_h__) || defined(__d3d12_x_h__) || defined(__XBOX_D3D12_X__)
-RECT DirectX::SimpleMath::Viewport::ComputeDisplayArea(DXGI_SCALING scaling, UINT backBufferWidth, UINT backBufferHeight, int outputWidth, int outputHeight) noexcept
+RECT Viewport::ComputeDisplayArea(DXGI_SCALING scaling, UINT backBufferWidth, UINT backBufferHeight, int outputWidth, int outputHeight) noexcept
 {
     RECT rct = {};
 
@@ -143,7 +227,7 @@ RECT DirectX::SimpleMath::Viewport::ComputeDisplayArea(DXGI_SCALING scaling, UIN
 }
 #endif
 
-RECT DirectX::SimpleMath::Viewport::ComputeTitleSafeArea(UINT backBufferWidth, UINT backBufferHeight) noexcept
+RECT Viewport::ComputeTitleSafeArea(UINT backBufferWidth, UINT backBufferHeight) noexcept
 {
     float safew = (float(backBufferWidth) + 19.f) / 20.f;
     float safeh = (float(backBufferHeight) + 19.f) / 20.f;

--- a/Src/SimpleMath.cpp
+++ b/Src/SimpleMath.cpp
@@ -122,7 +122,7 @@ void Quaternion::FromToRotation(const Vector3& fromDir, const Vector3& toDir, Qu
     }
 }
 
-inline void Quaternion::LookRotation(const Vector3& forward, const Vector3& up, Quaternion& result) noexcept
+void Quaternion::LookRotation(const Vector3& forward, const Vector3& up, Quaternion& result) noexcept
 {
     Quaternion q1;
     FromToRotation(Vector3::Forward, forward, q1);
@@ -132,6 +132,7 @@ inline void Quaternion::LookRotation(const Vector3& forward, const Vector3& up, 
     {
         // forward and up are co-linear
         result = q1;
+        return;
     }
 
     XMVECTOR U = XMQuaternionMultiply(q1, Vector3::Up);

--- a/Src/SimpleMath.cpp
+++ b/Src/SimpleMath.cpp
@@ -63,22 +63,26 @@ using namespace DirectX::SimpleMath;
  *
  ****************************************************************************/
 
-void Quaternion::RotateTowards(const Quaternion& target, float maxAngle) noexcept
+void Quaternion::RotateTowards(const Quaternion& target, float maxAngle, Quaternion& result) const noexcept
 {
     XMVECTOR T = XMLoadFloat4(this);
+
+    // We can use the conjugate here instead of inverse assuming q1 & q2 are normalized.
     XMVECTOR R = XMQuaternionMultiply(XMQuaternionConjugate(T), target);
 
-    float angle = 2.f * acosf(XMVectorGetW(R));
+    float rs = XMVectorGetW(R);
+    XMVECTOR L = XMVector3Length(R);
+    float angle = 2.f * atan2f(XMVectorGetX(L), rs);
     if (angle > maxAngle)
     {
         XMVECTOR delta = XMQuaternionRotationAxis(R, maxAngle);
         XMVECTOR Q = XMQuaternionMultiply(delta, T);
-        XMStoreFloat4(this, Q);
+        XMStoreFloat4(&result, Q);
     }
     else
     {
         // Don't overshoot.
-        *this = target;
+        result = target;
     }
 }
 


### PR DESCRIPTION
SimpleMath was based on the methods in the XNA Game Studio math classes. There are a few Quaternion functions that have been added to other math libraries that would be useful to add for Quaternion:

* ``RotateTowards`` which moves a quaternion toward a target quaternion limited by a maximum delta angle
* ``FromToRotation`` which computes a relative rotation between two direction vectors
* ``LookRotation`` which computes a rotation which aligns to a direction and up vector
* ``Angle`` which computes the angle between two quaternion rotations