### PR TITLE
Add DDS_LOADER_IGNORE_SRGB parameter/functionality to CreateDDSTexture*Ex

### DIFF
--- a/Inc/DDSTextureLoader.h
+++ b/Inc/DDSTextureLoader.h
@@ -40,6 +40,14 @@ namespace DirectX
     };
 #endif
 
+    enum DDS_LOADER_FLAGS : uint32_t
+    {
+        DDS_LOADER_DEFAULT = 0,
+        DDS_LOADER_FORCE_SRGB = 0x1,
+        DDS_LOADER_IGNORE_SRGB = 0x2,
+        DDS_LOADER_SRGB_DEFAULT = 0x4,
+    };
+
     // Standard version
     HRESULT __cdecl CreateDDSTextureFromMemory(
         _In_ ID3D11Device* d3dDevice,
@@ -98,8 +106,7 @@ namespace DirectX
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ bool forceSRGB,
-        _In_ bool stripSRGB,
+        _In_ DDS_LOADER_FLAGS loadFlags,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
         _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
@@ -112,8 +119,7 @@ namespace DirectX
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ bool forceSRGB,
-        _In_ bool stripSRGB,
+        _In_ DDS_LOADER_FLAGS loadFlags,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
         _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
@@ -134,8 +140,7 @@ namespace DirectX
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ bool forceSRGB,
-        _In_ bool stripSRGB,
+        _In_ DDS_LOADER_FLAGS loadFlags,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
         _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
@@ -154,9 +159,19 @@ namespace DirectX
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ bool forceSRGB,
-        _In_ bool stripSRGB,
+        _In_ DDS_LOADER_FLAGS loadFlags,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
         _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
+
+    DEFINE_ENUM_FLAG_OPERATORS(DDS_LOADER_FLAGS);
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 }

--- a/Inc/DDSTextureLoader.h
+++ b/Inc/DDSTextureLoader.h
@@ -99,6 +99,7 @@ namespace DirectX
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
         _In_ bool forceSRGB,
+        _In_ bool stripSRGB,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
         _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
@@ -112,6 +113,7 @@ namespace DirectX
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
         _In_ bool forceSRGB,
+        _In_ bool stripSRGB,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
         _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
@@ -133,6 +135,7 @@ namespace DirectX
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
         _In_ bool forceSRGB,
+        _In_ bool stripSRGB,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
         _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
@@ -152,6 +155,7 @@ namespace DirectX
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
         _In_ bool forceSRGB,
+        _In_ bool stripSRGB,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
         _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -145,6 +145,7 @@ namespace
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
         _In_ bool forceSRGB,
+        _In_ bool stripSRGB,
         _In_ bool isCubeMap,
         _In_reads_opt_(mipCount*arraySize) const D3D11_SUBRESOURCE_DATA* initData,
         _Outptr_opt_ ID3D11Resource** texture,
@@ -155,9 +156,16 @@ namespace
 
         HRESULT hr = E_FAIL;
 
+        if (forceSRGB && stripSRGB)
+            return E_INVALIDARG;
+
         if (forceSRGB)
         {
             format = MakeSRGB(format);
+        }
+        else if (stripSRGB)
+        {
+            format = StripSRGB(format);
         }
 
         switch (resDim)
@@ -381,6 +389,7 @@ namespace
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
         _In_ bool forceSRGB,
+        _In_ bool stripSRGB,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept
     {
@@ -612,7 +621,7 @@ namespace
                 usage,
                 bindFlags | D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET,
                 cpuAccessFlags,
-                miscFlags | D3D11_RESOURCE_MISC_GENERATE_MIPS, forceSRGB,
+                miscFlags | D3D11_RESOURCE_MISC_GENERATE_MIPS, forceSRGB, stripSRGB,
                 isCubeMap,
                 nullptr,
                 &tex, textureView);
@@ -789,7 +798,7 @@ namespace
                     resDim, twidth, theight, tdepth, mipCount - skipMip, arraySize,
                     format,
                     usage, bindFlags, cpuAccessFlags, miscFlags,
-                    forceSRGB,
+                    forceSRGB, stripSRGB,
                     isCubeMap,
                     initData.get(),
                     texture, textureView);
