### PR TITLE
Input refactoring and cleanup

### DIFF
--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1428,6 +1428,9 @@ X3DAUDIO_HANDLE& AudioEngine::Get3DHandle() const noexcept
 #pragma comment(lib,"runtimeobject.lib")
 #pragma warning(push)
 #pragma warning(disable: 4471 5204)
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wnonportable-system-include-path"
+#endif
 #include <Windows.Devices.Enumeration.h>
 #pragma warning(pop)
 #include <wrl.h>

--- a/Inc/GamePad.h
+++ b/Inc/GamePad.h
@@ -10,29 +10,31 @@
 
 #pragma once
 
-#if (_WIN32_WINNT < 0x0A00 /*_WIN32_WINNT_WIN10*/) || defined(_GAMING_DESKTOP)
-#ifndef _XBOX_ONE
-#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_PHONE_APP)
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)
+#ifndef USING_GAMEINPUT
+#define USING_GAMEINPUT
+#endif
+#elif (_WIN32_WINNT >= 0x0A00 /*_WIN32_WINNT_WIN10*/) && !defined(_GAMING_DESKTOP)
+#ifndef USING_WINDOWS_GAMING_INPUT
+#define USING_WINDOWS_GAMING_INPUT
+#endif
+#endif
+
+#ifdef USING_GAMEINPUT
+interface IGameInputDevice;
+#elif defined(USING_WINDOWS_GAMING_INPUT)
+#pragma comment(lib,"runtimeobject.lib")
+#include <string>
+#elif !defined(_XBOX_ONE)
 #if (_WIN32_WINNT >= 0x0602 /*_WIN32_WINNT_WIN8*/ )
 #pragma comment(lib,"xinput.lib")
 #else
 #pragma comment(lib,"xinput9_1_0.lib")
 #endif
 #endif
-#endif
-#endif
-
-#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)
-interface IGameInputDevice;
-#endif
 
 #include <cstdint>
 #include <memory>
-
-#if (_WIN32_WINNT >= 0x0A00 /*_WIN32_WINNT_WIN10*/) && !defined(_GAMING_DESKTOP)
-#pragma comment(lib,"runtimeobject.lib")
-#include <string>
-#endif
 
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -55,7 +57,7 @@ namespace DirectX
 
         virtual ~GamePad();
 
-    #if ((_WIN32_WINNT >= 0x0A00 /*_WIN32_WINNT_WIN10*/) && !defined(_GAMING_DESKTOP)) || defined(_XBOX_ONE)
+    #if defined(USING_GAMEINPUT) || defined(USING_WINDOWS_GAMING_INPUT) || defined(_XBOX_ONE)
         static constexpr int MAX_PLAYER_COUNT = 8;
     #else
         static constexpr int MAX_PLAYER_COUNT = 4;
@@ -63,7 +65,7 @@ namespace DirectX
 
         static constexpr int c_MostRecent = -1;
 
-    #if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)
+    #ifdef USING_GAMEINPUT
         static constexpr int c_MergedInput = -2;
     #endif
 
@@ -184,9 +186,9 @@ namespace DirectX
 
             bool                connected;
             Type                gamepadType;
-        #if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)
+        #ifdef USING_GAMEINPUT
             APP_LOCAL_DEVICE_ID id;
-        #elif (_WIN32_WINNT >= 0x0A00 /*_WIN32_WINNT_WIN10*/) && !defined(_GAMING_DESKTOP)
+        #elif defined(USING_WINDOWS_GAMING_INPUT)
             std::wstring        id;
         #else
             uint64_t            id;
@@ -277,16 +279,14 @@ namespace DirectX
         void __cdecl Suspend() noexcept;
         void __cdecl Resume() noexcept;
 
-    #if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)
+    #ifdef USING_GAMEINPUT
         void __cdecl RegisterEvents(void* ctrlChanged) noexcept;
-    #elif ((_WIN32_WINNT >= 0x0A00 /*_WIN32_WINNT_WIN10*/ ) && !defined(_GAMING_DESKTOP)) || defined(_XBOX_ONE)
-        void __cdecl RegisterEvents(void* ctrlChanged, void* userChanged) noexcept;
-    #endif
 
-    #if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)
         // Underlying device access
         _Success_(return)
-        bool __cdecl GetDevice(int player, _Outptr_ IGameInputDevice** device) noexcept;
+            bool __cdecl GetDevice(int player, _Outptr_ IGameInputDevice * *device) noexcept;
+    #elif defined(USING_WINDOWS_GAMING_INPUT) || defined(_XBOX_ONE)
+        void __cdecl RegisterEvents(void* ctrlChanged, void* userChanged) noexcept;
     #endif
 
         // Singleton

--- a/Inc/Keyboard.h
+++ b/Inc/Keyboard.h
@@ -10,10 +10,16 @@
 
 #pragma once
 
+#if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)) || (defined(_XBOX_ONE) && defined(_TITLE))
+#ifndef USING_COREWINDOW
+#define USING_COREWINDOW
+#endif
+#endif
+
 #include <cstdint>
 #include <memory>
 
-#if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)) || (defined(_XBOX_ONE) && defined(_TITLE))
+#ifdef USING_COREWINDOW
 namespace ABI { namespace Windows { namespace UI { namespace Core { struct ICoreWindow; } } } }
 #endif
 
@@ -462,11 +468,7 @@ namespace DirectX
         // Feature detection
         bool __cdecl IsConnected() const;
 
-    #if (!defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)) && defined(WM_USER)
-        static void __cdecl ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam);
-    #endif
-
-    #if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)) || (defined(_XBOX_ONE) && defined(_TITLE))
+    #ifdef USING_COREWINDOW
         void __cdecl SetWindow(ABI::Windows::UI::Core::ICoreWindow* window);
     #ifdef __cplusplus_winrt
         void __cdecl SetWindow(Windows::UI::Core::CoreWindow^ window)
@@ -482,7 +484,9 @@ namespace DirectX
             SetWindow(reinterpret_cast<ABI::Windows::UI::Core::ICoreWindow*>(winrt::get_abi(window)));
         }
     #endif
-    #endif // WINAPI_FAMILY == WINAPI_FAMILY_APP
+    #elif defined(WM_USER)
+        static void __cdecl ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam);
+    #endif
 
         // Singleton
         static Keyboard& __cdecl Get();

--- a/Inc/Mouse.h
+++ b/Inc/Mouse.h
@@ -10,9 +10,15 @@
 
 #pragma once
 
+#if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)) || (defined(_XBOX_ONE) && defined(_TITLE))
+#ifndef USING_COREWINDOW
+#define USING_COREWINDOW
+#endif
+#endif
+
 #include <memory>
 
