### PR TITLE
Convert internal functions to use Internal namespace instead of leading underscore

### DIFF
--- a/Audio/WAVFileReader.cpp
+++ b/Audio/WAVFileReader.cpp
@@ -486,18 +486,16 @@ namespace
 
         // open the file
     #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
-        ScopedHandle hFile(safe_handle(CreateFile2(szFileName,
-            GENERIC_READ,
-            FILE_SHARE_READ,
-            OPEN_EXISTING,
+        ScopedHandle hFile(safe_handle(CreateFile2(
+            szFileName,
+            GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
             nullptr)));
     #else
-        ScopedHandle hFile(safe_handle(CreateFileW(szFileName,
-            GENERIC_READ,
-            FILE_SHARE_READ,
+        ScopedHandle hFile(safe_handle(CreateFileW(
+            szFileName,
+            GENERIC_READ, FILE_SHARE_READ,
             nullptr,
-            OPEN_EXISTING,
-            FILE_ATTRIBUTE_NORMAL,
+            OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
             nullptr)));
     #endif
 

--- a/Audio/WaveBankReader.cpp
+++ b/Audio/WaveBankReader.cpp
@@ -519,19 +519,17 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
     CREATEFILE2_EXTENDED_PARAMETERS params = { sizeof(CREATEFILE2_EXTENDED_PARAMETERS), 0, 0, 0, {}, nullptr };
     params.dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
     params.dwFileFlags = FILE_FLAG_OVERLAPPED | FILE_FLAG_SEQUENTIAL_SCAN;
-    ScopedHandle hFile(safe_handle(CreateFile2(szFileName,
-                       GENERIC_READ,
-                       FILE_SHARE_READ,
-                       OPEN_EXISTING,
-                       &params)));
+    ScopedHandle hFile(safe_handle(CreateFile2(
+        szFileName,
+        GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
+        &params)));
 #else
-    ScopedHandle hFile(safe_handle(CreateFileW(szFileName,
-                       GENERIC_READ,
-                       FILE_SHARE_READ,
-                       nullptr,
-                       OPEN_EXISTING,
-                       FILE_FLAG_OVERLAPPED | FILE_FLAG_SEQUENTIAL_SCAN,
-                       nullptr)));
+    ScopedHandle hFile(safe_handle(CreateFileW(
+        szFileName,
+        GENERIC_READ, FILE_SHARE_READ,
+        nullptr,
+        OPEN_EXISTING, FILE_FLAG_OVERLAPPED | FILE_FLAG_SEQUENTIAL_SCAN,
+        nullptr)));
 #endif
 
     if (!hFile)
@@ -554,10 +552,14 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
 
     DWORD bytes;
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+    std::ignore = wait;
+
     BOOL result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
 #else
     if (wait)
+    {
         std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
+    }
 
     BOOL result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
 #endif
@@ -602,7 +604,9 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
     result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
 #else
     if (wait)
+    {
         std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
+    }
 
     result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
 #endif
@@ -686,7 +690,9 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
             result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
         #else
             if (wait)
+            {
                 std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
+            }
 
             result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
         #endif
@@ -737,7 +743,9 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
     result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
 #else
     if (wait)
+    {
         std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
+    }
 
     result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
 #endif
@@ -788,7 +796,9 @@ HRESULT WaveBankReader::Impl::Open(const wchar_t* szFileName) noexcept(false)
         result = GetOverlappedResultEx(hFile.get(), &request, &bytes, INFINITE, FALSE);
     #else
         if (wait)
+        {
             std::ignore = WaitForSingleObject(m_event.get(), INFINITE);
+        }
 
         result = GetOverlappedResult(hFile.get(), &request, &bytes, FALSE);
     #endif

--- a/Src/BinaryReader.cpp
+++ b/Src/BinaryReader.cpp
@@ -56,9 +56,17 @@ HRESULT BinaryReader::ReadEntireFile(
 
     // Open the file.
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
-    ScopedHandle hFile(safe_handle(CreateFile2(fileName, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, nullptr)));
+    ScopedHandle hFile(safe_handle(CreateFile2(
+        fileName,
+        GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
+        nullptr)));
 #else
-    ScopedHandle hFile(safe_handle(CreateFileW(fileName, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)));
+    ScopedHandle hFile(safe_handle(CreateFileW(
+        fileName,
+        GENERIC_READ, FILE_SHARE_READ,
+        nullptr,
+        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+        nullptr)));
 #endif
 
     if (!hFile)

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -366,19 +366,17 @@ namespace DirectX
 
             // open the file
         #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
-            ScopedHandle hFile(safe_handle(CreateFile2(fileName,
-                               GENERIC_READ,
-                               FILE_SHARE_READ,
-                               OPEN_EXISTING,
-                               nullptr)));
+            ScopedHandle hFile(safe_handle(CreateFile2(
+                fileName,
+                GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
+                nullptr)));
         #else
-            ScopedHandle hFile(safe_handle(CreateFileW(fileName,
-                               GENERIC_READ,
-                               FILE_SHARE_READ,
-                               nullptr,
-                               OPEN_EXISTING,
-                               FILE_ATTRIBUTE_NORMAL,
-                               nullptr)));
+            ScopedHandle hFile(safe_handle(CreateFileW(
+                fileName,
+                GENERIC_READ, FILE_SHARE_READ,
+                nullptr,
+                OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+                nullptr)));
         #endif
 
             if (!hFile)

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -186,11 +186,17 @@ HRESULT DirectX::SaveDDSTextureToFile(
 
     // Create file
 #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
-    ScopedHandle hFile(safe_handle(CreateFile2(fileName,
-        GENERIC_WRITE | DELETE, 0, CREATE_ALWAYS, nullptr)));
+    ScopedHandle hFile(safe_handle(CreateFile2(
+        fileName,
+        GENERIC_WRITE | DELETE, 0, CREATE_ALWAYS,
+        nullptr)));
 #else
-    ScopedHandle hFile(safe_handle(CreateFileW(fileName,
-        GENERIC_WRITE | DELETE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr)));
+    ScopedHandle hFile(safe_handle(CreateFileW(
+        fileName,
+        GENERIC_WRITE | DELETE, 0,
+        nullptr,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL,
+        nullptr)));
 #endif
     if (!hFile)
         return HRESULT_FROM_WIN32(GetLastError());
@@ -339,8 +345,11 @@ HRESULT DirectX::SaveDDSTextureToFile(
 //--------------------------------------------------------------------------------------
 namespace DirectX
 {
-    extern bool _IsWIC2() noexcept;
-    extern IWICImagingFactory* _GetWIC() noexcept;
+    namespace Internal
+    {
+        extern bool IsWIC2() noexcept;
+        extern IWICImagingFactory* GetWIC() noexcept;
+    }
 }
 
 _Use_decl_annotations_
@@ -353,6 +362,8 @@ HRESULT DirectX::SaveWICTextureToFile(
     std::function<void(IPropertyBag2*)> setCustomProps,
     bool forceSRGB)
 {
+    using namespace Internal;
+
     if (!fileName)
         return E_INVALIDARG;
 
@@ -412,7 +423,7 @@ HRESULT DirectX::SaveWICTextureToFile(
             return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
     }
 
-    auto pWIC = _GetWIC();
+    auto pWIC = GetWIC();
     if (!pWIC)
         return E_NOINTERFACE;
 
@@ -442,7 +453,7 @@ HRESULT DirectX::SaveWICTextureToFile(
     if (FAILED(hr))
         return hr;
 
-    if (targetFormat && memcmp(&guidContainerFormat, &GUID_ContainerFormatBmp, sizeof(WICPixelFormatGUID)) == 0 && _IsWIC2())
+    if (targetFormat && memcmp(&guidContainerFormat, &GUID_ContainerFormatBmp, sizeof(WICPixelFormatGUID)) == 0 && IsWIC2())
     {
         // Opt-in to the WIC2 support for writing 32-bit Windows BMP files with an alpha channel
         PROPBAG2 option = {};
@@ -485,7 +496,7 @@ HRESULT DirectX::SaveWICTextureToFile(
         #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
             case DXGI_FORMAT_R32G32B32A32_FLOAT:
             case DXGI_FORMAT_R16G16B16A16_FLOAT:
-                if (_IsWIC2())
+                if (IsWIC2())
                 {
                     targetGuid = GUID_WICPixelFormat96bppRGBFloat;
                 }

--- a/Src/XboxDDSTextureLoader.cpp
+++ b/Src/XboxDDSTextureLoader.cpp
@@ -78,10 +78,9 @@ namespace
         }
 
         // open the file
-        ScopedHandle hFile(safe_handle(CreateFile2(fileName,
-            GENERIC_READ,
-            FILE_SHARE_READ,
-            OPEN_EXISTING,
+        ScopedHandle hFile(safe_handle(CreateFile2(
+            fileName,
+            GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
             nullptr)));
 
         if (!hFile)

--- a/XWBTool/xwbtool.cpp
+++ b/XWBTool/xwbtool.cpp
@@ -1625,7 +1625,12 @@ int __cdecl wmain(_In_ int argc, _In_z_count_(argc) wchar_t* argv[])
     wprintf(L"writing %ls%ls wavebank %ls w/ %zu entries\n", (compact) ? L"compact " : L"", (dwOptions & (1 << OPT_STREAMING)) ? L"streaming" : L"in-memory", szOutputFile, waves.size());
     fflush(stdout);
 
-    ScopedHandle hFile(safe_handle(CreateFileW(szOutputFile, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr)));
+    ScopedHandle hFile(safe_handle(CreateFileW(
+        szOutputFile,
+        GENERIC_WRITE, 0,
+        nullptr,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL,
+        nullptr)));
     if (!hFile)
     {
         wprintf(L"ERROR: Failed opening output file %ls, %lu\n", szOutputFile, GetLastError());


### PR DESCRIPTION
Per the C++ Standard:

> the identifiers that begin with an underscore followed by an uppercase letter are reserved;

I had this in my backlog for some time, but never got around to it until now. Clang v13 (which is in VS 2022 Update 1) has added a new warning for this case: ``-Wreserved-identifier``