@@ -835,7 +844,7 @@ namespace
                             resDim, twidth, theight, tdepth, mipCount - skipMip, arraySize,
                             format,
                             usage, bindFlags, cpuAccessFlags, miscFlags,
-                            forceSRGB,
+                            forceSRGB, stripSRGB,
                             isCubeMap,
                             initData.get(),
                             texture, textureView);
@@ -939,7 +948,7 @@ HRESULT DirectX::CreateDDSTextureFromMemory(
         ddsData, ddsDataSize,
         maxsize,
         D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-        false,
+        false, false,
         texture, textureView, alphaMode);
 }
 
@@ -964,7 +973,7 @@ HRESULT DirectX::CreateDDSTextureFromMemory(
         ddsData, ddsDataSize,
         maxsize,
         D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-        false,
+        false, false,
         texture, textureView, alphaMode);
 }
 
@@ -979,6 +988,7 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
     unsigned int cpuAccessFlags,
     unsigned int miscFlags,
     bool forceSRGB,
+    bool stripSRGB,
     ID3D11Resource** texture,
     ID3D11ShaderResourceView** textureView,
     DDS_ALPHA_MODE* alphaMode) noexcept
@@ -1028,7 +1038,7 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
         header, bitData, bitSize,
         maxsize,
         usage, bindFlags, cpuAccessFlags, miscFlags,
-        forceSRGB,
+        forceSRGB, stripSRGB,
         texture, textureView);
     if (SUCCEEDED(hr))
     {
@@ -1067,6 +1077,7 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
         unsigned int cpuAccessFlags,
         unsigned int miscFlags,
         bool forceSRGB,
+        bool stripSRGB,
         ID3D11Resource** texture,
         ID3D11ShaderResourceView** textureView,
         DDS_ALPHA_MODE* alphaMode) noexcept
@@ -1116,7 +1127,7 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
         header, bitData, bitSize,
         maxsize,
         usage, bindFlags, cpuAccessFlags, miscFlags,
-        forceSRGB,
+        forceSRGB, stripSRGB,
         texture, textureView);
     if (SUCCEEDED(hr))
     {
@@ -1151,7 +1162,7 @@ HRESULT DirectX::CreateDDSTextureFromFile(
         fileName,
         maxsize,
         D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-        false,
+        false, false,
         texture, textureView, alphaMode);
 }
 
@@ -1175,7 +1186,7 @@ HRESULT DirectX::CreateDDSTextureFromFile(
         fileName,
         maxsize,
         D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-        false,
+        false, false,
         texture, textureView, alphaMode);
 }
 
@@ -1189,6 +1200,7 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
     unsigned int cpuAccessFlags,
     unsigned int miscFlags,
     bool forceSRGB,
+    bool stripSRGB,
     ID3D11Resource** texture,
     ID3D11ShaderResourceView** textureView,
     DDS_ALPHA_MODE* alphaMode) noexcept
@@ -1239,7 +1251,7 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
         header, bitData, bitSize,
         maxsize,
         usage, bindFlags, cpuAccessFlags, miscFlags,
-        forceSRGB,
+        forceSRGB, stripSRGB,
         texture, textureView);
 
     if (SUCCEEDED(hr))
@@ -1270,6 +1282,7 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
         unsigned int cpuAccessFlags,
         unsigned int miscFlags,
         bool forceSRGB,
+        bool stripSRGB,
         ID3D11Resource** texture,
         ID3D11ShaderResourceView** textureView,
         DDS_ALPHA_MODE* alphaMode) noexcept
@@ -1320,7 +1333,7 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
         header, bitData, bitSize,
         maxsize,
         usage, bindFlags, cpuAccessFlags, miscFlags,
-        forceSRGB,
+        forceSRGB, stripSRGB,
         texture, textureView);
 
     if (SUCCEEDED(hr))

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -158,7 +158,7 @@ namespace
         uint32_t exclusiveFlags = DDS_LOADER_FORCE_SRGB | DDS_LOADER_IGNORE_SRGB | DDS_LOADER_SRGB_DEFAULT;
         uint32_t exclusivesSet = loadFlags & exclusiveFlags;
 