-#if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)) || (defined(_XBOX_ONE) && defined(_TITLE) && (_XDK_VER >= 0x42D907D1))
+#ifdef USING_COREWINDOW
 namespace ABI { namespace Windows { namespace UI { namespace Core { struct ICoreWindow; } } } }
 #endif
 
@@ -102,17 +108,7 @@ namespace DirectX
         bool __cdecl IsVisible() const noexcept;
         void __cdecl SetVisible(bool visible);
 
-    #ifdef WM_USER
-    #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
-        void __cdecl SetWindow(HWND window);
-        static void __cdecl ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam);
-    #elif (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)
-        static void __cdecl ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam);
-        static void __cdecl SetResolution(float scale);
-    #endif
-    #endif
-
-    #if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)) || (defined(_XBOX_ONE) && defined(_TITLE) && (_XDK_VER >= 0x42D907D1))
+    #ifdef USING_COREWINDOW
         void __cdecl SetWindow(ABI::Windows::UI::Core::ICoreWindow* window);
     #ifdef __cplusplus_winrt
         void __cdecl SetWindow(Windows::UI::Core::CoreWindow^ window)
@@ -130,7 +126,14 @@ namespace DirectX
     #endif
 
         static void __cdecl SetDpi(float dpi);
-    #endif // WINAPI_FAMILY == WINAPI_FAMILY_APP
+    #elif defined(WM_USER)
+        void __cdecl SetWindow(HWND window);
+        static void __cdecl ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam);
+
+#ifdef _GAMING_XBOX
+        static void __cdecl SetResolution(float scale);
+#endif
+    #endif
 
         // Singleton
         static Mouse& __cdecl Get();

--- a/Src/Keyboard.cpp
+++ b/Src/Keyboard.cpp
@@ -183,150 +183,13 @@ private:
 Keyboard::Impl* Keyboard::Impl::s_keyboard = nullptr;
 
 
-#elif !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
-
-//======================================================================================
-// Win32 desktop implementation
-//======================================================================================
-
-//
-// For a Win32 desktop application, call this function from your Window Message Procedure
-//
-// LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-// {
-//     switch (message)
-//     {
-//
-//     case WM_ACTIVATEAPP:
-//         Keyboard::ProcessMessage(message, wParam, lParam);
-//         break;
-//
-//     case WM_KEYDOWN:
-//     case WM_SYSKEYDOWN:
-//     case WM_KEYUP:
-//     case WM_SYSKEYUP:
-//         Keyboard::ProcessMessage(message, wParam, lParam);
-//         break;
-//
-//     }
-// }
-//
-
-class Keyboard::Impl
+void Keyboard::ProcessMessage(UINT, WPARAM, LPARAM)
 {
-public:
-    Impl(Keyboard* owner) :
-        mState{},
-        mOwner(owner)
-    {
-        if (s_keyboard)
-        {
-            throw std::logic_error("Keyboard is a singleton");
-        }
-
-        s_keyboard = this;
-    }
-
-    Impl(Impl&&) = default;
-    Impl& operator= (Impl&&) = default;
-
-    Impl(Impl const&) = delete;
-    Impl& operator= (Impl const&) = delete;
-
-    ~Impl()
-    {
-        s_keyboard = nullptr;
-    }
-
-    void GetState(State& state) const
-    {
-        memcpy(&state, &mState, sizeof(State));
-    }
-
-    void Reset() noexcept
-    {
-        memset(&mState, 0, sizeof(State));
-    }
-
-    bool IsConnected() const
-    {
-        return true;
-    }
-
-    State           mState;
-    Keyboard*       mOwner;
-
-    static Keyboard::Impl* s_keyboard;
-};
-
-
-Keyboard::Impl* Keyboard::Impl::s_keyboard = nullptr;
-
-
-void Keyboard::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
-{
-    auto pImpl = Impl::s_keyboard;
-
-    if (!pImpl)
-        return;
-
-    bool down = false;
-
-    switch (message)
-    {
-        case WM_ACTIVATEAPP:
-            pImpl->Reset();
-            return;
-
-        case WM_KEYDOWN:
-        case WM_SYSKEYDOWN:
-            down = true;
-            break;
-
-        case WM_KEYUP:
-        case WM_SYSKEYUP:
-            break;
-
-        default:
-            return;
-    }
-
-    int vk = static_cast<int>(wParam);
-    switch (vk)
-    {
-        case VK_SHIFT:
-            vk = static_cast<int>(
-                MapVirtualKeyW((static_cast<UINT>(lParam) & 0x00ff0000) >> 16u,
-                    MAPVK_VSC_TO_VK_EX));
-            if (!down)
-            {
-                // Workaround to ensure left vs. right shift get cleared when both were pressed at same time
-                KeyUp(VK_LSHIFT, pImpl->mState);
-                KeyUp(VK_RSHIFT, pImpl->mState);
-            }
-            break;
-
-        case VK_CONTROL:
-            vk = (static_cast<UINT>(lParam) & 0x01000000) ? VK_RCONTROL : VK_LCONTROL;
-            break;
-
-        case VK_MENU:
-            vk = (static_cast<UINT>(lParam) & 0x01000000) ? VK_RMENU : VK_LMENU;
-            break;
-    }
-
-    if (down)
-    {
-        KeyDown(vk, pImpl->mState);
-    }
-    else
-    {
-        KeyUp(vk, pImpl->mState);
-    }
+    // GameInput for Keyboard doesn't require Win32 messages, but this simplifies integration.
 }
 
 
-#else
+#elif defined(USING_COREWINDOW)
 
 //======================================================================================
 // Windows Store or Universal Windows Platform (UWP) app implementation
@@ -463,7 +326,7 @@ private:
         }
     }
 
-    static HRESULT Activated(IInspectable *, ABI::Windows::UI::Core::IWindowActivatedEventArgs*)
+    static HRESULT Activated(IInspectable*, ABI::Windows::UI::Core::IWindowActivatedEventArgs*)
     {
         auto pImpl = Impl::s_keyboard;
 
@@ -475,7 +338,7 @@ private:
         return S_OK;
     }
 
-    static HRESULT AcceleratorKeyEvent(IInspectable *, ABI::Windows::UI::Core::IAcceleratorKeyEventArgs* args)
+    static HRESULT AcceleratorKeyEvent(IInspectable*, ABI::Windows::UI::Core::IAcceleratorKeyEventArgs* args)
     {
         using namespace ABI::Windows::System;
         using namespace ABI::Windows::UI::Core;
@@ -493,17 +356,17 @@ private:
 
         switch (evtType)
         {
-            case CoreAcceleratorKeyEventType_KeyDown:
-            case CoreAcceleratorKeyEventType_SystemKeyDown:
-                down = true;
-                break;
+        case CoreAcceleratorKeyEventType_KeyDown:
+        case CoreAcceleratorKeyEventType_SystemKeyDown:
+            down = true;
+            break;
 
-            case CoreAcceleratorKeyEventType_KeyUp:
-            case CoreAcceleratorKeyEventType_SystemKeyUp:
-                break;
+        case CoreAcceleratorKeyEventType_KeyUp:
+        case CoreAcceleratorKeyEventType_SystemKeyUp:
+            break;
 
-            default:
-                return S_OK;
+        default:
+            return S_OK;
         }
 
         CorePhysicalKeyStatus status;
@@ -518,23 +381,23 @@ private:
 
         switch (vk)
         {
-            case VK_SHIFT:
-                vk = (status.ScanCode == 0x36) ? VK_RSHIFT : VK_LSHIFT;
-                if (!down)
-                {
-                    // Workaround to ensure left vs. right shift get cleared when both were pressed at same time
-                    KeyUp(VK_LSHIFT, pImpl->mState);
-                    KeyUp(VK_RSHIFT, pImpl->mState);
-                }
-                break;
+        case VK_SHIFT:
+            vk = (status.ScanCode == 0x36) ? VK_RSHIFT : VK_LSHIFT;
+            if (!down)
+            {
+                // Workaround to ensure left vs. right shift get cleared when both were pressed at same time
+                KeyUp(VK_LSHIFT, pImpl->mState);
+                KeyUp(VK_RSHIFT, pImpl->mState);
+            }
+            break;
 
-            case VK_CONTROL:
-                vk = (status.IsExtendedKey) ? VK_RCONTROL : VK_LCONTROL;
-                break;
+        case VK_CONTROL:
+            vk = (status.IsExtendedKey) ? VK_RCONTROL : VK_LCONTROL;
+            break;
 
-            case VK_MENU:
-                vk = (status.IsExtendedKey) ? VK_RMENU : VK_LMENU;
-                break;
+        case VK_MENU:
+            vk = (status.IsExtendedKey) ? VK_RMENU : VK_LMENU;
+            break;
         }
 
         if (down)
@@ -557,6 +420,151 @@ Keyboard::Impl* Keyboard::Impl::s_keyboard = nullptr;
 void Keyboard::SetWindow(ABI::Windows::UI::Core::ICoreWindow* window)
 {
     pImpl->SetWindow(window);
+}
+
+
+#else
+
+//======================================================================================
+// Win32 desktop implementation
+//======================================================================================
+
+//
+// For a Win32 desktop application, call this function from your Window Message Procedure
+//
+// LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+// {
+//     switch (message)
+//     {
+//
+//     case WM_ACTIVATE:
+//     case WM_ACTIVATEAPP:
+//         Keyboard::ProcessMessage(message, wParam, lParam);
+//         break;
+//
+//     case WM_KEYDOWN:
+//     case WM_SYSKEYDOWN:
+//     case WM_KEYUP:
+//     case WM_SYSKEYUP:
+//         Keyboard::ProcessMessage(message, wParam, lParam);
+//         break;
+//
+//     }
+// }
+//
+
+class Keyboard::Impl
+{
+public:
+    Impl(Keyboard* owner) :
+        mState{},
+        mOwner(owner)
+    {
+        if (s_keyboard)
+        {
+            throw std::logic_error("Keyboard is a singleton");
+        }
+
+        s_keyboard = this;
+    }
+
+    Impl(Impl&&) = default;
+    Impl& operator= (Impl&&) = default;
+
+    Impl(Impl const&) = delete;
+    Impl& operator= (Impl const&) = delete;
+
+    ~Impl()
+    {
+        s_keyboard = nullptr;
+    }
+
+    void GetState(State& state) const
+    {
+        memcpy(&state, &mState, sizeof(State));
+    }
+
+    void Reset() noexcept
+    {
+        memset(&mState, 0, sizeof(State));
+    }
+
+    bool IsConnected() const
+    {
+        return true;
+    }
+
+    State           mState;
+    Keyboard*       mOwner;
+
+    static Keyboard::Impl* s_keyboard;
+};
+
+
+Keyboard::Impl* Keyboard::Impl::s_keyboard = nullptr;
+
+
+void Keyboard::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
+{
+    auto pImpl = Impl::s_keyboard;
+
+    if (!pImpl)
+        return;
+
+    bool down = false;
+
+    switch (message)
+    {
+        case WM_ACTIVATE:
+        case WM_ACTIVATEAPP:
+            pImpl->Reset();
+            return;
+
+        case WM_KEYDOWN:
+        case WM_SYSKEYDOWN:
+            down = true;
+            break;
+
+        case WM_KEYUP:
+        case WM_SYSKEYUP:
+            break;
+
+        default:
+            return;
+    }
+
+    int vk = static_cast<int>(wParam);
+    switch (vk)
+    {
+        case VK_SHIFT:
+            vk = static_cast<int>(
+                MapVirtualKeyW((static_cast<UINT>(lParam) & 0x00ff0000) >> 16u,
+                    MAPVK_VSC_TO_VK_EX));
+            if (!down)
+            {
+                // Workaround to ensure left vs. right shift get cleared when both were pressed at same time
+                KeyUp(VK_LSHIFT, pImpl->mState);
+                KeyUp(VK_RSHIFT, pImpl->mState);
+            }
+            break;
+
+        case VK_CONTROL:
+            vk = (static_cast<UINT>(lParam) & 0x01000000) ? VK_RCONTROL : VK_LCONTROL;
+            break;
+
+        case VK_MENU:
+            vk = (static_cast<UINT>(lParam) & 0x01000000) ? VK_RMENU : VK_LMENU;
+            break;
+    }
+
+    if (down)
+    {
+        KeyDown(vk, pImpl->mState);
+    }
+    else
+    {
+        KeyUp(vk, pImpl->mState);
+    }
 }
 
 #endif
@@ -643,7 +651,6 @@ void Keyboard::KeyboardStateTracker::Update(const State& state) noexcept
 
     lastState = state;
 }
-
 
 void Keyboard::KeyboardStateTracker::Reset() noexcept
 {

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -797,6 +797,15 @@ private:
             hr = currentPoint->get_Properties(props.GetAddressOf());
             ThrowIfFailed(hr);
 
+            boolean ishorz;
+            hr = props->get_IsHorizontalMouseWheel(&ishorz);
+            ThrowIfFailed(hr);
+            if (ishorz)
+            {
+                // Mouse only exposes the vertical scroll wheel.
+                return S_OK;
+            }
+
             INT32 value;
             hr = props->get_MouseWheelDelta(&value);
             ThrowIfFailed(hr);

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -32,6 +32,7 @@ using Microsoft::WRL::ComPtr;
 // {
 //     switch (message)
 //     {
+//     case WM_ACTIVATE:
 //     case WM_ACTIVATEAPP:
 //     case WM_MOUSEMOVE:
 //     case WM_LBUTTONDOWN:
@@ -59,6 +60,7 @@ public:
         mScale(1.f),
         mConnected(0),
         mDeviceToken(0),
+        mWindow(nullptr),
         mMode(MODE_ABSOLUTE),
         mScrollWheelCurrent(0),
         mRelativeX(INT64_MAX),
@@ -167,6 +169,11 @@ public:
         SetEvent(mScrollWheelValue.get());
     }
 