-        if (!(exclusivesSet && !(exclusivesSet & (exclusivesSet - 1))))
+        if (exclusivesSet && (exclusivesSet & (exclusivesSet - 1)))
             return E_INVALIDARG;
 
         if (loadFlags & DDS_LOADER_FORCE_SRGB)

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -144,8 +144,7 @@ namespace
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ bool forceSRGB,
-        _In_ bool stripSRGB,
+        _In_ DDS_LOADER_FLAGS loadFlags,
         _In_ bool isCubeMap,
         _In_reads_opt_(mipCount*arraySize) const D3D11_SUBRESOURCE_DATA* initData,
         _Outptr_opt_ ID3D11Resource** texture,
@@ -156,14 +155,17 @@ namespace
 
         HRESULT hr = E_FAIL;
 
-        if (forceSRGB && stripSRGB)
+        uint32_t exclusiveFlags = DDS_LOADER_FORCE_SRGB | DDS_LOADER_IGNORE_SRGB | DDS_LOADER_SRGB_DEFAULT;
+        uint32_t exclusivesSet = loadFlags & exclusiveFlags;
+
+        if (!(exclusivesSet && !(exclusivesSet & (exclusivesSet - 1))))
             return E_INVALIDARG;
 
-        if (forceSRGB)
+        if (loadFlags & DDS_LOADER_FORCE_SRGB)
         {
             format = MakeSRGB(format);
         }
-        else if (stripSRGB)
+        else if (loadFlags & DDS_LOADER_IGNORE_SRGB)
         {
             format = StripSRGB(format);
         }
@@ -388,8 +390,7 @@ namespace
         _In_ unsigned int bindFlags,
         _In_ unsigned int cpuAccessFlags,
         _In_ unsigned int miscFlags,
-        _In_ bool forceSRGB,
-        _In_ bool stripSRGB,
+        _In_ DDS_LOADER_FLAGS loadFlags,
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept
     {
@@ -621,7 +622,7 @@ namespace
                 usage,
                 bindFlags | D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET,
                 cpuAccessFlags,
-                miscFlags | D3D11_RESOURCE_MISC_GENERATE_MIPS, forceSRGB, stripSRGB,
+                miscFlags | D3D11_RESOURCE_MISC_GENERATE_MIPS, loadFlags,
                 isCubeMap,
                 nullptr,
                 &tex, textureView);
@@ -798,7 +799,7 @@ namespace
                     resDim, twidth, theight, tdepth, mipCount - skipMip, arraySize,
                     format,
                     usage, bindFlags, cpuAccessFlags, miscFlags,
-                    forceSRGB, stripSRGB,
+                    loadFlags,
                     isCubeMap,
                     initData.get(),
                     texture, textureView);
@@ -844,7 +845,7 @@ namespace
                             resDim, twidth, theight, tdepth, mipCount - skipMip, arraySize,
                             format,
                             usage, bindFlags, cpuAccessFlags, miscFlags,
-                            forceSRGB, stripSRGB,
+                            loadFlags,
                             isCubeMap,
                             initData.get(),
                             texture, textureView);
@@ -948,7 +949,7 @@ HRESULT DirectX::CreateDDSTextureFromMemory(
         ddsData, ddsDataSize,
         maxsize,
         D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-        false, false,
+        DDS_LOADER_DEFAULT,
         texture, textureView, alphaMode);
 }
 
@@ -973,7 +974,7 @@ HRESULT DirectX::CreateDDSTextureFromMemory(
         ddsData, ddsDataSize,
         maxsize,
         D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-        false, false,
+        DDS_LOADER_DEFAULT,
         texture, textureView, alphaMode);
 }
 
@@ -987,8 +988,7 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
     unsigned int bindFlags,
     unsigned int cpuAccessFlags,
     unsigned int miscFlags,
-    bool forceSRGB,
-    bool stripSRGB,
+    DDS_LOADER_FLAGS loadFlags,
     ID3D11Resource** texture,
     ID3D11ShaderResourceView** textureView,
     DDS_ALPHA_MODE* alphaMode) noexcept