+    void SetWindow(HWND window)
+    {
+        mWindow = window;
+    }
+
     void SetMode(Mode mode)
     {
         if (mMode == mode)
@@ -226,6 +233,7 @@ private:
     ComPtr<IGameInput>      mGameInput;
     GameInputCallbackToken  mDeviceToken;
 
+    HWND                    mWindow;
     Mode                    mMode;
     ScopedHandle            mScrollWheelValue;
 
@@ -279,6 +287,7 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
 
     switch (message)
     {
+    case WM_ACTIVATE:
     case WM_ACTIVATEAPP:
         if (wParam)
         {
@@ -372,7 +381,7 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
     }
 }
 
-
+#ifdef _GAMING_XBOX
 void Mouse::SetResolution(float scale)
 {
     auto pImpl = Impl::s_mouse;
@@ -382,260 +391,7 @@ void Mouse::SetResolution(float scale)
 
     pImpl->mScale = scale;
 }
-
-
-#elif !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
-
-//======================================================================================
-// Win32 desktop implementation
-//======================================================================================
-
-//
-// For a Win32 desktop application, in your window setup be sure to call this method:
-//
-// m_mouse->SetWindow(hwnd);
-//
-// And call this static function from your Window Message Procedure
-//
-// LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
-// {
-//     switch (message)
-//     {
-//     case WM_ACTIVATE:
-//     case WM_ACTIVATEAPP:
-//     case WM_INPUT:
-//     case WM_MOUSEMOVE:
-//     case WM_LBUTTONDOWN:
-//     case WM_LBUTTONUP:
-//     case WM_RBUTTONDOWN:
-//     case WM_RBUTTONUP:
-//     case WM_MBUTTONDOWN:
-//     case WM_MBUTTONUP:
-//     case WM_MOUSEWHEEL:
-//     case WM_XBUTTONDOWN:
-//     case WM_XBUTTONUP:
-//     case WM_MOUSEHOVER:
-//         Mouse::ProcessMessage(message, wParam, lParam);
-//         break;
-//
-//     }
-// }
-//
-
-class Mouse::Impl
-{
-public:
-    explicit Impl(Mouse* owner) noexcept(false) :
-        mState{},
-        mOwner(owner),
-        mWindow(nullptr),
-        mMode(MODE_ABSOLUTE),
-        mLastX(0),
-        mLastY(0),
-        mRelativeX(INT32_MAX),
-        mRelativeY(INT32_MAX),
-        mInFocus(true)
-    {
-        if (s_mouse)
-        {
-            throw std::logic_error("Mouse is a singleton");
-        }
-
-        s_mouse = this;
-
-        mScrollWheelValue.reset(CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, EVENT_MODIFY_STATE | SYNCHRONIZE));
-        mRelativeRead.reset(CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, EVENT_MODIFY_STATE | SYNCHRONIZE));
-        mAbsoluteMode.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
-        mRelativeMode.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
-        if (!mScrollWheelValue
-            || !mRelativeRead
-            || !mAbsoluteMode
-            || !mRelativeMode)
-        {
-            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
-        }
-    }
-
-    Impl(Impl&&) = default;
-    Impl& operator= (Impl&&) = default;
-
-    Impl(Impl const&) = delete;
-    Impl& operator= (Impl const&) = delete;
-
-    ~Impl()
-    {
-        s_mouse = nullptr;
-    }
-
-    void GetState(State& state) const
-    {
-        memcpy(&state, &mState, sizeof(State));
-        state.positionMode = mMode;
-
-        DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
-        if (result == WAIT_FAILED)
-            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
-
-        if (result == WAIT_OBJECT_0)
-        {
-            state.scrollWheelValue = 0;
-        }
-
-        if (state.positionMode == MODE_RELATIVE)
-        {
-            result = WaitForSingleObjectEx(mRelativeRead.get(), 0, FALSE);
-
-            if (result == WAIT_FAILED)
-                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
-
-            if (result == WAIT_OBJECT_0)
-            {
-                state.x = 0;
-                state.y = 0;
-            }
-            else
-            {
-                SetEvent(mRelativeRead.get());
-            }
-        }
-    }
-
-    void ResetScrollWheelValue() noexcept
-    {
-        SetEvent(mScrollWheelValue.get());
-    }
-
-    void SetMode(Mode mode)
-    {
-        if (mMode == mode)
-            return;
-
-        SetEvent((mode == MODE_ABSOLUTE) ? mAbsoluteMode.get() : mRelativeMode.get());
-
-        assert(mWindow != nullptr);
-
-        // Send a WM_HOVER as a way to 'kick' the message processing even if the mouse is still.
-        TRACKMOUSEEVENT tme;
-        tme.cbSize = sizeof(tme);
-        tme.dwFlags = TME_HOVER;
-        tme.hwndTrack = mWindow;
-        tme.dwHoverTime = 1;
-        if (!TrackMouseEvent(&tme))
-        {
-            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "TrackMouseEvent");
-        }
-    }
-
-    bool IsConnected() const noexcept
-    {
-        return GetSystemMetrics(SM_MOUSEPRESENT) != 0;
-    }
-
-    bool IsVisible() const noexcept
-    {
-        if (mMode == MODE_RELATIVE)
-            return false;
-
-        CURSORINFO info = { sizeof(CURSORINFO), 0, nullptr, {} };
-        if (!GetCursorInfo(&info))
-            return false;
-
-        return (info.flags & CURSOR_SHOWING) != 0;
-    }
-
-    void SetVisible(bool visible)
-    {
-        if (mMode == MODE_RELATIVE)
-            return;
-
-        CURSORINFO info = { sizeof(CURSORINFO), 0, nullptr, {} };
-        if (!GetCursorInfo(&info))
-        {
-            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "GetCursorInfo");
-        }
-
-        const bool isvisible = (info.flags & CURSOR_SHOWING) != 0;
-        if (isvisible != visible)
-        {
-            ShowCursor(visible);
-        }
-    }
-
-    void SetWindow(HWND window)
-    {
-        if (mWindow == window)
-            return;
-
-        assert(window != nullptr);
-
-        RAWINPUTDEVICE Rid;
-        Rid.usUsagePage = 0x1 /* HID_USAGE_PAGE_GENERIC */;
-        Rid.usUsage = 0x2 /* HID_USAGE_GENERIC_MOUSE */;
-        Rid.dwFlags = RIDEV_INPUTSINK;
-        Rid.hwndTarget = window;
-        if (!RegisterRawInputDevices(&Rid, 1, sizeof(RAWINPUTDEVICE)))
-        {
-            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "RegisterRawInputDevices");
-        }
-
-        mWindow = window;
-    }
-
-    State           mState;
-
-    Mouse*          mOwner;
-
-    static Mouse::Impl* s_mouse;
-
-private:
-    HWND            mWindow;
-    Mode            mMode;
-
-    ScopedHandle    mScrollWheelValue;
-    ScopedHandle    mRelativeRead;
-    ScopedHandle    mAbsoluteMode;
-    ScopedHandle    mRelativeMode;
-
-    int             mLastX;
-    int             mLastY;
-    int             mRelativeX;
-    int             mRelativeY;
-
-    bool            mInFocus;
-
-    friend void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam);
-
-    void ClipToWindow() noexcept
-    {
-        assert(mWindow != nullptr);
-
-        RECT rect;
-        GetClientRect(mWindow, &rect);
-
-        POINT ul;
-        ul.x = rect.left;
-        ul.y = rect.top;
-
-        POINT lr;
-        lr.x = rect.right;
-        lr.y = rect.bottom;
-
-        MapWindowPoints(mWindow, nullptr, &ul, 1);
-        MapWindowPoints(mWindow, nullptr, &lr, 1);
-
-        rect.left = ul.x;
-        rect.top = ul.y;
-
-        rect.right = lr.x;
-        rect.bottom = lr.y;
-
-        ClipCursor(&rect);
-    }
-};
-
-
-Mouse::Impl* Mouse::Impl::s_mouse = nullptr;
-
+#endif
 
 void Mouse::SetWindow(HWND window)
 {
@@ -643,284 +399,7 @@ void Mouse::SetWindow(HWND window)
 }
 
 