@@ -1038,7 +1038,7 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
         header, bitData, bitSize,
         maxsize,
         usage, bindFlags, cpuAccessFlags, miscFlags,
-        forceSRGB, stripSRGB,
+        loadFlags,
         texture, textureView);
     if (SUCCEEDED(hr))
     {
@@ -1076,8 +1076,7 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
         unsigned int bindFlags,
         unsigned int cpuAccessFlags,
         unsigned int miscFlags,
-        bool forceSRGB,
-        bool stripSRGB,
+        DDS_LOADER_FLAGS loadFlags,
         ID3D11Resource** texture,
         ID3D11ShaderResourceView** textureView,
         DDS_ALPHA_MODE* alphaMode) noexcept
@@ -1127,7 +1126,7 @@ HRESULT DirectX::CreateDDSTextureFromMemoryEx(
         header, bitData, bitSize,
         maxsize,
         usage, bindFlags, cpuAccessFlags, miscFlags,
-        forceSRGB, stripSRGB,
+        loadFlags,
         texture, textureView);
     if (SUCCEEDED(hr))
     {
@@ -1162,7 +1161,7 @@ HRESULT DirectX::CreateDDSTextureFromFile(
         fileName,
         maxsize,
         D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-        false, false,
+        DDS_LOADER_DEFAULT,
         texture, textureView, alphaMode);
 }
 
@@ -1186,7 +1185,7 @@ HRESULT DirectX::CreateDDSTextureFromFile(
         fileName,
         maxsize,
         D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-        false, false,
+        DDS_LOADER_DEFAULT,
         texture, textureView, alphaMode);
 }
 
@@ -1199,8 +1198,7 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
     unsigned int bindFlags,
     unsigned int cpuAccessFlags,
     unsigned int miscFlags,
-    bool forceSRGB,
-    bool stripSRGB,
+    DDS_LOADER_FLAGS loadFlags,
     ID3D11Resource** texture,
     ID3D11ShaderResourceView** textureView,
     DDS_ALPHA_MODE* alphaMode) noexcept
@@ -1251,7 +1249,7 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
         header, bitData, bitSize,
         maxsize,
         usage, bindFlags, cpuAccessFlags, miscFlags,
-        forceSRGB, stripSRGB,
+        loadFlags,
         texture, textureView);
 
     if (SUCCEEDED(hr))
@@ -1281,8 +1279,7 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
         unsigned int bindFlags,
         unsigned int cpuAccessFlags,
         unsigned int miscFlags,
-        bool forceSRGB,
-        bool stripSRGB,
+        DDS_LOADER_FLAGS loadFlags,
         ID3D11Resource** texture,
         ID3D11ShaderResourceView** textureView,
         DDS_ALPHA_MODE* alphaMode) noexcept
@@ -1333,7 +1330,7 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
         header, bitData, bitSize,
         maxsize,
         usage, bindFlags, cpuAccessFlags, miscFlags,
-        forceSRGB, stripSRGB,
+        loadFlags,
         texture, textureView);
 
     if (SUCCEEDED(hr))

--- a/Src/DGSLEffectFactory.cpp
+++ b/Src/DGSLEffectFactory.cpp
@@ -413,7 +413,7 @@ void DGSLEffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCon
             HRESULT hr = CreateDDSTextureFromFileEx(
                 mDevice.Get(), fullName, 0,
                 D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-                mForceSRGB, nullptr, textureView);
+                mForceSRGB, false, nullptr, textureView);
             if (FAILED(hr))
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",

--- a/Src/DGSLEffectFactory.cpp
+++ b/Src/DGSLEffectFactory.cpp
@@ -413,7 +413,7 @@ void DGSLEffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceCon
             HRESULT hr = CreateDDSTextureFromFileEx(
                 mDevice.Get(), fullName, 0,
                 D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-                mForceSRGB, false, nullptr, textureView);
+                mForceSRGB ? DDS_LOADER_FORCE_SRGB : DDS_LOADER_DEFAULT, nullptr, textureView);
             if (FAILED(hr))
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",

--- a/Src/EffectFactory.cpp
+++ b/Src/EffectFactory.cpp
@@ -411,7 +411,7 @@ void EffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext
             HRESULT hr = CreateDDSTextureFromFileEx(
                 mDevice.Get(), fullName, 0,
                 D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-                mForceSRGB, false, nullptr, textureView);
+                mForceSRGB ? DDS_LOADER_FORCE_SRGB : DDS_LOADER_DEFAULT, nullptr, textureView);
             if (FAILED(hr))
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",

--- a/Src/EffectFactory.cpp
+++ b/Src/EffectFactory.cpp
@@ -411,7 +411,7 @@ void EffectFactory::Impl::CreateTexture(const wchar_t* name, ID3D11DeviceContext
             HRESULT hr = CreateDDSTextureFromFileEx(
                 mDevice.Get(), fullName, 0,
                 D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-                mForceSRGB, nullptr, textureView);
+                mForceSRGB, false, nullptr, textureView);
             if (FAILED(hr))
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -222,6 +222,37 @@ namespace DirectX
         }
 
         //--------------------------------------------------------------------------------------
+        inline DXGI_FORMAT StripSRGB(_In_ DXGI_FORMAT format) noexcept
+        {
+            switch (format)
+            {
+            case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+                return DXGI_FORMAT_R8G8B8A8_UNORM;
+
+            case DXGI_FORMAT_BC1_UNORM_SRGB:
+                return DXGI_FORMAT_BC1_UNORM;
+
+            case DXGI_FORMAT_BC2_UNORM_SRGB:
+                return DXGI_FORMAT_BC2_UNORM;
+
+            case DXGI_FORMAT_BC3_UNORM_SRGB:
+                return DXGI_FORMAT_BC3_UNORM;
+
+            case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+                return DXGI_FORMAT_B8G8R8A8_UNORM;
+
+            case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+                return DXGI_FORMAT_B8G8R8X8_UNORM;
+
+            case DXGI_FORMAT_BC7_UNORM_SRGB:
+                return DXGI_FORMAT_BC7_UNORM;
+
+            default:
+                return format;
+            }
+        }
+
+        //--------------------------------------------------------------------------------------
         inline bool IsCompressed(_In_ DXGI_FORMAT fmt) noexcept
         {
             switch (fmt)

--- a/Src/PBREffectFactory.cpp
+++ b/Src/PBREffectFactory.cpp
@@ -243,7 +243,7 @@ void PBREffectFactory::Impl::CreateTexture(
             HRESULT hr = CreateDDSTextureFromFileEx(
                 mDevice.Get(), fullName, 0,
                 D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-                mForceSRGB, false, nullptr, textureView);
+                mForceSRGB ? DDS_LOADER_FORCE_SRGB : DDS_LOADER_DEFAULT, nullptr, textureView);
             if (FAILED(hr))
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",

--- a/Src/PBREffectFactory.cpp
+++ b/Src/PBREffectFactory.cpp
@@ -243,7 +243,7 @@ void PBREffectFactory::Impl::CreateTexture(
             HRESULT hr = CreateDDSTextureFromFileEx(
                 mDevice.Get(), fullName, 0,
                 D3D11_USAGE_DEFAULT, D3D11_BIND_SHADER_RESOURCE, 0, 0,
-                mForceSRGB, nullptr, textureView);
+                mForceSRGB, false, nullptr, textureView);
             if (FAILED(hr))
             {
                 DebugTrace("ERROR: CreateDDSTextureFromFile failed (%08X) for '%ls'\n",


### PR DESCRIPTION
In the process of migrating a non-gamma-aware project over to proper sRGB-aware rendering, I had need of functionality to _ignore_ the SRGB encoding of a texture during loading (the inverse of the existing forceSRGB parameter/functionality).  This allows one to incrementally (re)process textures to be SRGB tagged as appropriate, but allow the (still SRGB-ignorant) renderer to ignore that and process/fetch from it just as before to maintain visual consistency until the entire pipeline and renderer is ready to fully switch over.  While I don't personally have need of it past the migration switch-over, I could imagine it being handy for folks who want to use SRGB-encoded textures as-is in a non-SRGB-aware runtime.