-void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
-{
-    auto pImpl = Impl::s_mouse;
-
-    if (!pImpl)
-        return;
-
-    HANDLE events[3] = { pImpl->mScrollWheelValue.get(), pImpl->mAbsoluteMode.get(), pImpl->mRelativeMode.get() };
-    switch (WaitForMultipleObjectsEx(static_cast<DWORD>(std::size(events)), events, FALSE, 0, FALSE))
-    {
-        default:
-        case WAIT_TIMEOUT:
-            break;
-
-        case WAIT_OBJECT_0:
-            pImpl->mState.scrollWheelValue = 0;
-            ResetEvent(events[0]);
-            break;
-
-        case (WAIT_OBJECT_0 + 1):
-        {
-            pImpl->mMode = MODE_ABSOLUTE;
-            ClipCursor(nullptr);
-
-            POINT point;
-            point.x = pImpl->mLastX;
-            point.y = pImpl->mLastY;
-
-            // We show the cursor before moving it to support Remote Desktop
-            ShowCursor(TRUE);
-
-            if (MapWindowPoints(pImpl->mWindow, nullptr, &point, 1))
-            {
-                SetCursorPos(point.x, point.y);
-            }
-            pImpl->mState.x = pImpl->mLastX;
-            pImpl->mState.y = pImpl->mLastY;
-        }
-        break;
-
-        case (WAIT_OBJECT_0 + 2):
-        {
-            ResetEvent(pImpl->mRelativeRead.get());
-
-            pImpl->mMode = MODE_RELATIVE;
-            pImpl->mState.x = pImpl->mState.y = 0;
-            pImpl->mRelativeX = INT32_MAX;
-            pImpl->mRelativeY = INT32_MAX;
-
-            ShowCursor(FALSE);
-
-            pImpl->ClipToWindow();
-        }
-        break;
-
-        case WAIT_FAILED:
-            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForMultipleObjectsEx");
-    }
-
-    switch (message)
-    {
-        case WM_ACTIVATE:
-        case WM_ACTIVATEAPP:
-            if (wParam)
-            {
-                pImpl->mInFocus = true;
-
-                if (pImpl->mMode == MODE_RELATIVE)
-                {
-                    pImpl->mState.x = pImpl->mState.y = 0;
-
-                    ShowCursor(FALSE);
-
-                    pImpl->ClipToWindow();
-                }
-            }
-            else
-            {
-                const int scrollWheel = pImpl->mState.scrollWheelValue;
-                memset(&pImpl->mState, 0, sizeof(State));
-                pImpl->mState.scrollWheelValue = scrollWheel;
-
-                if (pImpl->mMode == MODE_RELATIVE)
-                {
-                    ClipCursor(nullptr);
-                }
-
-                pImpl->mInFocus = false;
-            }
-            return;
-
-        case WM_INPUT:
-            if (pImpl->mInFocus && pImpl->mMode == MODE_RELATIVE)
-            {
-                RAWINPUT raw;
-                UINT rawSize = sizeof(raw);
-
-                const UINT resultData = GetRawInputData(reinterpret_cast<HRAWINPUT>(lParam), RID_INPUT, &raw, &rawSize, sizeof(RAWINPUTHEADER));
-                if (resultData == UINT(-1))
-                {
-                    throw std::runtime_error("GetRawInputData");
-                }
-
-                if (raw.header.dwType == RIM_TYPEMOUSE)
-                {
-                    if (!(raw.data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE))
-                    {
-                        pImpl->mState.x = raw.data.mouse.lLastX;
-                        pImpl->mState.y = raw.data.mouse.lLastY;
-
-                        ResetEvent(pImpl->mRelativeRead.get());
-                    }
-                    else if (raw.data.mouse.usFlags & MOUSE_VIRTUAL_DESKTOP)
-                    {
-                        // This is used to make Remote Desktop sessons work
-                        const int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
-                        const int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
-
-                        auto const x = static_cast<int>((float(raw.data.mouse.lLastX) / 65535.0f) * float(width));
-                        auto const y = static_cast<int>((float(raw.data.mouse.lLastY) / 65535.0f) * float(height));
-
-                        if (pImpl->mRelativeX == INT32_MAX)
-                        {
-                            pImpl->mState.x = pImpl->mState.y = 0;
-                        }
-                        else
-                        {
-                            pImpl->mState.x = x - pImpl->mRelativeX;
-                            pImpl->mState.y = y - pImpl->mRelativeY;
-                        }
-
-                        pImpl->mRelativeX = x;
-                        pImpl->mRelativeY = y;
-
-                        ResetEvent(pImpl->mRelativeRead.get());
-                    }
-                }
-            }
-            return;
-
-        case WM_MOUSEMOVE:
-            break;
-
-        case WM_LBUTTONDOWN:
-            pImpl->mState.leftButton = true;
-            break;
-
-        case WM_LBUTTONUP:
-            pImpl->mState.leftButton = false;
-            break;
-
-        case WM_RBUTTONDOWN:
-            pImpl->mState.rightButton = true;
-            break;
-
-        case WM_RBUTTONUP:
-            pImpl->mState.rightButton = false;
-            break;
-
-        case WM_MBUTTONDOWN:
-            pImpl->mState.middleButton = true;
-            break;
-
-        case WM_MBUTTONUP:
-            pImpl->mState.middleButton = false;
-            break;
-
-        case WM_MOUSEWHEEL:
-            pImpl->mState.scrollWheelValue += GET_WHEEL_DELTA_WPARAM(wParam);
-            return;
-
-        case WM_XBUTTONDOWN:
-            switch (GET_XBUTTON_WPARAM(wParam))
-            {
-                case XBUTTON1:
-                    pImpl->mState.xButton1 = true;
-                    break;
-
-                case XBUTTON2:
-                    pImpl->mState.xButton2 = true;
-                    break;
-            }
-            break;
-
-        case WM_XBUTTONUP:
-            switch (GET_XBUTTON_WPARAM(wParam))
-            {
-                case XBUTTON1:
-                    pImpl->mState.xButton1 = false;
-                    break;
-
-                case XBUTTON2:
-                    pImpl->mState.xButton2 = false;
-                    break;
-            }
-            break;
-
-        case WM_MOUSEHOVER:
-            break;
-
-        default:
-            // Not a mouse message, so exit
-            return;
-    }
-
-    if (pImpl->mMode == MODE_ABSOLUTE)
-    {
-        // All mouse messages provide a new pointer position
-        const int xPos = static_cast<short>(LOWORD(lParam)); // GET_X_LPARAM(lParam);
-        const int yPos = static_cast<short>(HIWORD(lParam)); // GET_Y_LPARAM(lParam);
-
-        pImpl->mState.x = pImpl->mLastX = xPos;
-        pImpl->mState.y = pImpl->mLastY = yPos;
-    }
-}
-
-
-#elif defined(_XBOX_ONE) && (!defined(_TITLE) || (_XDK_VER < 0x42D907D1))
-
-//======================================================================================
-// Null device
-//======================================================================================
-
-class Mouse::Impl
-{
-public:
-    explicit Impl(Mouse* owner) noexcept(false) :
-        mOwner(owner)
-    {
-        if (s_mouse)
-        {
-            throw std::logic_error("Mouse is a singleton");
-        }
-
-        s_mouse = this;
-    }
-
-    ~Impl()
-    {
-        s_mouse = nullptr;
-    }
-
-    void GetState(State& state) const
-    {
-        memset(&state, 0, sizeof(State));
-    }
-
-    void ResetScrollWheelValue() noexcept
-    {
-    }
-
-    void SetMode(Mode)
-    {
-    }
-
-    bool IsConnected() const
-    {
-        return false;
-    }
-
-    bool IsVisible() const noexcept
-    {
-        return false;
-    }
-
-    void SetVisible(bool)
-    {
-    }
-
-    Mouse*  mOwner;
-
-    static Mouse::Impl* s_mouse;
-};
-
-Mouse::Impl* Mouse::Impl::s_mouse = nullptr;
-
-
-#else
+#elif defined(USING_COREWINDOW)
 
 //======================================================================================
 // Windows Store or Universal Windows Platform (UWP) app implementation
@@ -1182,7 +661,7 @@ public:
     }
 
     State           mState;
-    Mouse*          mOwner;
+    Mouse* mOwner;
     float           mDPI;
 
     static Mouse::Impl* s_mouse;
@@ -1227,7 +706,7 @@ private:
         }
     }
 
-    static HRESULT PointerEvent(IInspectable *, ABI::Windows::UI::Core::IPointerEventArgs*args)
+    static HRESULT PointerEvent(IInspectable*, ABI::Windows::UI::Core::IPointerEventArgs* args)
     {
         using namespace ABI::Windows::Foundation;
         using namespace ABI::Windows::UI::Input;
@@ -1291,7 +770,7 @@ private:
         return S_OK;
     }
 
-    static HRESULT PointerWheel(IInspectable *, ABI::Windows::UI::Core::IPointerEventArgs*args)
+    static HRESULT PointerWheel(IInspectable*, ABI::Windows::UI::Core::IPointerEventArgs* args)
     {
         using namespace ABI::Windows::Foundation;
         using namespace ABI::Windows::UI::Input;
@@ -1347,7 +826,7 @@ private:
         return S_OK;
     }
 
-    static HRESULT MouseMovedEvent(IInspectable *, ABI::Windows::Devices::Input::IMouseEventArgs* args)
+    static HRESULT MouseMovedEvent(IInspectable*, ABI::Windows::Devices::Input::IMouseEventArgs* args)
     {
         using namespace ABI::Windows::Devices::Input;
 
@@ -1388,6 +867,482 @@ void Mouse::SetDpi(float dpi)
         return;
 
     pImpl->mDPI = dpi;
+}
+
+
+#else
+
+//======================================================================================
+// Win32 desktop implementation
+//======================================================================================
+
+//
+// For a Win32 desktop application, in your window setup be sure to call this method:
+//
+// m_mouse->SetWindow(hwnd);
+//
+// And call this static function from your Window Message Procedure
+//
+// LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+// {
+//     switch (message)
+//     {
+//     case WM_ACTIVATE:
+//     case WM_ACTIVATEAPP:
+//     case WM_INPUT:
+//     case WM_MOUSEMOVE:
+//     case WM_LBUTTONDOWN:
+//     case WM_LBUTTONUP:
+//     case WM_RBUTTONDOWN:
+//     case WM_RBUTTONUP:
+//     case WM_MBUTTONDOWN:
+//     case WM_MBUTTONUP:
+//     case WM_MOUSEWHEEL:
+//     case WM_XBUTTONDOWN:
+//     case WM_XBUTTONUP:
+//     case WM_MOUSEHOVER:
+//         Mouse::ProcessMessage(message, wParam, lParam);
+//         break;
+//
+//     }
+// }
+//
+
+class Mouse::Impl
+{
+public:
+    explicit Impl(Mouse* owner) noexcept(false) :
+        mState{},
+        mOwner(owner),
+        mWindow(nullptr),
+        mMode(MODE_ABSOLUTE),
+        mLastX(0),
+        mLastY(0),
+        mRelativeX(INT32_MAX),
+        mRelativeY(INT32_MAX),
+        mInFocus(true)
+    {
+        if (s_mouse)
+        {
+            throw std::logic_error("Mouse is a singleton");
+        }
+
+        s_mouse = this;
+
+        mScrollWheelValue.reset(CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, EVENT_MODIFY_STATE | SYNCHRONIZE));
+        mRelativeRead.reset(CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, EVENT_MODIFY_STATE | SYNCHRONIZE));
+        mAbsoluteMode.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
+        mRelativeMode.reset(CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE));
+        if (!mScrollWheelValue
+            || !mRelativeRead
+            || !mAbsoluteMode
+            || !mRelativeMode)
+        {
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "CreateEventEx");
+        }
+    }
+
+    Impl(Impl&&) = default;
+    Impl& operator= (Impl&&) = default;
+
+    Impl(Impl const&) = delete;
+    Impl& operator= (Impl const&) = delete;
+
+    ~Impl()
+    {
+        s_mouse = nullptr;
+    }
+
+    void GetState(State& state) const
+    {
+        memcpy(&state, &mState, sizeof(State));
+        state.positionMode = mMode;
+
+        DWORD result = WaitForSingleObjectEx(mScrollWheelValue.get(), 0, FALSE);
+        if (result == WAIT_FAILED)
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
+
+        if (result == WAIT_OBJECT_0)
+        {
+            state.scrollWheelValue = 0;
+        }
+
+        if (state.positionMode == MODE_RELATIVE)
+        {
+            result = WaitForSingleObjectEx(mRelativeRead.get(), 0, FALSE);
+
+            if (result == WAIT_FAILED)
+                throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForSingleObjectEx");
+
+            if (result == WAIT_OBJECT_0)
+            {
+                state.x = 0;
+                state.y = 0;
+            }
+            else
+            {
+                SetEvent(mRelativeRead.get());
+            }
+        }
+    }
+
+    void ResetScrollWheelValue() noexcept
+    {
+        SetEvent(mScrollWheelValue.get());
+    }
+
+    void SetMode(Mode mode)
+    {
+        if (mMode == mode)
+            return;
+
+        SetEvent((mode == MODE_ABSOLUTE) ? mAbsoluteMode.get() : mRelativeMode.get());
+
+        assert(mWindow != nullptr);
+
+        // Send a WM_HOVER as a way to 'kick' the message processing even if the mouse is still.
+        TRACKMOUSEEVENT tme;
+        tme.cbSize = sizeof(tme);
+        tme.dwFlags = TME_HOVER;
+        tme.hwndTrack = mWindow;
+        tme.dwHoverTime = 1;
+        if (!TrackMouseEvent(&tme))
+        {
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "TrackMouseEvent");
+        }
+    }
+
+    bool IsConnected() const noexcept
+    {
+        return GetSystemMetrics(SM_MOUSEPRESENT) != 0;
+    }
+
+    bool IsVisible() const noexcept
+    {
+        if (mMode == MODE_RELATIVE)
+            return false;
+
+        CURSORINFO info = { sizeof(CURSORINFO), 0, nullptr, {} };
+        if (!GetCursorInfo(&info))
+            return false;
+
+        return (info.flags & CURSOR_SHOWING) != 0;
+    }
+
+    void SetVisible(bool visible)
+    {
+        if (mMode == MODE_RELATIVE)
+            return;
+
+        CURSORINFO info = { sizeof(CURSORINFO), 0, nullptr, {} };
+        if (!GetCursorInfo(&info))
+        {
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "GetCursorInfo");
+        }
+
+        const bool isvisible = (info.flags & CURSOR_SHOWING) != 0;
+        if (isvisible != visible)
+        {
+            ShowCursor(visible);
+        }
+    }
+
+    void SetWindow(HWND window)
+    {
+        if (mWindow == window)
+            return;
+
+        assert(window != nullptr);
+
+        RAWINPUTDEVICE Rid;
+        Rid.usUsagePage = 0x1 /* HID_USAGE_PAGE_GENERIC */;
+        Rid.usUsage = 0x2 /* HID_USAGE_GENERIC_MOUSE */;
+        Rid.dwFlags = RIDEV_INPUTSINK;
+        Rid.hwndTarget = window;
+        if (!RegisterRawInputDevices(&Rid, 1, sizeof(RAWINPUTDEVICE)))
+        {
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "RegisterRawInputDevices");
+        }
+
+        mWindow = window;
+    }
+
+    State           mState;
+
+    Mouse*          mOwner;
+
+    static Mouse::Impl* s_mouse;
+
+private:
+    HWND            mWindow;
+    Mode            mMode;
+
+    ScopedHandle    mScrollWheelValue;
+    ScopedHandle    mRelativeRead;
+    ScopedHandle    mAbsoluteMode;
+    ScopedHandle    mRelativeMode;
+
+    int             mLastX;
+    int             mLastY;
+    int             mRelativeX;
+    int             mRelativeY;
+
+    bool            mInFocus;
+
+    friend void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam);
+
+    void ClipToWindow() noexcept
+    {
+        assert(mWindow != nullptr);
+
+        RECT rect;
+        GetClientRect(mWindow, &rect);
+
+        POINT ul;
+        ul.x = rect.left;
+        ul.y = rect.top;
+
+        POINT lr;
+        lr.x = rect.right;
+        lr.y = rect.bottom;
+
+        std::ignore = MapWindowPoints(mWindow, nullptr, &ul, 1);
+        std::ignore = MapWindowPoints(mWindow, nullptr, &lr, 1);
+
+        rect.left = ul.x;
+        rect.top = ul.y;
+
+        rect.right = lr.x;
+        rect.bottom = lr.y;
+
+        ClipCursor(&rect);
+    }
+};
+
+
+Mouse::Impl* Mouse::Impl::s_mouse = nullptr;
+
+
+void Mouse::SetWindow(HWND window)
+{
+    pImpl->SetWindow(window);
+}
+
+
+void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
+{
+    auto pImpl = Impl::s_mouse;
+
+    if (!pImpl)
+        return;
+
+    HANDLE events[3] = { pImpl->mScrollWheelValue.get(), pImpl->mAbsoluteMode.get(), pImpl->mRelativeMode.get() };
+    switch (WaitForMultipleObjectsEx(static_cast<DWORD>(std::size(events)), events, FALSE, 0, FALSE))
+    {
+        default:
+        case WAIT_TIMEOUT:
+            break;
+
+        case WAIT_OBJECT_0:
+            pImpl->mState.scrollWheelValue = 0;
+            ResetEvent(events[0]);
+            break;
+
+        case (WAIT_OBJECT_0 + 1):
+        {
+            pImpl->mMode = MODE_ABSOLUTE;
+            ClipCursor(nullptr);
+
+            POINT point;
+            point.x = pImpl->mLastX;
+            point.y = pImpl->mLastY;
+
+            // We show the cursor before moving it to support Remote Desktop
+            ShowCursor(TRUE);
+
+            if (MapWindowPoints(pImpl->mWindow, nullptr, &point, 1))
+            {
+                SetCursorPos(point.x, point.y);
+            }
+            pImpl->mState.x = pImpl->mLastX;
+            pImpl->mState.y = pImpl->mLastY;
+        }
+        break;
+
+        case (WAIT_OBJECT_0 + 2):
+        {
+            ResetEvent(pImpl->mRelativeRead.get());
+
+            pImpl->mMode = MODE_RELATIVE;
+            pImpl->mState.x = pImpl->mState.y = 0;
+            pImpl->mRelativeX = INT32_MAX;
+            pImpl->mRelativeY = INT32_MAX;
+
+            ShowCursor(FALSE);
+
+            pImpl->ClipToWindow();
+        }
+        break;
+
+        case WAIT_FAILED:
+            throw std::system_error(std::error_code(static_cast<int>(GetLastError()), std::system_category()), "WaitForMultipleObjectsEx");
+    }
+
+    switch (message)
+    {
+        case WM_ACTIVATE:
+        case WM_ACTIVATEAPP:
+            if (wParam)
+            {
+                pImpl->mInFocus = true;
+
+                if (pImpl->mMode == MODE_RELATIVE)
+                {
+                    pImpl->mState.x = pImpl->mState.y = 0;
+
+                    ShowCursor(FALSE);
+
+                    pImpl->ClipToWindow();
+                }
+            }
+            else
+            {
+                const int scrollWheel = pImpl->mState.scrollWheelValue;
+                memset(&pImpl->mState, 0, sizeof(State));
+                pImpl->mState.scrollWheelValue = scrollWheel;
+
+                if (pImpl->mMode == MODE_RELATIVE)
+                {
+                    ClipCursor(nullptr);
+                }
+
+                pImpl->mInFocus = false;
+            }
+            return;
+
+        case WM_INPUT:
+            if (pImpl->mInFocus && pImpl->mMode == MODE_RELATIVE)
+            {
+                RAWINPUT raw;
+                UINT rawSize = sizeof(raw);
+
+                const UINT resultData = GetRawInputData(reinterpret_cast<HRAWINPUT>(lParam), RID_INPUT, &raw, &rawSize, sizeof(RAWINPUTHEADER));
+                if (resultData == UINT(-1))
+                {
+                    throw std::runtime_error("GetRawInputData");
+                }
+
+                if (raw.header.dwType == RIM_TYPEMOUSE)
+                {
+                    if (!(raw.data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE))
+                    {
+                        pImpl->mState.x = raw.data.mouse.lLastX;
+                        pImpl->mState.y = raw.data.mouse.lLastY;
+
+                        ResetEvent(pImpl->mRelativeRead.get());
+                    }
+                    else if (raw.data.mouse.usFlags & MOUSE_VIRTUAL_DESKTOP)
+                    {
+                        // This is used to make Remote Desktop sessons work
+                        const int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+                        const int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+
+                        auto const x = static_cast<int>((float(raw.data.mouse.lLastX) / 65535.0f) * float(width));
+                        auto const y = static_cast<int>((float(raw.data.mouse.lLastY) / 65535.0f) * float(height));
+
+                        if (pImpl->mRelativeX == INT32_MAX)
+                        {
+                            pImpl->mState.x = pImpl->mState.y = 0;
+                        }
+                        else
+                        {
+                            pImpl->mState.x = x - pImpl->mRelativeX;
+                            pImpl->mState.y = y - pImpl->mRelativeY;
+                        }
+
+                        pImpl->mRelativeX = x;
+                        pImpl->mRelativeY = y;
+
+                        ResetEvent(pImpl->mRelativeRead.get());
+                    }
+                }
+            }
+            return;
+
+        case WM_MOUSEMOVE:
+            break;
+
+        case WM_LBUTTONDOWN:
+            pImpl->mState.leftButton = true;
+            break;
+
+        case WM_LBUTTONUP:
+            pImpl->mState.leftButton = false;
+            break;
+
+        case WM_RBUTTONDOWN:
+            pImpl->mState.rightButton = true;
+            break;
+
+        case WM_RBUTTONUP:
+            pImpl->mState.rightButton = false;
+            break;
+
+        case WM_MBUTTONDOWN:
+            pImpl->mState.middleButton = true;
+            break;
+
+        case WM_MBUTTONUP:
+            pImpl->mState.middleButton = false;
+            break;
+
+        case WM_MOUSEWHEEL:
+            pImpl->mState.scrollWheelValue += GET_WHEEL_DELTA_WPARAM(wParam);
+            return;
+
+        case WM_XBUTTONDOWN:
+            switch (GET_XBUTTON_WPARAM(wParam))
+            {
+                case XBUTTON1:
+                    pImpl->mState.xButton1 = true;
+                    break;
+
+                case XBUTTON2:
+                    pImpl->mState.xButton2 = true;
+                    break;
+            }
+            break;
+
+        case WM_XBUTTONUP:
+            switch (GET_XBUTTON_WPARAM(wParam))
+            {
+                case XBUTTON1:
+                    pImpl->mState.xButton1 = false;
+                    break;
+
+                case XBUTTON2:
+                    pImpl->mState.xButton2 = false;
+                    break;
+            }
+            break;
+
+        case WM_MOUSEHOVER:
+            break;
+
+        default:
+            // Not a mouse message, so exit
+            return;
+    }
+
+    if (pImpl->mMode == MODE_ABSOLUTE)
+    {
+        // All mouse messages provide a new pointer position
+        const int xPos = static_cast<short>(LOWORD(lParam)); // GET_X_LPARAM(lParam);
+        const int yPos = static_cast<short>(HIWORD(lParam)); // GET_Y_LPARAM(lParam);
+
+        pImpl->mState.x = pImpl->mLastX = xPos;
+        pImpl->mState.y = pImpl->mLastY = yPos;
+    }
 }
 
 #endif

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -102,6 +102,12 @@
 #ifdef _GAMING_XBOX
 #error This version of DirectX Tool Kit not supported for GDK
 #elif defined(_XBOX_ONE) && defined(_TITLE)
+#include <xdk.h>
+
+#if _XDK_VER < 0x42ED07E4 /* XDK Edition 180400 */
+#error DirectX Tool Kit for Direct3D 11 requires the April 2018 XDK or later
+#endif
+
 #include <d3d11_x.h>
 #else
 #include <d3d11_1.h>


### PR DESCRIPTION
* Cleaned up the code a bit to simplify the various ``#if`` conditions
* Added ``WM_ACTIVATE`` to Win32 Keyboard
* Added ``Mouse::SetWindow`` and ``Keyboard::ProcessMessage`` methods for GameInput implementation to simplify integration instructions
* Fixed bug with UWP Mouse so it doesn't track the HWHEEL as the normal WHEEL
* Legacy Xbox One XDK support now requires April 2018, May 2018, or June 2018.
