### PR TITLE
Add use of C++11 inline namespaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,36 +50,25 @@ set(LIBRARY_HEADERS
     Inc/DDSTextureLoader.h
     Inc/DirectXHelpers.h
     Inc/Effects.h
-    Inc/GamePad.h
     Inc/GeometricPrimitive.h
     Inc/GraphicsMemory.h
-    Inc/Keyboard.h
     Inc/Model.h
-    Inc/Mouse.h
     Inc/PostProcess.h
     Inc/PrimitiveBatch.h
     Inc/ScreenGrab.h
-    Inc/SimpleMath.h
-    Inc/SimpleMath.inl
     Inc/SpriteBatch.h
     Inc/SpriteFont.h
     Inc/VertexTypes.h
     Inc/WICTextureLoader.h)
 
 set(LIBRARY_SOURCES
-    Src/AlignedNew.h
     Src/AlphaTestEffect.cpp
     Src/BasicEffect.cpp
     Src/BasicPostProcess.cpp
-    Src/Bezier.h
-    Src/BinaryReader.cpp
-    Src/BinaryReader.h
     Src/BufferHelpers.cpp
     Src/CommonStates.cpp
-    Src/DDS.h
     Src/DDSTextureLoader.cpp
     Src/DebugEffect.cpp
-    Src/DemandCreate.h
     Src/DGSLEffect.cpp
     Src/DGSLEffectFactory.cpp
     Src/DirectXHelpers.cpp
@@ -89,41 +78,28 @@ set(LIBRARY_SOURCES
     Src/EffectCommon.h
     Src/EffectFactory.cpp
     Src/EnvironmentMapEffect.cpp
-    Src/GamePad.cpp
     Src/GeometricPrimitive.cpp
-    Src/Geometry.h
-    Src/Geometry.cpp
     Src/GraphicsMemory.cpp
-    Src/Keyboard.cpp
-    Src/LoaderHelpers.h
     Src/Model.cpp
     Src/ModelLoadCMO.cpp
     Src/ModelLoadSDKMESH.cpp
     Src/ModelLoadVBO.cpp
-    Src/Mouse.cpp
     Src/NormalMapEffect.cpp
     Src/PBREffect.cpp
     Src/PBREffectFactory.cpp
     Src/pch.h
-    Src/PlatformHelpers.h
     Src/PrimitiveBatch.cpp
     Src/ScreenGrab.cpp
-    Src/SDKMesh.h
-    Src/SharedResourcePool.h
-    Src/SimpleMath.cpp
     Src/SkinnedEffect.cpp
     Src/SpriteBatch.cpp
     Src/SpriteFont.cpp
-    Src/TeapotData.inc
     Src/ToneMapPostProcess.cpp
-    Src/vbo.h
     Src/VertexTypes.cpp
     Src/WICTextureLoader.cpp)
 
 set(SHADER_SOURCES
     Src/Shaders/AlphaTestEffect.fx
     Src/Shaders/BasicEffect.fx
-    Src/Shaders/Common.fxh
     Src/Shaders/DebugEffect.fx
     Src/Shaders/DGSLEffect.fx
     Src/Shaders/DGSLLambert.hlsl
@@ -131,17 +107,48 @@ set(SHADER_SOURCES
     Src/Shaders/DGSLUnlit.hlsl
     Src/Shaders/DualTextureEffect.fx
     Src/Shaders/EnvironmentMapEffect.fx
-    Src/Shaders/Lighting.fxh
     Src/Shaders/NormalMapEffect.fx
-    Src/Shaders/PBRCommon.fxh
     Src/Shaders/PBREffect.fx
-    Src/Shaders/PixelPacking_Velocity.hlsli
     Src/Shaders/PostProcess.fx
     Src/Shaders/SkinnedEffect.fx
-    Src/Shaders/Skinning.fxh
     Src/Shaders/SpriteEffect.fx
+    Src/Shaders/ToneMap.fx)
+
+# These source files are identical in both DX11 and DX12 version.
+set(LIBRARY_HEADERS ${LIBRARY_HEADERS}
+    Inc/GamePad.h
+    Inc/Keyboard.h
+    Inc/Mouse.h
+    Inc/SimpleMath.h
+    Inc/SimpleMath.inl)
+
+set(LIBRARY_SOURCES ${LIBRARY_SOURCES}
+    Src/AlignedNew.h
+    Src/Bezier.h
+    Src/BinaryReader.h
+    Src/DDS.h
+    Src/DemandCreate.h
+    Src/Geometry.h
+    Src/LoaderHelpers.h
+    Src/PlatformHelpers.h
+    Src/SDKMesh.h
+    Src/SharedResourcePool.h
+    Src/vbo.h
+    Src/TeapotData.inc
+    Src/BinaryReader.cpp
+    Src/GamePad.cpp
+    Src/Geometry.cpp
+    Src/Keyboard.cpp
+    Src/Mouse.cpp
+    Src/SimpleMath.cpp)
+
+set(SHADER_SOURCES ${SHADER_SOURCES}
+    Src/Shaders/Common.fxh
+    Src/Shaders/Lighting.fxh
+    Src/Shaders/PBRCommon.fxh
+    Src/Shaders/PixelPacking_Velocity.hlsli
+    Src/Shaders/Skinning.fxh
     Src/Shaders/Structures.fxh
-    Src/Shaders/ToneMap.fx
     Src/Shaders/Utilities.fxh)
 
 if(MINGW)

--- a/Inc/BufferHelpers.h
+++ b/Inc/BufferHelpers.h
@@ -91,7 +91,7 @@ namespace DirectX
         unsigned int bindFlags = D3D11_BIND_SHADER_RESOURCE) noexcept;
 
     // Strongly typed wrapper around a Direct3D constant buffer.
-    namespace Internal
+    namespace Private
     {
         // Base class, not to be used directly: clients should access this via the derived PrimitiveBatch<T>.
         class ConstantBufferBase
@@ -102,7 +102,7 @@ namespace DirectX
     }
 
     template<typename T>
-    class ConstantBuffer : public Internal::ConstantBufferBase
+    class ConstantBuffer : public Private::ConstantBufferBase
     {
     public:
         // Constructor.

--- a/Inc/CommonStates.h
+++ b/Inc/CommonStates.h
@@ -20,50 +20,53 @@
 
 namespace DirectX
 {
-    class CommonStates
+    inline namespace DX11
     {
-    public:
-        explicit CommonStates(_In_ ID3D11Device* device);
+        class CommonStates
+        {
+        public:
+            explicit CommonStates(_In_ ID3D11Device* device);
 
-        CommonStates(CommonStates&&) noexcept;
-        CommonStates& operator= (CommonStates&&) noexcept;
+            CommonStates(CommonStates&&) noexcept;
+            CommonStates& operator= (CommonStates&&) noexcept;
 
-        CommonStates(CommonStates const&) = delete;
-        CommonStates& operator= (CommonStates const&) = delete;
+            CommonStates(CommonStates const&) = delete;
+            CommonStates& operator= (CommonStates const&) = delete;
 
-        virtual ~CommonStates();
+            virtual ~CommonStates();
 
-        // Blend states.
-        ID3D11BlendState* __cdecl Opaque() const;
-        ID3D11BlendState* __cdecl AlphaBlend() const;
-        ID3D11BlendState* __cdecl Additive() const;
-        ID3D11BlendState* __cdecl NonPremultiplied() const;
+            // Blend states.
+            ID3D11BlendState* __cdecl Opaque() const;
+            ID3D11BlendState* __cdecl AlphaBlend() const;
+            ID3D11BlendState* __cdecl Additive() const;
+            ID3D11BlendState* __cdecl NonPremultiplied() const;
 
-        // Depth stencil states.
-        ID3D11DepthStencilState* __cdecl DepthNone() const;
-        ID3D11DepthStencilState* __cdecl DepthDefault() const;
-        ID3D11DepthStencilState* __cdecl DepthRead() const;
-        ID3D11DepthStencilState* __cdecl DepthReverseZ() const;
-        ID3D11DepthStencilState* __cdecl DepthReadReverseZ() const;
+            // Depth stencil states.
+            ID3D11DepthStencilState* __cdecl DepthNone() const;
+            ID3D11DepthStencilState* __cdecl DepthDefault() const;
+            ID3D11DepthStencilState* __cdecl DepthRead() const;
+            ID3D11DepthStencilState* __cdecl DepthReverseZ() const;
+            ID3D11DepthStencilState* __cdecl DepthReadReverseZ() const;
 
-        // Rasterizer states.
-        ID3D11RasterizerState* __cdecl CullNone() const;
-        ID3D11RasterizerState* __cdecl CullClockwise() const;
-        ID3D11RasterizerState* __cdecl CullCounterClockwise() const;
-        ID3D11RasterizerState* __cdecl Wireframe() const;
+            // Rasterizer states.
+            ID3D11RasterizerState* __cdecl CullNone() const;
+            ID3D11RasterizerState* __cdecl CullClockwise() const;
+            ID3D11RasterizerState* __cdecl CullCounterClockwise() const;
+            ID3D11RasterizerState* __cdecl Wireframe() const;
 
-        // Sampler states.
-        ID3D11SamplerState* __cdecl PointWrap() const;
-        ID3D11SamplerState* __cdecl PointClamp() const;
-        ID3D11SamplerState* __cdecl LinearWrap() const;
-        ID3D11SamplerState* __cdecl LinearClamp() const;
-        ID3D11SamplerState* __cdecl AnisotropicWrap() const;
-        ID3D11SamplerState* __cdecl AnisotropicClamp() const;
+            // Sampler states.
+            ID3D11SamplerState* __cdecl PointWrap() const;
+            ID3D11SamplerState* __cdecl PointClamp() const;
+            ID3D11SamplerState* __cdecl LinearWrap() const;
+            ID3D11SamplerState* __cdecl LinearClamp() const;
+            ID3D11SamplerState* __cdecl AnisotropicWrap() const;
+            ID3D11SamplerState* __cdecl AnisotropicClamp() const;
 
-    private:
-        // Private implementation.
-        class Impl;
+        private:
+            // Private implementation.
+            class Impl;
 
-        std::shared_ptr<Impl> pImpl;
-    };
+            std::shared_ptr<Impl> pImpl;
+        };
+    }
 }

--- a/Inc/DDSTextureLoader.h
+++ b/Inc/DDSTextureLoader.h
@@ -40,12 +40,15 @@ namespace DirectX
     };
 #endif
 
-    enum DDS_LOADER_FLAGS : uint32_t
+    inline namespace DX11
     {
-        DDS_LOADER_DEFAULT = 0,
-        DDS_LOADER_FORCE_SRGB = 0x1,
-        DDS_LOADER_IGNORE_SRGB = 0x2,
-    };
+        enum DDS_LOADER_FLAGS : uint32_t
+        {
+            DDS_LOADER_DEFAULT = 0,
+            DDS_LOADER_FORCE_SRGB = 0x1,
+            DDS_LOADER_IGNORE_SRGB = 0x2,
+        };
+    }
 
     // Standard version
     HRESULT __cdecl CreateDDSTextureFromMemory(
@@ -168,7 +171,10 @@ namespace DirectX
 #pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
 #endif
 
-    DEFINE_ENUM_FLAG_OPERATORS(DDS_LOADER_FLAGS);
+    inline namespace DX11
+    {
+        DEFINE_ENUM_FLAG_OPERATORS(DDS_LOADER_FLAGS);
+    }
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/Inc/DirectXHelpers.h
+++ b/Inc/DirectXHelpers.h
@@ -55,7 +55,10 @@
 
 namespace DirectX
 {
-    class IEffect;
+    inline namespace DX11
+    {
+        class IEffect;
+    }
 
     // simliar to std::lock_guard for exception-safe Direct3D resource locking
     class MapGuard : public D3D11_MAPPED_SUBRESOURCE
@@ -166,33 +169,36 @@ namespace DirectX
     #endif
     }
 
-    // Helper to check for power-of-2
-    template<typename T>
-    constexpr bool IsPowerOf2(T x) noexcept { return ((x != 0) && !(x & (x - 1))); }
-
-    // Helpers for aligning values by a power of 2
-    template<typename T>
-    inline T AlignDown(T size, size_t alignment) noexcept
+    inline namespace DX11
     {
-        if (alignment > 0)
-        {
-            assert(((alignment - 1) & alignment) == 0);
-            auto mask = static_cast<T>(alignment - 1);
-            return size & ~mask;
-        }
-        return size;
-    }
+        // Helper to check for power-of-2
+        template<typename T>
+        constexpr bool IsPowerOf2(T x) noexcept { return ((x != 0) && !(x & (x - 1))); }
 
-    template<typename T>
-    inline T AlignUp(T size, size_t alignment) noexcept
-    {
-        if (alignment > 0)
+        // Helpers for aligning values by a power of 2
+        template<typename T>
+        inline T AlignDown(T size, size_t alignment) noexcept
         {
-            assert(((alignment - 1) & alignment) == 0);
-            auto mask = static_cast<T>(alignment - 1);
-            return (size + mask) & ~mask;
+            if (alignment > 0)
+            {
+                assert(((alignment - 1) & alignment) == 0);
+                auto mask = static_cast<T>(alignment - 1);
+                return size & ~mask;
+            }
+            return size;
         }
-        return size;
+
+        template<typename T>
+        inline T AlignUp(T size, size_t alignment) noexcept
+        {
+            if (alignment > 0)
+            {
+                assert(((alignment - 1) & alignment) == 0);
+                auto mask = static_cast<T>(alignment - 1);
+                return (size + mask) & ~mask;
+            }
+            return size;
+        }
     }
 
     // Helper for creating a Direct3D input layout to match a shader from an IEffect

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -23,1003 +23,1007 @@
 
 namespace DirectX
 {
-    //----------------------------------------------------------------------------------
-    // Abstract interface representing any effect which can be applied onto a D3D device context.
-    class IEffect
+    inline namespace DX11
     {
-    public:
-        virtual ~IEffect() = default;
-
-        IEffect(const IEffect&) = delete;
-        IEffect& operator=(const IEffect&) = delete;
-
-        virtual void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) = 0;
-
-        virtual void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) = 0;
-
-    protected:
-        IEffect() = default;
-        IEffect(IEffect&&) = default;
-        IEffect& operator=(IEffect&&) = default;
-    };
-
-
-    // Abstract interface for effects with world, view, and projection matrices.
-    class IEffectMatrices
-    {
-    public:
-        virtual ~IEffectMatrices() = default;
-
-        IEffectMatrices(const IEffectMatrices&) = delete;
-        IEffectMatrices& operator=(const IEffectMatrices&) = delete;
-
-        virtual void XM_CALLCONV SetWorld(FXMMATRIX value) = 0;
-        virtual void XM_CALLCONV SetView(FXMMATRIX value) = 0;
-        virtual void XM_CALLCONV SetProjection(FXMMATRIX value) = 0;
-        virtual void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection);
-
-    protected:
-        IEffectMatrices() = default;
-        IEffectMatrices(IEffectMatrices&&) = default;
-        IEffectMatrices& operator=(IEffectMatrices&&) = default;
-    };
-
-
-    // Abstract interface for effects which support directional lighting.
-    class IEffectLights
-    {
-    public:
-        virtual ~IEffectLights() = default;
-
-        IEffectLights(const IEffectLights&) = delete;
-        IEffectLights& operator=(const IEffectLights&) = delete;
-
-        virtual void __cdecl SetLightingEnabled(bool value) = 0;
-        virtual void __cdecl SetPerPixelLighting(bool value) = 0;
-        virtual void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) = 0;
-
-        virtual void __cdecl SetLightEnabled(int whichLight, bool value) = 0;
-        virtual void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) = 0;
-        virtual void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) = 0;
-        virtual void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) = 0;
-
-        virtual void __cdecl EnableDefaultLighting() = 0;
-
-        static constexpr int MaxDirectionalLights = 3;
-
-    protected:
-        IEffectLights() = default;
-        IEffectLights(IEffectLights&&) = default;
-        IEffectLights& operator=(IEffectLights&&) = default;
-    };
-
-
-    // Abstract interface for effects which support fog.
-    class IEffectFog
-    {
-    public:
-        virtual ~IEffectFog() = default;
-
-        IEffectFog(const IEffectFog&) = delete;
-        IEffectFog& operator=(const IEffectFog&) = delete;
-
-        virtual void __cdecl SetFogEnabled(bool value) = 0;
-        virtual void __cdecl SetFogStart(float value) = 0;
-        virtual void __cdecl SetFogEnd(float value) = 0;
-        virtual void XM_CALLCONV SetFogColor(FXMVECTOR value) = 0;
-
-    protected:
-        IEffectFog() = default;
-        IEffectFog(IEffectFog&&) = default;
-        IEffectFog& operator=(IEffectFog&&) = default;
-    };
-
-
-    // Abstract interface for effects which support skinning
-    class IEffectSkinning
-    {
-    public:
-        virtual ~IEffectSkinning() = default;
-
-        IEffectSkinning(const IEffectSkinning&) = delete;
-        IEffectSkinning& operator=(const IEffectSkinning&) = delete;
-
-        virtual void __cdecl SetWeightsPerVertex(int value) = 0;
-        virtual void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) = 0;
-        virtual void __cdecl ResetBoneTransforms() = 0;
-
-        static constexpr int MaxBones = 72;
-
-    protected:
-        IEffectSkinning() = default;
-        IEffectSkinning(IEffectSkinning&&) = default;
-        IEffectSkinning& operator=(IEffectSkinning&&) = default;
-    };
-
-    //----------------------------------------------------------------------------------
-    // Built-in shader supports optional texture mapping, vertex coloring, directional lighting, and fog.
-    class BasicEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
-    {
-    public:
-        explicit BasicEffect(_In_ ID3D11Device* device);
-
-        BasicEffect(BasicEffect&&) noexcept;
-        BasicEffect& operator= (BasicEffect&&) noexcept;
-
-        BasicEffect(BasicEffect const&) = delete;
-        BasicEffect& operator= (BasicEffect const&) = delete;
-
-        ~BasicEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
-
-        void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
-        void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
-        void __cdecl SetSpecularPower(float value);
-        void __cdecl DisableSpecular();
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Light settings.
-        void __cdecl SetLightingEnabled(bool value) override;
-        void __cdecl SetPerPixelLighting(bool value) override;
-        void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
-
-        void __cdecl SetLightEnabled(int whichLight, bool value) override;
-        void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
-
-        void __cdecl EnableDefaultLighting() override;
-
-        // Fog settings.
-        void __cdecl SetFogEnabled(bool value) override;
-        void __cdecl SetFogStart(float value) override;
-        void __cdecl SetFogEnd(float value) override;
-        void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
-
-        // Vertex color setting.
-        void __cdecl SetVertexColorEnabled(bool value);
-
-        // Texture setting.
-        void __cdecl SetTextureEnabled(bool value);
-        void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
-
-        // Normal compression settings.
-        void __cdecl SetBiasedVertexNormals(bool value);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-
-    // Built-in shader supports per-pixel alpha testing.
-    class AlphaTestEffect : public IEffect, public IEffectMatrices, public IEffectFog
-    {
-    public:
-        explicit AlphaTestEffect(_In_ ID3D11Device* device);
-
-        AlphaTestEffect(AlphaTestEffect&&) noexcept;
-        AlphaTestEffect& operator= (AlphaTestEffect&&) noexcept;
-
-        AlphaTestEffect(AlphaTestEffect const&) = delete;
-        AlphaTestEffect& operator= (AlphaTestEffect const&) = delete;
-
-        ~AlphaTestEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
-
-        void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Fog settings.
-        void __cdecl SetFogEnabled(bool value) override;
-        void __cdecl SetFogStart(float value) override;
-        void __cdecl SetFogEnd(float value) override;
-        void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
-
-        // Vertex color setting.
-        void __cdecl SetVertexColorEnabled(bool value);
-
-        // Texture setting.
-        void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
-
-        // Alpha test settings.
-        void __cdecl SetAlphaFunction(D3D11_COMPARISON_FUNC value);
-        void __cdecl SetReferenceAlpha(int value);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-
-    // Built-in shader supports two layer multitexturing (eg. for lightmaps or detail textures).
-    class DualTextureEffect : public IEffect, public IEffectMatrices, public IEffectFog
-    {
-    public:
-        explicit DualTextureEffect(_In_ ID3D11Device* device);
-
-        DualTextureEffect(DualTextureEffect&&) noexcept;
-        DualTextureEffect& operator= (DualTextureEffect&&) noexcept;
-
-        DualTextureEffect(DualTextureEffect const&) = delete;
-        DualTextureEffect& operator= (DualTextureEffect const&) = delete;
-
-        ~DualTextureEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
-
-        void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Fog settings.
-        void __cdecl SetFogEnabled(bool value) override;
-        void __cdecl SetFogStart(float value) override;
-        void __cdecl SetFogEnd(float value) override;
-        void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
-
-        // Vertex color setting.
-        void __cdecl SetVertexColorEnabled(bool value);
-
-        // Texture settings.
-        void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
-        void __cdecl SetTexture2(_In_opt_ ID3D11ShaderResourceView* value);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-
-    // Built-in shader supports cubic environment mapping.
-    class EnvironmentMapEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
-    {
-    public:
-        enum Mapping
+        //------------------------------------------------------------------------------
+        // Abstract interface representing any effect which can be applied onto a D3D device context.
+        class IEffect
         {
-            Mapping_Cube = 0,       // Cubic environment map
-            Mapping_Sphere,         // Spherical environment map
-            Mapping_DualParabola,   // Dual-parabola environment map (requires Feature Level 10.0)
+        public:
+            virtual ~IEffect() = default;
+
+            IEffect(const IEffect&) = delete;
+            IEffect& operator=(const IEffect&) = delete;
+
+            virtual void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) = 0;
+
+            virtual void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) = 0;
+
+        protected:
+            IEffect() = default;
+            IEffect(IEffect&&) = default;
+            IEffect& operator=(IEffect&&) = default;
         };
 
-        explicit EnvironmentMapEffect(_In_ ID3D11Device* device);
 
-        EnvironmentMapEffect(EnvironmentMapEffect&&) noexcept;
-        EnvironmentMapEffect& operator= (EnvironmentMapEffect&&) noexcept;
-
-        EnvironmentMapEffect(EnvironmentMapEffect const&) = delete;
-        EnvironmentMapEffect& operator= (EnvironmentMapEffect const&) = delete;
-
-        ~EnvironmentMapEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
-
-        void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Light settings.
-        void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
-
-        void __cdecl SetPerPixelLighting(bool value) override;
-        void __cdecl SetLightEnabled(int whichLight, bool value) override;
-        void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
-
-        void __cdecl EnableDefaultLighting() override;
-
-        // Fog settings.
-        void __cdecl SetFogEnabled(bool value) override;
-        void __cdecl SetFogStart(float value) override;
-        void __cdecl SetFogEnd(float value) override;
-        void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
-
-        // Texture setting.
-        void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
-        void __cdecl SetEnvironmentMap(_In_opt_ ID3D11ShaderResourceView* value);
-
-        // Environment map settings.
-        void __cdecl SetMode(Mapping mapping);
-        void __cdecl SetEnvironmentMapAmount(float value);
-        void XM_CALLCONV SetEnvironmentMapSpecular(FXMVECTOR value);
-        void __cdecl SetFresnelFactor(float value);
-
-        // Normal compression settings.
-        void __cdecl SetBiasedVertexNormals(bool value);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-
-        // Unsupported interface methods.
-        void __cdecl SetLightingEnabled(bool value) override;
-        void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
-    };
-
-
-
-    // Built-in shader supports skinned animation.
-    class SkinnedEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog, public IEffectSkinning
-    {
-    public:
-        explicit SkinnedEffect(_In_ ID3D11Device* device);
-
-        SkinnedEffect(SkinnedEffect&&) noexcept;
-        SkinnedEffect& operator= (SkinnedEffect&&) noexcept;
-
-        SkinnedEffect(SkinnedEffect const&) = delete;
-        SkinnedEffect& operator= (SkinnedEffect const&) = delete;
-
-        ~SkinnedEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
-
-        void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
-        void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
-        void __cdecl SetSpecularPower(float value);
-        void __cdecl DisableSpecular();
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Light settings.
-        void __cdecl SetPerPixelLighting(bool value) override;
-        void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
-
-        void __cdecl SetLightEnabled(int whichLight, bool value) override;
-        void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
-
-        void __cdecl EnableDefaultLighting() override;
-
-        // Fog settings.
-        void __cdecl SetFogEnabled(bool value) override;
-        void __cdecl SetFogStart(float value) override;
-        void __cdecl SetFogEnd(float value) override;
-        void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
-
-        // Texture setting.
-        void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
-
-        // Animation settings.
-        void __cdecl SetWeightsPerVertex(int value) override;
-        void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
-        void __cdecl ResetBoneTransforms() override;
-
-        // Normal compression settings.
-        void __cdecl SetBiasedVertexNormals(bool value);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-
-        // Unsupported interface method.
-        void __cdecl SetLightingEnabled(bool value) override;
-    };
-
-    //----------------------------------------------------------------------------------
-    // Built-in effect for Visual Studio Shader Designer (DGSL) shaders
-    class DGSLEffect : public IEffect, public IEffectMatrices, public IEffectLights
-    {
-    public:
-        explicit DGSLEffect(_In_ ID3D11Device* device, _In_opt_ ID3D11PixelShader* pixelShader = nullptr) :
-            DGSLEffect(device, pixelShader, false)
+        // Abstract interface for effects with world, view, and projection matrices.
+        class IEffectMatrices
         {
-        }
-
-        DGSLEffect(DGSLEffect&&) noexcept;
-        DGSLEffect& operator= (DGSLEffect&&) noexcept;
-
-        DGSLEffect(DGSLEffect const&) = delete;
-        DGSLEffect& operator= (DGSLEffect const&) = delete;
-
-        ~DGSLEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
-
-        void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetAmbientColor(FXMVECTOR value);
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
-        void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
-        void __cdecl SetSpecularPower(float value);
-        void __cdecl DisableSpecular();
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Additional settings.
-        void XM_CALLCONV SetUVTransform(FXMMATRIX value);
-        void __cdecl SetViewport(float width, float height);
-        void __cdecl SetTime(float time);
-        void __cdecl SetAlphaDiscardEnable(bool value);
-
-        // Light settings.
-        void __cdecl SetLightingEnabled(bool value) override;
-        void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
-
-        void __cdecl SetLightEnabled(int whichLight, bool value) override;
-        void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
-
-        void __cdecl EnableDefaultLighting() override;
-
-        static constexpr int MaxDirectionalLights = 4;
-
-        // Vertex color setting.
-        void __cdecl SetVertexColorEnabled(bool value);
-
-        // Texture settings.
-        void __cdecl SetTextureEnabled(bool value);
-        void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
-        void __cdecl SetTexture(int whichTexture, _In_opt_ ID3D11ShaderResourceView* value);
-
-        static constexpr int MaxTextures = 8;
-
-    protected:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-
-        DGSLEffect(_In_ ID3D11Device* device, _In_opt_ ID3D11PixelShader* pixelShader, bool skinningEnabled);
-
-        // Unsupported interface methods.
-        void __cdecl SetPerPixelLighting(bool value) override;
-    };
-
-    class SkinnedDGSLEffect : public DGSLEffect, public IEffectSkinning
-    {
-    public:
-        explicit SkinnedDGSLEffect(_In_ ID3D11Device* device, _In_opt_ ID3D11PixelShader* pixelShader = nullptr) :
-            DGSLEffect(device, pixelShader, true)
-        {
-        }
-
-        SkinnedDGSLEffect(SkinnedDGSLEffect&&) = default;
-        SkinnedDGSLEffect& operator= (SkinnedDGSLEffect&&) = default;
-
-        SkinnedDGSLEffect(SkinnedDGSLEffect const&) = delete;
-        SkinnedDGSLEffect& operator= (SkinnedDGSLEffect const&) = delete;
-
-        // Animation setting.
-        void __cdecl SetWeightsPerVertex(int value) override;
-        void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
-        void __cdecl ResetBoneTransforms() override;
-    };
-
-    //----------------------------------------------------------------------------------
-    // Built-in shader extends BasicEffect with normal maps and optional specular maps
-    class NormalMapEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
-    {
-    public:
-        explicit NormalMapEffect(_In_ ID3D11Device* device) :
-            NormalMapEffect(device, false)
-        {
-        }
-
-        NormalMapEffect(NormalMapEffect&&) noexcept;
-        NormalMapEffect& operator= (NormalMapEffect&&) noexcept;
-
-        NormalMapEffect(NormalMapEffect const&) = delete;
-        NormalMapEffect& operator= (NormalMapEffect const&) = delete;
-
-        ~NormalMapEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
-
-        void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Material settings.
-        void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
-        void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
-        void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
-        void __cdecl SetSpecularPower(float value);
-        void __cdecl DisableSpecular();
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
-
-        // Light settings.
-        void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
-
-        void __cdecl SetLightEnabled(int whichLight, bool value) override;
-        void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
-
-        void __cdecl EnableDefaultLighting() override;
-
-        // Fog settings.
-        void __cdecl SetFogEnabled(bool value) override;
-        void __cdecl SetFogStart(float value) override;
-        void __cdecl SetFogEnd(float value) override;
-        void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
-
-        // Vertex color setting.
-        void __cdecl SetVertexColorEnabled(bool value);
-
-        // Texture setting - albedo, normal and specular intensity
-        void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
-        void __cdecl SetNormalTexture(_In_opt_ ID3D11ShaderResourceView* value);
-        void __cdecl SetSpecularTexture(_In_opt_ ID3D11ShaderResourceView* value);
-
-        // Normal compression settings.
-        void __cdecl SetBiasedVertexNormals(bool value);
-
-        // Instancing settings.
-        void __cdecl SetInstancingEnabled(bool value);
-
-    protected:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-
-        NormalMapEffect(_In_ ID3D11Device* device, bool skinningEnabled);
-
-        // Unsupported interface methods.
-        void __cdecl SetLightingEnabled(bool value) override;
-        void __cdecl SetPerPixelLighting(bool value) override;
-    };
-
-    class SkinnedNormalMapEffect : public NormalMapEffect, public IEffectSkinning
-    {
-    public:
-        explicit SkinnedNormalMapEffect(_In_ ID3D11Device* device) :
-            NormalMapEffect(device, true)
-        {
-        }
-
-        SkinnedNormalMapEffect(SkinnedNormalMapEffect&&) = default;
-        SkinnedNormalMapEffect& operator= (SkinnedNormalMapEffect&&) = default;
-
-        SkinnedNormalMapEffect(SkinnedNormalMapEffect const&) = delete;
-        SkinnedNormalMapEffect& operator= (SkinnedNormalMapEffect const&) = delete;
-
-        // Animation settings.
-        void __cdecl SetWeightsPerVertex(int value) override;
-        void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
-        void __cdecl ResetBoneTransforms() override;
-    };
-
-    //----------------------------------------------------------------------------------
-    // Built-in shader for Physically-Based Rendering (Roughness/Metalness) with Image-based lighting
-    class PBREffect : public IEffect, public IEffectMatrices, public IEffectLights
-    {
-    public:
-        explicit PBREffect(_In_ ID3D11Device* device) :
-            PBREffect(device, false)
-        {
-        }
-
-        PBREffect(PBREffect&&) noexcept;
-        PBREffect& operator= (PBREffect&&) noexcept;
-
-        PBREffect(PBREffect const&) = delete;
-        PBREffect& operator= (PBREffect const&) = delete;
-
-        ~PBREffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
-
-        void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Light settings.
-        void __cdecl SetLightEnabled(int whichLight, bool value) override;
-        void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
-        void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
-
-        void __cdecl EnableDefaultLighting() override;
-
-        // PBR Settings.
-        void __cdecl SetAlpha(float value);
-        void XM_CALLCONV SetConstantAlbedo(FXMVECTOR value);
-        void __cdecl SetConstantMetallic(float value);
-        void __cdecl SetConstantRoughness(float value);
-
-        // Texture settings.
-        void __cdecl SetAlbedoTexture(_In_opt_ ID3D11ShaderResourceView* value);
-        void __cdecl SetNormalTexture(_In_opt_ ID3D11ShaderResourceView* value);
-        void __cdecl SetRMATexture(_In_opt_ ID3D11ShaderResourceView* value);
-
-        void __cdecl SetEmissiveTexture(_In_opt_ ID3D11ShaderResourceView* value);
-
-        void __cdecl SetSurfaceTextures(
-            _In_opt_ ID3D11ShaderResourceView* albedo,
-            _In_opt_ ID3D11ShaderResourceView* normal,
-            _In_opt_ ID3D11ShaderResourceView* roughnessMetallicAmbientOcclusion);
-
-        void __cdecl SetIBLTextures(
-            _In_opt_ ID3D11ShaderResourceView* radiance,
-            int numRadianceMips,
-            _In_opt_ ID3D11ShaderResourceView* irradiance);
-
-        // Normal compression settings.
-        void __cdecl SetBiasedVertexNormals(bool value);
-
-        // Instancing settings.
-        void __cdecl SetInstancingEnabled(bool value);
-
-        // Velocity buffer settings.
-        void __cdecl SetVelocityGeneration(bool value);
-
-        // Render target size, required for velocity buffer output.
-        void __cdecl SetRenderTargetSizeInPixels(int width, int height);
-
-    protected:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-
-        PBREffect(_In_ ID3D11Device* device, bool skinningEnabled);
-
-        // Unsupported interface methods.
-        void __cdecl SetLightingEnabled(bool value) override;
-        void __cdecl SetPerPixelLighting(bool value) override;
-        void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
-        void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
-    };
-
-    class SkinnedPBREffect : public PBREffect, public IEffectSkinning
-    {
-    public:
-        explicit SkinnedPBREffect(_In_ ID3D11Device* device) :
-            PBREffect(device, true)
-        {
-        }
-
-        SkinnedPBREffect(SkinnedPBREffect&&) = default;
-        SkinnedPBREffect& operator= (SkinnedPBREffect&&) = default;
-
-        SkinnedPBREffect(SkinnedPBREffect const&) = delete;
-        SkinnedPBREffect& operator= (SkinnedPBREffect const&) = delete;
-
-        // Animation settings.
-        void __cdecl SetWeightsPerVertex(int value) override;
-        void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
-        void __cdecl ResetBoneTransforms() override;
-    };
-
-    //----------------------------------------------------------------------------------
-    // Built-in shader for debug visualization of normals, tangents, etc.
-    class DebugEffect : public IEffect, public IEffectMatrices
-    {
-    public:
-        enum Mode
-        {
-            Mode_Default = 0,   // Hemispherical ambient lighting
-            Mode_Normals,       // RGB normals
-            Mode_Tangents,      // RGB tangents
-            Mode_BiTangents,    // RGB bi-tangents
+        public:
+            virtual ~IEffectMatrices() = default;
+
+            IEffectMatrices(const IEffectMatrices&) = delete;
+            IEffectMatrices& operator=(const IEffectMatrices&) = delete;
+
+            virtual void XM_CALLCONV SetWorld(FXMMATRIX value) = 0;
+            virtual void XM_CALLCONV SetView(FXMMATRIX value) = 0;
+            virtual void XM_CALLCONV SetProjection(FXMMATRIX value) = 0;
+            virtual void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection);
+
+        protected:
+            IEffectMatrices() = default;
+            IEffectMatrices(IEffectMatrices&&) = default;
+            IEffectMatrices& operator=(IEffectMatrices&&) = default;
         };
 
-        explicit DebugEffect(_In_ ID3D11Device* device);
 
-        DebugEffect(DebugEffect&&) noexcept;
-        DebugEffect& operator= (DebugEffect&&) noexcept;
-
-        DebugEffect(DebugEffect const&) = delete;
-        DebugEffect& operator= (DebugEffect const&) = delete;
-
-        ~DebugEffect() override;
-
-        // IEffect methods.
-        void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
-
-        void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
-
-        // Camera settings.
-        void XM_CALLCONV SetWorld(FXMMATRIX value) override;
-        void XM_CALLCONV SetView(FXMMATRIX value) override;
-        void XM_CALLCONV SetProjection(FXMMATRIX value) override;
-        void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
-
-        // Debug Settings.
-        void __cdecl SetMode(Mode debugMode);
-        void XM_CALLCONV SetHemisphericalAmbientColor(FXMVECTOR upper, FXMVECTOR lower);
-        void __cdecl SetAlpha(float value);
-
-        // Vertex color setting.
-        void __cdecl SetVertexColorEnabled(bool value);
-
-        // Normal compression settings.
-        void __cdecl SetBiasedVertexNormals(bool value);
-
-        // Instancing settings.
-        void __cdecl SetInstancingEnabled(bool value);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-    //----------------------------------------------------------------------------------
-    // Abstract interface to factory for sharing effects and texture resources
-    class IEffectFactory
-    {
-    public:
-        virtual ~IEffectFactory() = default;
-
-        IEffectFactory(const IEffectFactory&) = delete;
-        IEffectFactory& operator=(const IEffectFactory&) = delete;
-
-        struct EffectInfo
+        // Abstract interface for effects which support directional lighting.
+        class IEffectLights
         {
-            const wchar_t*      name;
-            bool                perVertexColor;
-            bool                enableSkinning;
-            bool                enableDualTexture;
-            bool                enableNormalMaps;
-            bool                biasedVertexNormals;
-            float               specularPower;
-            float               alpha;
-            XMFLOAT3            ambientColor;
-            XMFLOAT3            diffuseColor;
-            XMFLOAT3            specularColor;
-            XMFLOAT3            emissiveColor;
-            const wchar_t*      diffuseTexture;
-            const wchar_t*      specularTexture;
-            const wchar_t*      normalTexture;
-            const wchar_t*      emissiveTexture;
+        public:
+            virtual ~IEffectLights() = default;
 
-            EffectInfo() noexcept :
-                name(nullptr),
-                perVertexColor(false),
-                enableSkinning(false),
-                enableDualTexture(false),
-                enableNormalMaps(false),
-                biasedVertexNormals(false),
-                specularPower(0),
-                alpha(0),
-                ambientColor(0, 0, 0),
-                diffuseColor(0, 0, 0),
-                specularColor(0, 0, 0),
-                emissiveColor(0, 0, 0),
-                diffuseTexture(nullptr),
-                specularTexture(nullptr),
-                normalTexture(nullptr),
-                emissiveTexture(nullptr)
+            IEffectLights(const IEffectLights&) = delete;
+            IEffectLights& operator=(const IEffectLights&) = delete;
+
+            virtual void __cdecl SetLightingEnabled(bool value) = 0;
+            virtual void __cdecl SetPerPixelLighting(bool value) = 0;
+            virtual void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) = 0;
+
+            virtual void __cdecl SetLightEnabled(int whichLight, bool value) = 0;
+            virtual void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) = 0;
+            virtual void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) = 0;
+            virtual void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) = 0;
+
+            virtual void __cdecl EnableDefaultLighting() = 0;
+
+            static constexpr int MaxDirectionalLights = 3;
+
+        protected:
+            IEffectLights() = default;
+            IEffectLights(IEffectLights&&) = default;
+            IEffectLights& operator=(IEffectLights&&) = default;
+        };
+
+
+        // Abstract interface for effects which support fog.
+        class IEffectFog
+        {
+        public:
+            virtual ~IEffectFog() = default;
+
+            IEffectFog(const IEffectFog&) = delete;
+            IEffectFog& operator=(const IEffectFog&) = delete;
+
+            virtual void __cdecl SetFogEnabled(bool value) = 0;
+            virtual void __cdecl SetFogStart(float value) = 0;
+            virtual void __cdecl SetFogEnd(float value) = 0;
+            virtual void XM_CALLCONV SetFogColor(FXMVECTOR value) = 0;
+
+        protected:
+            IEffectFog() = default;
+            IEffectFog(IEffectFog&&) = default;
+            IEffectFog& operator=(IEffectFog&&) = default;
+        };
+
+
+        // Abstract interface for effects which support skinning
+        class IEffectSkinning
+        {
+        public:
+            virtual ~IEffectSkinning() = default;
+
+            IEffectSkinning(const IEffectSkinning&) = delete;
+            IEffectSkinning& operator=(const IEffectSkinning&) = delete;
+
+            virtual void __cdecl SetWeightsPerVertex(int value) = 0;
+            virtual void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) = 0;
+            virtual void __cdecl ResetBoneTransforms() = 0;
+
+            static constexpr int MaxBones = 72;
+
+        protected:
+            IEffectSkinning() = default;
+            IEffectSkinning(IEffectSkinning&&) = default;
+            IEffectSkinning& operator=(IEffectSkinning&&) = default;
+        };
+
+        //------------------------------------------------------------------------------
+        // Built-in shader supports optional texture mapping, vertex coloring, directional lighting, and fog.
+        class BasicEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
+        {
+        public:
+            explicit BasicEffect(_In_ ID3D11Device* device);
+
+            BasicEffect(BasicEffect&&) noexcept;
+            BasicEffect& operator= (BasicEffect&&) noexcept;
+
+            BasicEffect(BasicEffect const&) = delete;
+            BasicEffect& operator= (BasicEffect const&) = delete;
+
+            ~BasicEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
+
+            void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Material settings.
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
+            void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
+            void __cdecl SetSpecularPower(float value);
+            void __cdecl DisableSpecular();
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
+
+            // Light settings.
+            void __cdecl SetLightingEnabled(bool value) override;
+            void __cdecl SetPerPixelLighting(bool value) override;
+            void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
+
+            void __cdecl SetLightEnabled(int whichLight, bool value) override;
+            void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
+
+            void __cdecl EnableDefaultLighting() override;
+
+            // Fog settings.
+            void __cdecl SetFogEnabled(bool value) override;
+            void __cdecl SetFogStart(float value) override;
+            void __cdecl SetFogEnd(float value) override;
+            void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
+
+            // Vertex color setting.
+            void __cdecl SetVertexColorEnabled(bool value);
+
+            // Texture setting.
+            void __cdecl SetTextureEnabled(bool value);
+            void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
+
+            // Normal compression settings.
+            void __cdecl SetBiasedVertexNormals(bool value);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+
+
+
+        // Built-in shader supports per-pixel alpha testing.
+        class AlphaTestEffect : public IEffect, public IEffectMatrices, public IEffectFog
+        {
+        public:
+            explicit AlphaTestEffect(_In_ ID3D11Device* device);
+
+            AlphaTestEffect(AlphaTestEffect&&) noexcept;
+            AlphaTestEffect& operator= (AlphaTestEffect&&) noexcept;
+
+            AlphaTestEffect(AlphaTestEffect const&) = delete;
+            AlphaTestEffect& operator= (AlphaTestEffect const&) = delete;
+
+            ~AlphaTestEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
+
+            void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Material settings.
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
+
+            // Fog settings.
+            void __cdecl SetFogEnabled(bool value) override;
+            void __cdecl SetFogStart(float value) override;
+            void __cdecl SetFogEnd(float value) override;
+            void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
+
+            // Vertex color setting.
+            void __cdecl SetVertexColorEnabled(bool value);
+
+            // Texture setting.
+            void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
+
+            // Alpha test settings.
+            void __cdecl SetAlphaFunction(D3D11_COMPARISON_FUNC value);
+            void __cdecl SetReferenceAlpha(int value);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+
+
+
+        // Built-in shader supports two layer multitexturing (eg. for lightmaps or detail textures).
+        class DualTextureEffect : public IEffect, public IEffectMatrices, public IEffectFog
+        {
+        public:
+            explicit DualTextureEffect(_In_ ID3D11Device* device);
+
+            DualTextureEffect(DualTextureEffect&&) noexcept;
+            DualTextureEffect& operator= (DualTextureEffect&&) noexcept;
+
+            DualTextureEffect(DualTextureEffect const&) = delete;
+            DualTextureEffect& operator= (DualTextureEffect const&) = delete;
+
+            ~DualTextureEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
+
+            void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Material settings.
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
+
+            // Fog settings.
+            void __cdecl SetFogEnabled(bool value) override;
+            void __cdecl SetFogStart(float value) override;
+            void __cdecl SetFogEnd(float value) override;
+            void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
+
+            // Vertex color setting.
+            void __cdecl SetVertexColorEnabled(bool value);
+
+            // Texture settings.
+            void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
+            void __cdecl SetTexture2(_In_opt_ ID3D11ShaderResourceView* value);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+
+
+
+        // Built-in shader supports cubic environment mapping.
+        class EnvironmentMapEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
+        {
+        public:
+            enum Mapping
+            {
+                Mapping_Cube = 0,       // Cubic environment map
+                Mapping_Sphere,         // Spherical environment map
+                Mapping_DualParabola,   // Dual-parabola environment map (requires Feature Level 10.0)
+            };
+
+            explicit EnvironmentMapEffect(_In_ ID3D11Device* device);
+
+            EnvironmentMapEffect(EnvironmentMapEffect&&) noexcept;
+            EnvironmentMapEffect& operator= (EnvironmentMapEffect&&) noexcept;
+
+            EnvironmentMapEffect(EnvironmentMapEffect const&) = delete;
+            EnvironmentMapEffect& operator= (EnvironmentMapEffect const&) = delete;
+
+            ~EnvironmentMapEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
+
+            void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Material settings.
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
+
+            // Light settings.
+            void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
+
+            void __cdecl SetPerPixelLighting(bool value) override;
+            void __cdecl SetLightEnabled(int whichLight, bool value) override;
+            void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
+
+            void __cdecl EnableDefaultLighting() override;
+
+            // Fog settings.
+            void __cdecl SetFogEnabled(bool value) override;
+            void __cdecl SetFogStart(float value) override;
+            void __cdecl SetFogEnd(float value) override;
+            void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
+
+            // Texture setting.
+            void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
+            void __cdecl SetEnvironmentMap(_In_opt_ ID3D11ShaderResourceView* value);
+
+            // Environment map settings.
+            void __cdecl SetMode(Mapping mapping);
+            void __cdecl SetEnvironmentMapAmount(float value);
+            void XM_CALLCONV SetEnvironmentMapSpecular(FXMVECTOR value);
+            void __cdecl SetFresnelFactor(float value);
+
+            // Normal compression settings.
+            void __cdecl SetBiasedVertexNormals(bool value);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+
+            // Unsupported interface methods.
+            void __cdecl SetLightingEnabled(bool value) override;
+            void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
+        };
+
+
+
+        // Built-in shader supports skinned animation.
+        class SkinnedEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog, public IEffectSkinning
+        {
+        public:
+            explicit SkinnedEffect(_In_ ID3D11Device* device);
+
+            SkinnedEffect(SkinnedEffect&&) noexcept;
+            SkinnedEffect& operator= (SkinnedEffect&&) noexcept;
+
+            SkinnedEffect(SkinnedEffect const&) = delete;
+            SkinnedEffect& operator= (SkinnedEffect const&) = delete;
+
+            ~SkinnedEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
+
+            void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Material settings.
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
+            void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
+            void __cdecl SetSpecularPower(float value);
+            void __cdecl DisableSpecular();
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
+
+            // Light settings.
+            void __cdecl SetPerPixelLighting(bool value) override;
+            void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
+
+            void __cdecl SetLightEnabled(int whichLight, bool value) override;
+            void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
+
+            void __cdecl EnableDefaultLighting() override;
+
+            // Fog settings.
+            void __cdecl SetFogEnabled(bool value) override;
+            void __cdecl SetFogStart(float value) override;
+            void __cdecl SetFogEnd(float value) override;
+            void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
+
+            // Texture setting.
+            void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
+
+            // Animation settings.
+            void __cdecl SetWeightsPerVertex(int value) override;
+            void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
+            void __cdecl ResetBoneTransforms() override;
+
+            // Normal compression settings.
+            void __cdecl SetBiasedVertexNormals(bool value);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+
+            // Unsupported interface method.
+            void __cdecl SetLightingEnabled(bool value) override;
+        };
+
+        //------------------------------------------------------------------------------
+        // Built-in effect for Visual Studio Shader Designer (DGSL) shaders
+        class DGSLEffect : public IEffect, public IEffectMatrices, public IEffectLights
+        {
+        public:
+            explicit DGSLEffect(_In_ ID3D11Device* device, _In_opt_ ID3D11PixelShader* pixelShader = nullptr) :
+                DGSLEffect(device, pixelShader, false)
             {
             }
+
+            DGSLEffect(DGSLEffect&&) noexcept;
+            DGSLEffect& operator= (DGSLEffect&&) noexcept;
+
+            DGSLEffect(DGSLEffect const&) = delete;
+            DGSLEffect& operator= (DGSLEffect const&) = delete;
+
+            ~DGSLEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
+
+            void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Material settings.
+            void XM_CALLCONV SetAmbientColor(FXMVECTOR value);
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
+            void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
+            void __cdecl SetSpecularPower(float value);
+            void __cdecl DisableSpecular();
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
+
+            // Additional settings.
+            void XM_CALLCONV SetUVTransform(FXMMATRIX value);
+            void __cdecl SetViewport(float width, float height);
+            void __cdecl SetTime(float time);
+            void __cdecl SetAlphaDiscardEnable(bool value);
+
+            // Light settings.
+            void __cdecl SetLightingEnabled(bool value) override;
+            void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
+
+            void __cdecl SetLightEnabled(int whichLight, bool value) override;
+            void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
+
+            void __cdecl EnableDefaultLighting() override;
+
+            static constexpr int MaxDirectionalLights = 4;
+
+            // Vertex color setting.
+            void __cdecl SetVertexColorEnabled(bool value);
+
+            // Texture settings.
+            void __cdecl SetTextureEnabled(bool value);
+            void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
+            void __cdecl SetTexture(int whichTexture, _In_opt_ ID3D11ShaderResourceView* value);
+
+            static constexpr int MaxTextures = 8;
+
+        protected:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+
+            DGSLEffect(_In_ ID3D11Device* device, _In_opt_ ID3D11PixelShader* pixelShader, bool skinningEnabled);
+
+            // Unsupported interface methods.
+            void __cdecl SetPerPixelLighting(bool value) override;
         };
 
-        virtual std::shared_ptr<IEffect> __cdecl CreateEffect(_In_ const EffectInfo& info, _In_opt_ ID3D11DeviceContext* deviceContext) = 0;
-
-        virtual void __cdecl CreateTexture(_In_z_ const wchar_t* name, _In_opt_ ID3D11DeviceContext* deviceContext, _Outptr_ ID3D11ShaderResourceView** textureView) = 0;
-
-    protected:
-        IEffectFactory() = default;
-        IEffectFactory(IEffectFactory&&) = default;
-        IEffectFactory& operator=(IEffectFactory&&) = default;
-    };
-
-
-    // Factory for sharing effects and texture resources
-    class EffectFactory : public IEffectFactory
-    {
-    public:
-        explicit EffectFactory(_In_ ID3D11Device* device);
-
-        EffectFactory(EffectFactory&&) noexcept;
-        EffectFactory& operator= (EffectFactory&&) noexcept;
-
-        EffectFactory(EffectFactory const&) = delete;
-        EffectFactory& operator= (EffectFactory const&) = delete;
-
-        ~EffectFactory() override;
-
-        // IEffectFactory methods.
-        std::shared_ptr<IEffect> __cdecl CreateEffect(_In_ const EffectInfo& info, _In_opt_ ID3D11DeviceContext* deviceContext) override;
-        void __cdecl CreateTexture(_In_z_ const wchar_t* name, _In_opt_ ID3D11DeviceContext* deviceContext, _Outptr_ ID3D11ShaderResourceView** textureView) override;
-
-        // Settings.
-        void __cdecl ReleaseCache();
-
-        void __cdecl SetSharing(bool enabled) noexcept;
-
-        void __cdecl EnableNormalMapEffect(bool enabled) noexcept;
-        void __cdecl EnableForceSRGB(bool forceSRGB) noexcept;
-
-        void __cdecl SetDirectory(_In_opt_z_ const wchar_t* path) noexcept;
-
-        // Properties.
-        ID3D11Device* GetDevice() const noexcept;
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::shared_ptr<Impl> pImpl;
-    };
-
-
-    // Factory for Physically Based Rendering (PBR)
-    class PBREffectFactory : public IEffectFactory
-    {
-    public:
-        explicit PBREffectFactory(_In_ ID3D11Device* device);
-
-        PBREffectFactory(PBREffectFactory&&) noexcept;
-        PBREffectFactory& operator= (PBREffectFactory&&) noexcept;
-
-        PBREffectFactory(PBREffectFactory const&) = delete;
-        PBREffectFactory& operator= (PBREffectFactory const&) = delete;
-
-        ~PBREffectFactory() override;
-
-        // IEffectFactory methods.
-        std::shared_ptr<IEffect> __cdecl CreateEffect(_In_ const EffectInfo& info, _In_opt_ ID3D11DeviceContext* deviceContext) override;
-        void __cdecl CreateTexture(_In_z_ const wchar_t* name, _In_opt_ ID3D11DeviceContext* deviceContext, _Outptr_ ID3D11ShaderResourceView** textureView) override;
-
-        // Settings.
-        void __cdecl ReleaseCache();
-
-        void __cdecl SetSharing(bool enabled) noexcept;
-
-        void __cdecl EnableForceSRGB(bool forceSRGB) noexcept;
-
-        void __cdecl SetDirectory(_In_opt_z_ const wchar_t* path) noexcept;
-
-        // Properties.
-        ID3D11Device* GetDevice() const noexcept;
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::shared_ptr<Impl> pImpl;
-    };
-
-
-    // Factory for sharing Visual Studio Shader Designer (DGSL) shaders and texture resources
-    class DGSLEffectFactory : public IEffectFactory
-    {
-    public:
-        explicit DGSLEffectFactory(_In_ ID3D11Device* device);
-
-        DGSLEffectFactory(DGSLEffectFactory&&) noexcept;
-        DGSLEffectFactory& operator= (DGSLEffectFactory&&) noexcept;
-
-        DGSLEffectFactory(DGSLEffectFactory const&) = delete;
-        DGSLEffectFactory& operator= (DGSLEffectFactory const&) = delete;
-
-        ~DGSLEffectFactory() override;
-
-        // IEffectFactory methods.
-        std::shared_ptr<IEffect> __cdecl CreateEffect(_In_ const EffectInfo& info, _In_opt_ ID3D11DeviceContext* deviceContext) override;
-        void __cdecl CreateTexture(_In_z_ const wchar_t* name, _In_opt_ ID3D11DeviceContext* deviceContext, _Outptr_ ID3D11ShaderResourceView** textureView) override;
-
-        // DGSL methods.
-        struct DGSLEffectInfo : public EffectInfo
+        class SkinnedDGSLEffect : public DGSLEffect, public IEffectSkinning
         {
-            static constexpr int BaseTextureOffset = 4;
+        public:
+            explicit SkinnedDGSLEffect(_In_ ID3D11Device* device, _In_opt_ ID3D11PixelShader* pixelShader = nullptr) :
+                DGSLEffect(device, pixelShader, true)
+            {
+            }
 
-            const wchar_t* textures[DGSLEffect::MaxTextures - BaseTextureOffset];
-            const wchar_t* pixelShader;
+            SkinnedDGSLEffect(SkinnedDGSLEffect&&) = default;
+            SkinnedDGSLEffect& operator= (SkinnedDGSLEffect&&) = default;
 
-            DGSLEffectInfo() noexcept :
-                EffectInfo(),
-                textures{},
-                pixelShader(nullptr)
-            {}
+            SkinnedDGSLEffect(SkinnedDGSLEffect const&) = delete;
+            SkinnedDGSLEffect& operator= (SkinnedDGSLEffect const&) = delete;
+
+            // Animation setting.
+            void __cdecl SetWeightsPerVertex(int value) override;
+            void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
+            void __cdecl ResetBoneTransforms() override;
         };
 
-        virtual std::shared_ptr<IEffect> __cdecl CreateDGSLEffect(_In_ const DGSLEffectInfo& info, _In_opt_ ID3D11DeviceContext* deviceContext);
+        //------------------------------------------------------------------------------
+        // Built-in shader extends BasicEffect with normal maps and optional specular maps
+        class NormalMapEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
+        {
+        public:
+            explicit NormalMapEffect(_In_ ID3D11Device* device) :
+                NormalMapEffect(device, false)
+            {
+            }
 
-        virtual void __cdecl CreatePixelShader(_In_z_ const wchar_t* shader, _Outptr_ ID3D11PixelShader** pixelShader);
+            NormalMapEffect(NormalMapEffect&&) noexcept;
+            NormalMapEffect& operator= (NormalMapEffect&&) noexcept;
 
-        // Settings.
-        void __cdecl ReleaseCache();
+            NormalMapEffect(NormalMapEffect const&) = delete;
+            NormalMapEffect& operator= (NormalMapEffect const&) = delete;
 
-        void __cdecl SetSharing(bool enabled) noexcept;
+            ~NormalMapEffect() override;
 
-        void __cdecl EnableForceSRGB(bool forceSRGB) noexcept;
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
 
-        void __cdecl SetDirectory(_In_opt_z_ const wchar_t* path) noexcept;
+            void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
 
-        // Properties.
-        ID3D11Device* GetDevice() const noexcept;
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
 
-    private:
-        // Private implementation.
-        class Impl;
+            // Material settings.
+            void XM_CALLCONV SetDiffuseColor(FXMVECTOR value);
+            void XM_CALLCONV SetEmissiveColor(FXMVECTOR value);
+            void XM_CALLCONV SetSpecularColor(FXMVECTOR value);
+            void __cdecl SetSpecularPower(float value);
+            void __cdecl DisableSpecular();
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
 
-        std::shared_ptr<Impl> pImpl;
-    };
+            // Light settings.
+            void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
+
+            void __cdecl SetLightEnabled(int whichLight, bool value) override;
+            void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
+
+            void __cdecl EnableDefaultLighting() override;
+
+            // Fog settings.
+            void __cdecl SetFogEnabled(bool value) override;
+            void __cdecl SetFogStart(float value) override;
+            void __cdecl SetFogEnd(float value) override;
+            void XM_CALLCONV SetFogColor(FXMVECTOR value) override;
+
+            // Vertex color setting.
+            void __cdecl SetVertexColorEnabled(bool value);
+
+            // Texture setting - albedo, normal and specular intensity
+            void __cdecl SetTexture(_In_opt_ ID3D11ShaderResourceView* value);
+            void __cdecl SetNormalTexture(_In_opt_ ID3D11ShaderResourceView* value);
+            void __cdecl SetSpecularTexture(_In_opt_ ID3D11ShaderResourceView* value);
+
+            // Normal compression settings.
+            void __cdecl SetBiasedVertexNormals(bool value);
+
+            // Instancing settings.
+            void __cdecl SetInstancingEnabled(bool value);
+
+        protected:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+
+            NormalMapEffect(_In_ ID3D11Device* device, bool skinningEnabled);
+
+            // Unsupported interface methods.
+            void __cdecl SetLightingEnabled(bool value) override;
+            void __cdecl SetPerPixelLighting(bool value) override;
+        };
+
+        class SkinnedNormalMapEffect : public NormalMapEffect, public IEffectSkinning
+        {
+        public:
+            explicit SkinnedNormalMapEffect(_In_ ID3D11Device* device) :
+                NormalMapEffect(device, true)
+            {
+            }
+
+            SkinnedNormalMapEffect(SkinnedNormalMapEffect&&) = default;
+            SkinnedNormalMapEffect& operator= (SkinnedNormalMapEffect&&) = default;
+
+            SkinnedNormalMapEffect(SkinnedNormalMapEffect const&) = delete;
+            SkinnedNormalMapEffect& operator= (SkinnedNormalMapEffect const&) = delete;
+
+            // Animation settings.
+            void __cdecl SetWeightsPerVertex(int value) override;
+            void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
+            void __cdecl ResetBoneTransforms() override;
+        };
+
+        //------------------------------------------------------------------------------
+        // Built-in shader for Physically-Based Rendering (Roughness/Metalness) with Image-based lighting
+        class PBREffect : public IEffect, public IEffectMatrices, public IEffectLights
+        {
+        public:
+            explicit PBREffect(_In_ ID3D11Device* device) :
+                PBREffect(device, false)
+            {
+            }
+
+            PBREffect(PBREffect&&) noexcept;
+            PBREffect& operator= (PBREffect&&) noexcept;
+
+            PBREffect(PBREffect const&) = delete;
+            PBREffect& operator= (PBREffect const&) = delete;
+
+            ~PBREffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
+
+            void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Light settings.
+            void __cdecl SetLightEnabled(int whichLight, bool value) override;
+            void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
+            void XM_CALLCONV SetLightDiffuseColor(int whichLight, FXMVECTOR value) override;
+
+            void __cdecl EnableDefaultLighting() override;
+
+            // PBR Settings.
+            void __cdecl SetAlpha(float value);
+            void XM_CALLCONV SetConstantAlbedo(FXMVECTOR value);
+            void __cdecl SetConstantMetallic(float value);
+            void __cdecl SetConstantRoughness(float value);
+
+            // Texture settings.
+            void __cdecl SetAlbedoTexture(_In_opt_ ID3D11ShaderResourceView* value);
+            void __cdecl SetNormalTexture(_In_opt_ ID3D11ShaderResourceView* value);
+            void __cdecl SetRMATexture(_In_opt_ ID3D11ShaderResourceView* value);
+
+            void __cdecl SetEmissiveTexture(_In_opt_ ID3D11ShaderResourceView* value);
+
+            void __cdecl SetSurfaceTextures(
+                _In_opt_ ID3D11ShaderResourceView* albedo,
+                _In_opt_ ID3D11ShaderResourceView* normal,
+                _In_opt_ ID3D11ShaderResourceView* roughnessMetallicAmbientOcclusion);
+
+            void __cdecl SetIBLTextures(
+                _In_opt_ ID3D11ShaderResourceView* radiance,
+                int numRadianceMips,
+                _In_opt_ ID3D11ShaderResourceView* irradiance);
+
+            // Normal compression settings.
+            void __cdecl SetBiasedVertexNormals(bool value);
+
+            // Instancing settings.
+            void __cdecl SetInstancingEnabled(bool value);
+
+            // Velocity buffer settings.
+            void __cdecl SetVelocityGeneration(bool value);
+
+            // Render target size, required for velocity buffer output.
+            void __cdecl SetRenderTargetSizeInPixels(int width, int height);
+
+        protected:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+
+            PBREffect(_In_ ID3D11Device* device, bool skinningEnabled);
+
+            // Unsupported interface methods.
+            void __cdecl SetLightingEnabled(bool value) override;
+            void __cdecl SetPerPixelLighting(bool value) override;
+            void XM_CALLCONV SetAmbientLightColor(FXMVECTOR value) override;
+            void XM_CALLCONV SetLightSpecularColor(int whichLight, FXMVECTOR value) override;
+        };
+
+        class SkinnedPBREffect : public PBREffect, public IEffectSkinning
+        {
+        public:
+            explicit SkinnedPBREffect(_In_ ID3D11Device* device) :
+                PBREffect(device, true)
+            {
+            }
+
+            SkinnedPBREffect(SkinnedPBREffect&&) = default;
+            SkinnedPBREffect& operator= (SkinnedPBREffect&&) = default;
+
+            SkinnedPBREffect(SkinnedPBREffect const&) = delete;
+            SkinnedPBREffect& operator= (SkinnedPBREffect const&) = delete;
+
+            // Animation settings.
+            void __cdecl SetWeightsPerVertex(int value) override;
+            void __cdecl SetBoneTransforms(_In_reads_(count) XMMATRIX const* value, size_t count) override;
+            void __cdecl ResetBoneTransforms() override;
+        };
+
+        //------------------------------------------------------------------------------
+        // Built-in shader for debug visualization of normals, tangents, etc.
+        class DebugEffect : public IEffect, public IEffectMatrices
+        {
+        public:
+            enum Mode
+            {
+                Mode_Default = 0,   // Hemispherical ambient lighting
+                Mode_Normals,       // RGB normals
+                Mode_Tangents,      // RGB tangents
+                Mode_BiTangents,    // RGB bi-tangents
+            };
+
+            explicit DebugEffect(_In_ ID3D11Device* device);
+
+            DebugEffect(DebugEffect&&) noexcept;
+            DebugEffect& operator= (DebugEffect&&) noexcept;
+
+            DebugEffect(DebugEffect const&) = delete;
+            DebugEffect& operator= (DebugEffect const&) = delete;
+
+            ~DebugEffect() override;
+
+            // IEffect methods.
+            void __cdecl Apply(_In_ ID3D11DeviceContext* deviceContext) override;
+
+            void __cdecl GetVertexShaderBytecode(_Out_ void const** pShaderByteCode, _Out_ size_t* pByteCodeLength) override;
+
+            // Camera settings.
+            void XM_CALLCONV SetWorld(FXMMATRIX value) override;
+            void XM_CALLCONV SetView(FXMMATRIX value) override;
+            void XM_CALLCONV SetProjection(FXMMATRIX value) override;
+            void XM_CALLCONV SetMatrices(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection) override;
+
+            // Debug Settings.
+            void __cdecl SetMode(Mode debugMode);
+            void XM_CALLCONV SetHemisphericalAmbientColor(FXMVECTOR upper, FXMVECTOR lower);
+            void __cdecl SetAlpha(float value);
+
+            // Vertex color setting.
+            void __cdecl SetVertexColorEnabled(bool value);
+
+            // Normal compression settings.
+            void __cdecl SetBiasedVertexNormals(bool value);
+
+            // Instancing settings.
+            void __cdecl SetInstancingEnabled(bool value);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+
+        //------------------------------------------------------------------------------
+        // Abstract interface to factory for sharing effects and texture resources
+        class IEffectFactory
+        {
+        public:
+            virtual ~IEffectFactory() = default;
+
+            IEffectFactory(const IEffectFactory&) = delete;
+            IEffectFactory& operator=(const IEffectFactory&) = delete;
+
+            struct EffectInfo
+            {
+                const wchar_t*      name;
+                bool                perVertexColor;
+                bool                enableSkinning;
+                bool                enableDualTexture;
+                bool                enableNormalMaps;
+                bool                biasedVertexNormals;
+                float               specularPower;
+                float               alpha;
+                XMFLOAT3            ambientColor;
+                XMFLOAT3            diffuseColor;
+                XMFLOAT3            specularColor;
+                XMFLOAT3            emissiveColor;
+                const wchar_t*      diffuseTexture;
+                const wchar_t*      specularTexture;
+                const wchar_t*      normalTexture;
+                const wchar_t*      emissiveTexture;
+
+                EffectInfo() noexcept :
+                    name(nullptr),
+                    perVertexColor(false),
+                    enableSkinning(false),
+                    enableDualTexture(false),
+                    enableNormalMaps(false),
+                    biasedVertexNormals(false),
+                    specularPower(0),
+                    alpha(0),
+                    ambientColor(0, 0, 0),
+                    diffuseColor(0, 0, 0),
+                    specularColor(0, 0, 0),
+                    emissiveColor(0, 0, 0),
+                    diffuseTexture(nullptr),
+                    specularTexture(nullptr),
+                    normalTexture(nullptr),
+                    emissiveTexture(nullptr)
+                {
+                }
+            };
+
+            virtual std::shared_ptr<IEffect> __cdecl CreateEffect(_In_ const EffectInfo& info, _In_opt_ ID3D11DeviceContext* deviceContext) = 0;
+
+            virtual void __cdecl CreateTexture(_In_z_ const wchar_t* name, _In_opt_ ID3D11DeviceContext* deviceContext, _Outptr_ ID3D11ShaderResourceView** textureView) = 0;
+
+        protected:
+            IEffectFactory() = default;
+            IEffectFactory(IEffectFactory&&) = default;
+            IEffectFactory& operator=(IEffectFactory&&) = default;
+        };
+
+
+        // Factory for sharing effects and texture resources
+        class EffectFactory : public IEffectFactory
+        {
+        public:
+            explicit EffectFactory(_In_ ID3D11Device* device);
+
+            EffectFactory(EffectFactory&&) noexcept;
+            EffectFactory& operator= (EffectFactory&&) noexcept;
+
+            EffectFactory(EffectFactory const&) = delete;
+            EffectFactory& operator= (EffectFactory const&) = delete;
+
+            ~EffectFactory() override;
+
+            // IEffectFactory methods.
+            std::shared_ptr<IEffect> __cdecl CreateEffect(_In_ const EffectInfo& info, _In_opt_ ID3D11DeviceContext* deviceContext) override;
+            void __cdecl CreateTexture(_In_z_ const wchar_t* name, _In_opt_ ID3D11DeviceContext* deviceContext, _Outptr_ ID3D11ShaderResourceView** textureView) override;
+
+            // Settings.
+            void __cdecl ReleaseCache();
+
+            void __cdecl SetSharing(bool enabled) noexcept;
+
+            void __cdecl EnableNormalMapEffect(bool enabled) noexcept;
+            void __cdecl EnableForceSRGB(bool forceSRGB) noexcept;
+
+            void __cdecl SetDirectory(_In_opt_z_ const wchar_t* path) noexcept;
+
+            // Properties.
+            ID3D11Device* GetDevice() const noexcept;
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::shared_ptr<Impl> pImpl;
+        };
+
+
+        // Factory for Physically Based Rendering (PBR)
+        class PBREffectFactory : public IEffectFactory
+        {
+        public:
+            explicit PBREffectFactory(_In_ ID3D11Device* device);
+
+            PBREffectFactory(PBREffectFactory&&) noexcept;
+            PBREffectFactory& operator= (PBREffectFactory&&) noexcept;
+
+            PBREffectFactory(PBREffectFactory const&) = delete;
+            PBREffectFactory& operator= (PBREffectFactory const&) = delete;
+
+            ~PBREffectFactory() override;
+
+            // IEffectFactory methods.
+            std::shared_ptr<IEffect> __cdecl CreateEffect(_In_ const EffectInfo& info, _In_opt_ ID3D11DeviceContext* deviceContext) override;
+            void __cdecl CreateTexture(_In_z_ const wchar_t* name, _In_opt_ ID3D11DeviceContext* deviceContext, _Outptr_ ID3D11ShaderResourceView** textureView) override;
+
+            // Settings.
+            void __cdecl ReleaseCache();
+
+            void __cdecl SetSharing(bool enabled) noexcept;
+
+            void __cdecl EnableForceSRGB(bool forceSRGB) noexcept;
+
+            void __cdecl SetDirectory(_In_opt_z_ const wchar_t* path) noexcept;
+
+            // Properties.
+            ID3D11Device* GetDevice() const noexcept;
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::shared_ptr<Impl> pImpl;
+        };
+
+
+        // Factory for sharing Visual Studio Shader Designer (DGSL) shaders and texture resources
+        class DGSLEffectFactory : public IEffectFactory
+        {
+        public:
+            explicit DGSLEffectFactory(_In_ ID3D11Device* device);
+
+            DGSLEffectFactory(DGSLEffectFactory&&) noexcept;
+            DGSLEffectFactory& operator= (DGSLEffectFactory&&) noexcept;
+
+            DGSLEffectFactory(DGSLEffectFactory const&) = delete;
+            DGSLEffectFactory& operator= (DGSLEffectFactory const&) = delete;
+
+            ~DGSLEffectFactory() override;
+
+            // IEffectFactory methods.
+            std::shared_ptr<IEffect> __cdecl CreateEffect(_In_ const EffectInfo& info, _In_opt_ ID3D11DeviceContext* deviceContext) override;
+            void __cdecl CreateTexture(_In_z_ const wchar_t* name, _In_opt_ ID3D11DeviceContext* deviceContext, _Outptr_ ID3D11ShaderResourceView** textureView) override;
+
+            // DGSL methods.
+            struct DGSLEffectInfo : public EffectInfo
+            {
+                static constexpr int BaseTextureOffset = 4;
+
+                const wchar_t* textures[DGSLEffect::MaxTextures - BaseTextureOffset];
+                const wchar_t* pixelShader;
+
+                DGSLEffectInfo() noexcept :
+                    EffectInfo(),
+                    textures{},
+                    pixelShader(nullptr)
+                {
+                }
+            };
+
+            virtual std::shared_ptr<IEffect> __cdecl CreateDGSLEffect(_In_ const DGSLEffectInfo& info, _In_opt_ ID3D11DeviceContext* deviceContext);
+
+            virtual void __cdecl CreatePixelShader(_In_z_ const wchar_t* shader, _Outptr_ ID3D11PixelShader** pixelShader);
+
+            // Settings.
+            void __cdecl ReleaseCache();
+
+            void __cdecl SetSharing(bool enabled) noexcept;
+
+            void __cdecl EnableForceSRGB(bool forceSRGB) noexcept;
+
+            void __cdecl SetDirectory(_In_opt_z_ const wchar_t* path) noexcept;
+
+            // Properties.
+            ID3D11Device* GetDevice() const noexcept;
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::shared_ptr<Impl> pImpl;
+        };
+    }
 }

--- a/Inc/GeometricPrimitive.h
+++ b/Inc/GeometricPrimitive.h
@@ -22,87 +22,90 @@
 
 namespace DirectX
 {
-    class IEffect;
-
-    class GeometricPrimitive
+    inline namespace DX11
     {
-    public:
-        GeometricPrimitive(GeometricPrimitive&&) = default;
-        GeometricPrimitive& operator= (GeometricPrimitive&&) = default;
+        class IEffect;
 
-        GeometricPrimitive(GeometricPrimitive const&) = delete;
-        GeometricPrimitive& operator= (GeometricPrimitive const&) = delete;
-
-        using VertexType = VertexPositionNormalTexture;
-        using VertexCollection = std::vector<VertexType>;
-        using IndexCollection = std::vector<uint16_t>;
-
-        virtual ~GeometricPrimitive();
-
-        // Factory methods.
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCube(_In_ ID3D11DeviceContext* deviceContext, float size = 1, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateBox(_In_ ID3D11DeviceContext* deviceContext, const XMFLOAT3& size, bool rhcoords = true, bool invertn = false);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateSphere(_In_ ID3D11DeviceContext* deviceContext, float diameter = 1, size_t tessellation = 16, bool rhcoords = true, bool invertn = false);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateGeoSphere(_In_ ID3D11DeviceContext* deviceContext, float diameter = 1, size_t tessellation = 3, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCylinder(_In_ ID3D11DeviceContext* deviceContext, float height = 1, float diameter = 1, size_t tessellation = 32, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCone(_In_ ID3D11DeviceContext* deviceContext, float diameter = 1, float height = 1, size_t tessellation = 32, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateTorus(_In_ ID3D11DeviceContext* deviceContext, float diameter = 1, float thickness = 0.333f, size_t tessellation = 32, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateTetrahedron(_In_ ID3D11DeviceContext* deviceContext, float size = 1, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateOctahedron(_In_ ID3D11DeviceContext* deviceContext, float size = 1, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateDodecahedron(_In_ ID3D11DeviceContext* deviceContext, float size = 1, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateIcosahedron(_In_ ID3D11DeviceContext* deviceContext, float size = 1, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateTeapot(_In_ ID3D11DeviceContext* deviceContext, float size = 1, size_t tessellation = 8, bool rhcoords = true);
-        static std::unique_ptr<GeometricPrimitive> __cdecl CreateCustom(_In_ ID3D11DeviceContext* deviceContext, const VertexCollection& vertices, const IndexCollection& indices);
-
-        static void __cdecl CreateCube(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
-        static void __cdecl CreateBox(VertexCollection& vertices, IndexCollection& indices, const XMFLOAT3& size, bool rhcoords = true, bool invertn = false);
-        static void __cdecl CreateSphere(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, size_t tessellation = 16, bool rhcoords = true, bool invertn = false);
-        static void __cdecl CreateGeoSphere(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, size_t tessellation = 3, bool rhcoords = true);
-        static void __cdecl CreateCylinder(VertexCollection& vertices, IndexCollection& indices, float height = 1, float diameter = 1, size_t tessellation = 32, bool rhcoords = true);
-        static void __cdecl CreateCone(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, float height = 1, size_t tessellation = 32, bool rhcoords = true);
-        static void __cdecl CreateTorus(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, float thickness = 0.333f, size_t tessellation = 32, bool rhcoords = true);
-        static void __cdecl CreateTetrahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
-        static void __cdecl CreateOctahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
-        static void __cdecl CreateDodecahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
-        static void __cdecl CreateIcosahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
-        static void __cdecl CreateTeapot(VertexCollection& vertices, IndexCollection& indices, float size = 1, size_t tessellation = 8, bool rhcoords = true);
-
-        // Draw the primitive.
-        void XM_CALLCONV Draw(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
-            FXMVECTOR color = Colors::White,
-            _In_opt_ ID3D11ShaderResourceView* texture = nullptr,
-            bool wireframe = false,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
-
-        // Draw the primitive using a custom effect.
-        void __cdecl Draw(_In_ IEffect* effect,
-            _In_ ID3D11InputLayout* inputLayout,
-            bool alpha = false, bool wireframe = false,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
-
-        void __cdecl DrawInstanced(_In_ IEffect* effect,
-            _In_ ID3D11InputLayout* inputLayout,
-            uint32_t instanceCount,
-            bool alpha = false, bool wireframe = false,
-            uint32_t startInstanceLocation = 0,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
-
-       // Create input layout for drawing with a custom effect.
-        void __cdecl CreateInputLayout(_In_ IEffect* effect, _Outptr_ ID3D11InputLayout** inputLayout) const;
-
-        static void SetDepthBufferMode(bool reverseZ)
+        class GeometricPrimitive
         {
-            s_reversez = reverseZ;
-        }
+        public:
+            GeometricPrimitive(GeometricPrimitive&&) = default;
+            GeometricPrimitive& operator= (GeometricPrimitive&&) = default;
 
-    private:
-        static bool s_reversez;
+            GeometricPrimitive(GeometricPrimitive const&) = delete;
+            GeometricPrimitive& operator= (GeometricPrimitive const&) = delete;
 
-        GeometricPrimitive() noexcept(false);
+            using VertexType = VertexPositionNormalTexture;
+            using VertexCollection = std::vector<VertexType>;
+            using IndexCollection = std::vector<uint16_t>;
 
-        // Private implementation.
-        class Impl;
+            virtual ~GeometricPrimitive();
 
-        std::unique_ptr<Impl> pImpl;
-    };
+            // Factory methods.
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateCube(_In_ ID3D11DeviceContext* deviceContext, float size = 1, bool rhcoords = true);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateBox(_In_ ID3D11DeviceContext* deviceContext, const XMFLOAT3& size, bool rhcoords = true, bool invertn = false);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateSphere(_In_ ID3D11DeviceContext* deviceContext, float diameter = 1, size_t tessellation = 16, bool rhcoords = true, bool invertn = false);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateGeoSphere(_In_ ID3D11DeviceContext* deviceContext, float diameter = 1, size_t tessellation = 3, bool rhcoords = true);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateCylinder(_In_ ID3D11DeviceContext* deviceContext, float height = 1, float diameter = 1, size_t tessellation = 32, bool rhcoords = true);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateCone(_In_ ID3D11DeviceContext* deviceContext, float diameter = 1, float height = 1, size_t tessellation = 32, bool rhcoords = true);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateTorus(_In_ ID3D11DeviceContext* deviceContext, float diameter = 1, float thickness = 0.333f, size_t tessellation = 32, bool rhcoords = true);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateTetrahedron(_In_ ID3D11DeviceContext* deviceContext, float size = 1, bool rhcoords = true);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateOctahedron(_In_ ID3D11DeviceContext* deviceContext, float size = 1, bool rhcoords = true);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateDodecahedron(_In_ ID3D11DeviceContext* deviceContext, float size = 1, bool rhcoords = true);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateIcosahedron(_In_ ID3D11DeviceContext* deviceContext, float size = 1, bool rhcoords = true);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateTeapot(_In_ ID3D11DeviceContext* deviceContext, float size = 1, size_t tessellation = 8, bool rhcoords = true);
+            static std::unique_ptr<GeometricPrimitive> __cdecl CreateCustom(_In_ ID3D11DeviceContext* deviceContext, const VertexCollection& vertices, const IndexCollection& indices);
+
+            static void __cdecl CreateCube(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
+            static void __cdecl CreateBox(VertexCollection& vertices, IndexCollection& indices, const XMFLOAT3& size, bool rhcoords = true, bool invertn = false);
+            static void __cdecl CreateSphere(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, size_t tessellation = 16, bool rhcoords = true, bool invertn = false);
+            static void __cdecl CreateGeoSphere(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, size_t tessellation = 3, bool rhcoords = true);
+            static void __cdecl CreateCylinder(VertexCollection& vertices, IndexCollection& indices, float height = 1, float diameter = 1, size_t tessellation = 32, bool rhcoords = true);
+            static void __cdecl CreateCone(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, float height = 1, size_t tessellation = 32, bool rhcoords = true);
+            static void __cdecl CreateTorus(VertexCollection& vertices, IndexCollection& indices, float diameter = 1, float thickness = 0.333f, size_t tessellation = 32, bool rhcoords = true);
+            static void __cdecl CreateTetrahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
+            static void __cdecl CreateOctahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
+            static void __cdecl CreateDodecahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
+            static void __cdecl CreateIcosahedron(VertexCollection& vertices, IndexCollection& indices, float size = 1, bool rhcoords = true);
+            static void __cdecl CreateTeapot(VertexCollection& vertices, IndexCollection& indices, float size = 1, size_t tessellation = 8, bool rhcoords = true);
+
+            // Draw the primitive.
+            void XM_CALLCONV Draw(FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
+                FXMVECTOR color = Colors::White,
+                _In_opt_ ID3D11ShaderResourceView* texture = nullptr,
+                bool wireframe = false,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+
+            // Draw the primitive using a custom effect.
+            void __cdecl Draw(_In_ IEffect* effect,
+                _In_ ID3D11InputLayout* inputLayout,
+                bool alpha = false, bool wireframe = false,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+
+            void __cdecl DrawInstanced(_In_ IEffect* effect,
+                _In_ ID3D11InputLayout* inputLayout,
+                uint32_t instanceCount,
+                bool alpha = false, bool wireframe = false,
+                uint32_t startInstanceLocation = 0,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+
+           // Create input layout for drawing with a custom effect.
+            void __cdecl CreateInputLayout(_In_ IEffect* effect, _Outptr_ ID3D11InputLayout** inputLayout) const;
+
+            static void SetDepthBufferMode(bool reverseZ)
+            {
+                s_reversez = reverseZ;
+            }
+
+        private:
+            static bool s_reversez;
+
+            GeometricPrimitive() noexcept(false);
+
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+        };
+    }
 }

--- a/Inc/GraphicsMemory.h
+++ b/Inc/GraphicsMemory.h
@@ -21,34 +21,37 @@
 
 namespace DirectX
 {
-    class GraphicsMemory
+    inline namespace DX11
     {
-    public:
-    #if defined(_XBOX_ONE) && defined(_TITLE)
-        GraphicsMemory(_In_ ID3D11DeviceX* device, unsigned int backBufferCount = 2);
-    #else
-        GraphicsMemory(_In_ ID3D11Device* device, unsigned int backBufferCount = 2);
-    #endif
+        class GraphicsMemory
+        {
+        public:
+        #if defined(_XBOX_ONE) && defined(_TITLE)
+            GraphicsMemory(_In_ ID3D11DeviceX* device, unsigned int backBufferCount = 2);
+        #else
+            GraphicsMemory(_In_ ID3D11Device* device, unsigned int backBufferCount = 2);
+        #endif
 
-        GraphicsMemory(GraphicsMemory&&) noexcept;
-        GraphicsMemory& operator= (GraphicsMemory&&) noexcept;
+            GraphicsMemory(GraphicsMemory&&) noexcept;
+            GraphicsMemory& operator= (GraphicsMemory&&) noexcept;
 
-        GraphicsMemory(GraphicsMemory const&) = delete;
-        GraphicsMemory& operator=(GraphicsMemory const&) = delete;
+            GraphicsMemory(GraphicsMemory const&) = delete;
+            GraphicsMemory& operator=(GraphicsMemory const&) = delete;
 
-        virtual ~GraphicsMemory();
+            virtual ~GraphicsMemory();
 
-        void* __cdecl Allocate(_In_opt_ ID3D11DeviceContext* context, size_t size, int alignment);
+            void* __cdecl Allocate(_In_opt_ ID3D11DeviceContext* context, size_t size, int alignment);
 
-        void __cdecl Commit();
+            void __cdecl Commit();
 
-        // Singleton
-        static GraphicsMemory& __cdecl Get();
+            // Singleton
+            static GraphicsMemory& __cdecl Get();
 
-    private:
-        // Private implementation.
-        class Impl;
+        private:
+            // Private implementation.
+            class Impl;
 
-        std::unique_ptr<Impl> pImpl;
-    };
+            std::unique_ptr<Impl> pImpl;
+        };
+    }
 }

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -35,314 +35,317 @@
 
 namespace DirectX
 {
-    class IEffect;
-    class IEffectFactory;
-    class CommonStates;
-    class ModelMesh;
-
-    //----------------------------------------------------------------------------------
-    // Model loading options
-    enum ModelLoaderFlags : uint32_t
+    inline namespace DX11
     {
-        ModelLoader_Clockwise = 0x0,
-        ModelLoader_CounterClockwise = 0x1,
-        ModelLoader_PremultipledAlpha = 0x2,
-        ModelLoader_MaterialColorsSRGB = 0x4,
-        ModelLoader_AllowLargeModels = 0x8,
-        ModelLoader_IncludeBones = 0x10,
-        ModelLoader_DisableSkinning = 0x20,
-    };
+        class IEffect;
+        class IEffectFactory;
+        class CommonStates;
+        class ModelMesh;
 
-    //----------------------------------------------------------------------------------
-    // Frame hierarchy for rigid body and skeletal animation
-    struct ModelBone
-    {
-        ModelBone() noexcept :
-            parentIndex(c_Invalid),
-            childIndex(c_Invalid),
-            siblingIndex(c_Invalid)
+        //------------------------------------------------------------------------------
+        // Model loading options
+        enum ModelLoaderFlags : uint32_t
         {
-        }
+            ModelLoader_Clockwise = 0x0,
+            ModelLoader_CounterClockwise = 0x1,
+            ModelLoader_PremultipledAlpha = 0x2,
+            ModelLoader_MaterialColorsSRGB = 0x4,
+            ModelLoader_AllowLargeModels = 0x8,
+            ModelLoader_IncludeBones = 0x10,
+            ModelLoader_DisableSkinning = 0x20,
+        };
 
-        ModelBone(uint32_t parent, uint32_t child, uint32_t sibling) noexcept :
-            parentIndex(parent),
-            childIndex(child),
-            siblingIndex(sibling)
+        //------------------------------------------------------------------------------
+        // Frame hierarchy for rigid body and skeletal animation
+        struct ModelBone
         {
-        }
+            ModelBone() noexcept :
+                parentIndex(c_Invalid),
+                childIndex(c_Invalid),
+                siblingIndex(c_Invalid)
+            {
+            }
 
-        uint32_t            parentIndex;
-        uint32_t            childIndex;
-        uint32_t            siblingIndex;
-        std::wstring        name;
+            ModelBone(uint32_t parent, uint32_t child, uint32_t sibling) noexcept :
+                parentIndex(parent),
+                childIndex(child),
+                siblingIndex(sibling)
+            {
+            }
 
-        using Collection = std::vector<ModelBone>;
+            uint32_t            parentIndex;
+            uint32_t            childIndex;
+            uint32_t            siblingIndex;
+            std::wstring        name;
 
-        static constexpr uint32_t c_Invalid = uint32_t(-1);
+            using Collection = std::vector<ModelBone>;
 
-        struct aligned_deleter { void operator()(void* p) noexcept { _aligned_free(p); } };
+            static constexpr uint32_t c_Invalid = uint32_t(-1);
 
-        using TransformArray = std::unique_ptr<XMMATRIX[], aligned_deleter>;
+            struct aligned_deleter { void operator()(void* p) noexcept { _aligned_free(p); } };
 
-        static TransformArray MakeArray(size_t count)
+            using TransformArray = std::unique_ptr<XMMATRIX[], aligned_deleter>;
+
+            static TransformArray MakeArray(size_t count)
+            {
+                void* temp = _aligned_malloc(sizeof(XMMATRIX) * count, 16);
+                if (!temp)
+                    throw std::bad_alloc();
+                return TransformArray(static_cast<XMMATRIX*>(temp));
+            }
+        };
+
+
+        //------------------------------------------------------------------------------
+        // Each mesh part is a submesh with a single effect
+        class ModelMeshPart
         {
-            void* temp = _aligned_malloc(sizeof(XMMATRIX) * count, 16);
-            if (!temp)
-                throw std::bad_alloc();
-            return TransformArray(static_cast<XMMATRIX*>(temp));
-        }
-    };
+        public:
+            ModelMeshPart() noexcept;
+
+            ModelMeshPart(ModelMeshPart&&) = default;
+            ModelMeshPart& operator= (ModelMeshPart&&) = default;
+
+            ModelMeshPart(ModelMeshPart const&) = default;
+            ModelMeshPart& operator= (ModelMeshPart const&) = default;
+
+            virtual ~ModelMeshPart();
+
+            using Collection = std::vector<std::unique_ptr<ModelMeshPart>>;
+            using InputLayoutCollection = std::vector<D3D11_INPUT_ELEMENT_DESC>;
+
+            uint32_t                                                indexCount;
+            uint32_t                                                startIndex;
+            int32_t                                                 vertexOffset;
+            uint32_t                                                vertexStride;
+            D3D_PRIMITIVE_TOPOLOGY                                  primitiveType;
+            DXGI_FORMAT                                             indexFormat;
+            Microsoft::WRL::ComPtr<ID3D11InputLayout>               inputLayout;
+            Microsoft::WRL::ComPtr<ID3D11Buffer>                    indexBuffer;
+            Microsoft::WRL::ComPtr<ID3D11Buffer>                    vertexBuffer;
+            std::shared_ptr<IEffect>                                effect;
+            std::shared_ptr<InputLayoutCollection>                  vbDecl;
+            bool                                                    isAlpha;
+
+            // Draw mesh part with custom effect
+            void __cdecl Draw(
+                _In_ ID3D11DeviceContext* deviceContext,
+                _In_ IEffect* ieffect,
+                _In_ ID3D11InputLayout* iinputLayout,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+
+            void __cdecl DrawInstanced(
+                _In_ ID3D11DeviceContext* deviceContext,
+                _In_ IEffect* ieffect,
+                _In_ ID3D11InputLayout* iinputLayout,
+                uint32_t instanceCount,
+                uint32_t startInstanceLocation = 0,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+
+           // Create input layout for drawing with a custom effect.
+            void __cdecl CreateInputLayout(_In_ ID3D11Device* device, _In_ IEffect* ieffect, _Outptr_ ID3D11InputLayout** iinputLayout) const;
+
+            // Change effect used by part and regenerate input layout (be sure to call Model::Modified as well)
+            void __cdecl ModifyEffect(_In_ ID3D11Device* device, _In_ const std::shared_ptr<IEffect>& ieffect, bool isalpha = false);
+        };
 
 
-    //----------------------------------------------------------------------------------
-    // Each mesh part is a submesh with a single effect
-    class ModelMeshPart
-    {
-    public:
-        ModelMeshPart() noexcept;
-
-        ModelMeshPart(ModelMeshPart&&) = default;
-        ModelMeshPart& operator= (ModelMeshPart&&) = default;
-
-        ModelMeshPart(ModelMeshPart const&) = default;
-        ModelMeshPart& operator= (ModelMeshPart const&) = default;
-
-        virtual ~ModelMeshPart();
-
-        using Collection = std::vector<std::unique_ptr<ModelMeshPart>>;
-        using InputLayoutCollection = std::vector<D3D11_INPUT_ELEMENT_DESC>;
-
-        uint32_t                                                indexCount;
-        uint32_t                                                startIndex;
-        int32_t                                                 vertexOffset;
-        uint32_t                                                vertexStride;
-        D3D_PRIMITIVE_TOPOLOGY                                  primitiveType;
-        DXGI_FORMAT                                             indexFormat;
-        Microsoft::WRL::ComPtr<ID3D11InputLayout>               inputLayout;
-        Microsoft::WRL::ComPtr<ID3D11Buffer>                    indexBuffer;
-        Microsoft::WRL::ComPtr<ID3D11Buffer>                    vertexBuffer;
-        std::shared_ptr<IEffect>                                effect;
-        std::shared_ptr<InputLayoutCollection>                  vbDecl;
-        bool                                                    isAlpha;
-
-        // Draw mesh part with custom effect
-        void __cdecl Draw(
-            _In_ ID3D11DeviceContext* deviceContext,
-            _In_ IEffect* ieffect,
-            _In_ ID3D11InputLayout* iinputLayout,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
-
-        void __cdecl DrawInstanced(
-            _In_ ID3D11DeviceContext* deviceContext,
-            _In_ IEffect* ieffect,
-            _In_ ID3D11InputLayout* iinputLayout,
-            uint32_t instanceCount,
-            uint32_t startInstanceLocation = 0,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
-
-       // Create input layout for drawing with a custom effect.
-        void __cdecl CreateInputLayout(_In_ ID3D11Device* device, _In_ IEffect* ieffect, _Outptr_ ID3D11InputLayout** iinputLayout) const;
-
-        // Change effect used by part and regenerate input layout (be sure to call Model::Modified as well)
-        void __cdecl ModifyEffect(_In_ ID3D11Device* device, _In_ const std::shared_ptr<IEffect>& ieffect, bool isalpha = false);
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // A mesh consists of one or more model mesh parts
-    class ModelMesh
-    {
-    public:
-        ModelMesh() noexcept;
-
-        ModelMesh(ModelMesh&&) = default;
-        ModelMesh& operator= (ModelMesh&&) = default;
-
-        ModelMesh(ModelMesh const&) = default;
-        ModelMesh& operator= (ModelMesh const&) = default;
-
-        virtual ~ModelMesh();
-
-        BoundingSphere              boundingSphere;
-        BoundingBox                 boundingBox;
-        ModelMeshPart::Collection   meshParts;
-        uint32_t                    boneIndex;
-        std::vector<uint32_t>       boneInfluences;
-        std::wstring                name;
-        bool                        ccw;
-        bool                        pmalpha;
-
-        using Collection = std::vector<std::shared_ptr<ModelMesh>>;
-
-        // Setup states for drawing mesh
-        void __cdecl PrepareForRendering(
-            _In_ ID3D11DeviceContext* deviceContext,
-            const CommonStates& states,
-            bool alpha = false,
-            bool wireframe = false) const;
-
-        // Draw the mesh
-        void XM_CALLCONV Draw(
-            _In_ ID3D11DeviceContext* deviceContext,
-            FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
-            bool alpha = false,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
-
-        // Draw the mesh using model bones
-        void XM_CALLCONV Draw(
-            _In_ ID3D11DeviceContext* deviceContext,
-            size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
-            FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
-            bool alpha = false,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
-
-        // Draw the mesh using skinning
-        void XM_CALLCONV DrawSkinned(
-            _In_ ID3D11DeviceContext* deviceContext,
-            size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
-            FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
-            bool alpha = false,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
-
-        static void SetDepthBufferMode(bool reverseZ)
+        //------------------------------------------------------------------------------
+        // A mesh consists of one or more model mesh parts
+        class ModelMesh
         {
-            s_reversez = reverseZ;
-        }
+        public:
+            ModelMesh() noexcept;
 
-    private:
-        static bool s_reversez;
-    };
+            ModelMesh(ModelMesh&&) = default;
+            ModelMesh& operator= (ModelMesh&&) = default;
+
+            ModelMesh(ModelMesh const&) = default;
+            ModelMesh& operator= (ModelMesh const&) = default;
+
+            virtual ~ModelMesh();
+
+            BoundingSphere              boundingSphere;
+            BoundingBox                 boundingBox;
+            ModelMeshPart::Collection   meshParts;
+            uint32_t                    boneIndex;
+            std::vector<uint32_t>       boneInfluences;
+            std::wstring                name;
+            bool                        ccw;
+            bool                        pmalpha;
+
+            using Collection = std::vector<std::shared_ptr<ModelMesh>>;
+
+            // Setup states for drawing mesh
+            void __cdecl PrepareForRendering(
+                _In_ ID3D11DeviceContext* deviceContext,
+                const CommonStates& states,
+                bool alpha = false,
+                bool wireframe = false) const;
+
+            // Draw the mesh
+            void XM_CALLCONV Draw(
+                _In_ ID3D11DeviceContext* deviceContext,
+                FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
+                bool alpha = false,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+
+            // Draw the mesh using model bones
+            void XM_CALLCONV Draw(
+                _In_ ID3D11DeviceContext* deviceContext,
+                size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
+                FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
+                bool alpha = false,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+
+            // Draw the mesh using skinning
+            void XM_CALLCONV DrawSkinned(
+                _In_ ID3D11DeviceContext* deviceContext,
+                size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
+                FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
+                bool alpha = false,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+
+            static void SetDepthBufferMode(bool reverseZ)
+            {
+                s_reversez = reverseZ;
+            }
+
+        private:
+            static bool s_reversez;
+        };
 
 
-    //----------------------------------------------------------------------------------
-    // A model consists of one or more meshes
-    class Model
-    {
-    public:
-        Model() = default;
+        //------------------------------------------------------------------------------
+        // A model consists of one or more meshes
+        class Model
+        {
+        public:
+            Model() = default;
 
-        Model(Model&&) = default;
-        Model& operator= (Model&&) = default;
+            Model(Model&&) = default;
+            Model& operator= (Model&&) = default;
 
-        Model(Model const& other);
-        Model& operator= (Model const& rhs);
+            Model(Model const& other);
+            Model& operator= (Model const& rhs);
 
-        virtual ~Model();
+            virtual ~Model();
 
-        ModelMesh::Collection       meshes;
-        ModelBone::Collection       bones;
-        ModelBone::TransformArray   boneMatrices;
-        ModelBone::TransformArray   invBindPoseMatrices;
-        std::wstring                name;
+            ModelMesh::Collection       meshes;
+            ModelBone::Collection       bones;
+            ModelBone::TransformArray   boneMatrices;
+            ModelBone::TransformArray   invBindPoseMatrices;
+            std::wstring                name;
 
-        // Draw all the meshes in the model
-        void XM_CALLCONV Draw(
-            _In_ ID3D11DeviceContext* deviceContext,
-            const CommonStates& states,
-            FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
-            bool wireframe = false,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+            // Draw all the meshes in the model
+            void XM_CALLCONV Draw(
+                _In_ ID3D11DeviceContext* deviceContext,
+                const CommonStates& states,
+                FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
+                bool wireframe = false,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
-        // Draw all the meshes using model bones
-        void XM_CALLCONV Draw(
-            _In_ ID3D11DeviceContext* deviceContext,
-            const CommonStates& states,
-            size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
-            FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
-            bool wireframe = false,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+            // Draw all the meshes using model bones
+            void XM_CALLCONV Draw(
+                _In_ ID3D11DeviceContext* deviceContext,
+                const CommonStates& states,
+                size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
+                FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
+                bool wireframe = false,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
-        // Draw all the meshes using skinning
-        void XM_CALLCONV DrawSkinned(
-            _In_ ID3D11DeviceContext* deviceContext,
-            const CommonStates& states,
-            size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
-            FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
-            bool wireframe = false,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+            // Draw all the meshes using skinning
+            void XM_CALLCONV DrawSkinned(
+                _In_ ID3D11DeviceContext* deviceContext,
+                const CommonStates& states,
+                size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
+                FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
+                bool wireframe = false,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
-        // Compute bone positions based on heirarchy and transform matrices
-        void __cdecl CopyAbsoluteBoneTransformsTo(
-            size_t nbones,
-            _Out_writes_(nbones) XMMATRIX* boneTransforms) const;
+            // Compute bone positions based on heirarchy and transform matrices
+            void __cdecl CopyAbsoluteBoneTransformsTo(
+                size_t nbones,
+                _Out_writes_(nbones) XMMATRIX* boneTransforms) const;
 
-        void __cdecl CopyAbsoluteBoneTransforms(
-            size_t nbones,
-            _In_reads_(nbones) const XMMATRIX* inBoneTransforms,
-            _Out_writes_(nbones) XMMATRIX* outBoneTransforms) const;
+            void __cdecl CopyAbsoluteBoneTransforms(
+                size_t nbones,
+                _In_reads_(nbones) const XMMATRIX* inBoneTransforms,
+                _Out_writes_(nbones) XMMATRIX* outBoneTransforms) const;
 
-        // Set bone matrices to a set of relative tansforms
-        void __cdecl CopyBoneTransformsFrom(
-            size_t nbones,
-            _In_reads_(nbones) const XMMATRIX* boneTransforms);
+            // Set bone matrices to a set of relative tansforms
+            void __cdecl CopyBoneTransformsFrom(
+                size_t nbones,
+                _In_reads_(nbones) const XMMATRIX* boneTransforms);
 
-        // Copies the relative bone matrices to a transform array
-        void __cdecl CopyBoneTransformsTo(
-            size_t nbones,
-            _Out_writes_(nbones) XMMATRIX* boneTransforms) const;
+            // Copies the relative bone matrices to a transform array
+            void __cdecl CopyBoneTransformsTo(
+                size_t nbones,
+                _Out_writes_(nbones) XMMATRIX* boneTransforms) const;
 
-        // Notify model that effects, parts list, or mesh list has changed
-        void __cdecl Modified() noexcept { mEffectCache.clear(); }
+            // Notify model that effects, parts list, or mesh list has changed
+            void __cdecl Modified() noexcept { mEffectCache.clear(); }
 
-        // Update all effects used by the model
-        void __cdecl UpdateEffects(_In_ std::function<void __cdecl(IEffect*)> setEffect);
+            // Update all effects used by the model
+            void __cdecl UpdateEffects(_In_ std::function<void __cdecl(IEffect*)> setEffect);
 
-        // Loads a model from a Visual Studio Starter Kit .CMO file
-        static std::unique_ptr<Model> __cdecl CreateFromCMO(
-            _In_ ID3D11Device* device,
-            _In_reads_bytes_(dataSize) const uint8_t* meshData, size_t dataSize,
-            _In_ IEffectFactory& fxFactory,
-            ModelLoaderFlags flags = ModelLoader_CounterClockwise,
-            _Out_opt_ size_t* animsOffset = nullptr);
-        static std::unique_ptr<Model> __cdecl CreateFromCMO(
-            _In_ ID3D11Device* device,
-            _In_z_ const wchar_t* szFileName,
-            _In_ IEffectFactory& fxFactory,
-            ModelLoaderFlags flags = ModelLoader_CounterClockwise,
-            _Out_opt_ size_t* animsOffset = nullptr);
+            // Loads a model from a Visual Studio Starter Kit .CMO file
+            static std::unique_ptr<Model> __cdecl CreateFromCMO(
+                _In_ ID3D11Device* device,
+                _In_reads_bytes_(dataSize) const uint8_t* meshData, size_t dataSize,
+                _In_ IEffectFactory& fxFactory,
+                ModelLoaderFlags flags = ModelLoader_CounterClockwise,
+                _Out_opt_ size_t* animsOffset = nullptr);
+            static std::unique_ptr<Model> __cdecl CreateFromCMO(
+                _In_ ID3D11Device* device,
+                _In_z_ const wchar_t* szFileName,
+                _In_ IEffectFactory& fxFactory,
+                ModelLoaderFlags flags = ModelLoader_CounterClockwise,
+                _Out_opt_ size_t* animsOffset = nullptr);
 
-        // Loads a model from a DirectX SDK .SDKMESH file
-        static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
-            _In_ ID3D11Device* device,
-            _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
-            _In_ IEffectFactory& fxFactory,
-            ModelLoaderFlags flags = ModelLoader_Clockwise);
-        static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
-            _In_ ID3D11Device* device,
-            _In_z_ const wchar_t* szFileName,
-            _In_ IEffectFactory& fxFactory,
-            ModelLoaderFlags flags = ModelLoader_Clockwise);
+            // Loads a model from a DirectX SDK .SDKMESH file
+            static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
+                _In_ ID3D11Device* device,
+                _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
+                _In_ IEffectFactory& fxFactory,
+                ModelLoaderFlags flags = ModelLoader_Clockwise);
+            static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
+                _In_ ID3D11Device* device,
+                _In_z_ const wchar_t* szFileName,
+                _In_ IEffectFactory& fxFactory,
+                ModelLoaderFlags flags = ModelLoader_Clockwise);
 
-        // Loads a model from a .VBO file
-        static std::unique_ptr<Model> __cdecl CreateFromVBO(
-            _In_ ID3D11Device* device,
-            _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
-            _In_opt_ std::shared_ptr<IEffect> ieffect = nullptr,
-            ModelLoaderFlags flags = ModelLoader_Clockwise);
-        static std::unique_ptr<Model> __cdecl CreateFromVBO(
-            _In_ ID3D11Device* device,
-            _In_z_ const wchar_t* szFileName,
-            _In_opt_ std::shared_ptr<IEffect> ieffect = nullptr,
-            ModelLoaderFlags flags = ModelLoader_Clockwise);
+            // Loads a model from a .VBO file
+            static std::unique_ptr<Model> __cdecl CreateFromVBO(
+                _In_ ID3D11Device* device,
+                _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
+                _In_opt_ std::shared_ptr<IEffect> ieffect = nullptr,
+                ModelLoaderFlags flags = ModelLoader_Clockwise);
+            static std::unique_ptr<Model> __cdecl CreateFromVBO(
+                _In_ ID3D11Device* device,
+                _In_z_ const wchar_t* szFileName,
+                _In_opt_ std::shared_ptr<IEffect> ieffect = nullptr,
+                ModelLoaderFlags flags = ModelLoader_Clockwise);
 
-    private:
-        std::set<IEffect*>  mEffectCache;
+        private:
+            std::set<IEffect*>  mEffectCache;
 
-        void __cdecl ComputeAbsolute(uint32_t index,
-            CXMMATRIX local, size_t nbones,
-            _In_reads_(nbones) const XMMATRIX* inBoneTransforms,
-            _Inout_updates_(nbones) XMMATRIX* outBoneTransforms,
-            size_t& visited) const;
-    };
+            void __cdecl ComputeAbsolute(uint32_t index,
+                CXMMATRIX local, size_t nbones,
+                _In_reads_(nbones) const XMMATRIX* inBoneTransforms,
+                _Inout_updates_(nbones) XMMATRIX* outBoneTransforms,
+                size_t& visited) const;
+        };
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
-#endif
+    #ifdef __clang__
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+    #endif
 
-    DEFINE_ENUM_FLAG_OPERATORS(ModelLoaderFlags);
+        DEFINE_ENUM_FLAG_OPERATORS(ModelLoaderFlags);
 
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+    #ifdef __clang__
+    #pragma clang diagnostic pop
+    #endif
+    }
 }

--- a/Inc/PostProcess.h
+++ b/Inc/PostProcess.h
@@ -23,202 +23,205 @@
 
 namespace DirectX
 {
-    //----------------------------------------------------------------------------------
-    // Abstract interface representing a post-process pass
-    class IPostProcess
+    inline namespace DX11
     {
-    public:
-        virtual ~IPostProcess() = default;
-
-        IPostProcess(const IPostProcess&) = delete;
-        IPostProcess& operator=(const IPostProcess&) = delete;
-
-        virtual void __cdecl Process(_In_ ID3D11DeviceContext* deviceContext,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) = 0;
-
-    protected:
-        IPostProcess() = default;
-        IPostProcess(IPostProcess&&) = default;
-        IPostProcess& operator=(IPostProcess&&) = default;
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // Basic post-process
-    class BasicPostProcess : public IPostProcess
-    {
-    public:
-        enum Effect : unsigned int
+        //------------------------------------------------------------------------------
+        // Abstract interface representing a post-process pass
+        class IPostProcess
         {
-            Copy,
-            Monochrome,
-            Sepia,
-            DownScale_2x2,
-            DownScale_4x4,
-            GaussianBlur_5x5,
-            BloomExtract,
-            BloomBlur,
-            Effect_Max
+        public:
+            virtual ~IPostProcess() = default;
+
+            IPostProcess(const IPostProcess&) = delete;
+            IPostProcess& operator=(const IPostProcess&) = delete;
+
+            virtual void __cdecl Process(_In_ ID3D11DeviceContext* deviceContext,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) = 0;
+
+        protected:
+            IPostProcess() = default;
+            IPostProcess(IPostProcess&&) = default;
+            IPostProcess& operator=(IPostProcess&&) = default;
         };
 
-        explicit BasicPostProcess(_In_ ID3D11Device* device);
 
-        BasicPostProcess(BasicPostProcess&&) noexcept;
-        BasicPostProcess& operator= (BasicPostProcess&&) noexcept;
-
-        BasicPostProcess(BasicPostProcess const&) = delete;
-        BasicPostProcess& operator= (BasicPostProcess const&) = delete;
-
-        ~BasicPostProcess() override;
-
-        // IPostProcess methods.
-        void __cdecl Process(
-            _In_ ID3D11DeviceContext* deviceContext,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) override;
-
-        // Shader control
-        void __cdecl SetEffect(Effect fx);
-
-        // Properties
-        void __cdecl SetSourceTexture(_In_opt_ ID3D11ShaderResourceView* value);
-
-        // Sets multiplier for GaussianBlur_5x5
-        void __cdecl SetGaussianParameter(float multiplier);
-
-        // Sets parameters for BloomExtract
-        void __cdecl SetBloomExtractParameter(float threshold);
-
-        // Sets parameters for BloomBlur
-        void __cdecl SetBloomBlurParameters(bool horizontal, float size, float brightness);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // Dual-texure post-process
-    class DualPostProcess : public IPostProcess
-    {
-    public:
-        enum Effect : unsigned int
+        //------------------------------------------------------------------------------
+        // Basic post-process
+        class BasicPostProcess : public IPostProcess
         {
-            Merge,
-            BloomCombine,
-            Effect_Max
+        public:
+            enum Effect : unsigned int
+            {
+                Copy,
+                Monochrome,
+                Sepia,
+                DownScale_2x2,
+                DownScale_4x4,
+                GaussianBlur_5x5,
+                BloomExtract,
+                BloomBlur,
+                Effect_Max
+            };
+
+            explicit BasicPostProcess(_In_ ID3D11Device* device);
+
+            BasicPostProcess(BasicPostProcess&&) noexcept;
+            BasicPostProcess& operator= (BasicPostProcess&&) noexcept;
+
+            BasicPostProcess(BasicPostProcess const&) = delete;
+            BasicPostProcess& operator= (BasicPostProcess const&) = delete;
+
+            ~BasicPostProcess() override;
+
+            // IPostProcess methods.
+            void __cdecl Process(
+                _In_ ID3D11DeviceContext* deviceContext,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) override;
+
+            // Shader control
+            void __cdecl SetEffect(Effect fx);
+
+            // Properties
+            void __cdecl SetSourceTexture(_In_opt_ ID3D11ShaderResourceView* value);
+
+            // Sets multiplier for GaussianBlur_5x5
+            void __cdecl SetGaussianParameter(float multiplier);
+
+            // Sets parameters for BloomExtract
+            void __cdecl SetBloomExtractParameter(float threshold);
+
+            // Sets parameters for BloomBlur
+            void __cdecl SetBloomBlurParameters(bool horizontal, float size, float brightness);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
         };
 
-        explicit DualPostProcess(_In_ ID3D11Device* device);
 
-        DualPostProcess(DualPostProcess&&) noexcept;
-        DualPostProcess& operator= (DualPostProcess&&) noexcept;
-
-        DualPostProcess(DualPostProcess const&) = delete;
-        DualPostProcess& operator= (DualPostProcess const&) = delete;
-
-        ~DualPostProcess() override;
-
-        // IPostProcess methods.
-        void __cdecl Process(_In_ ID3D11DeviceContext* deviceContext,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) override;
-
-        // Shader control
-        void __cdecl SetEffect(Effect fx);
-
-        // Properties
-        void __cdecl SetSourceTexture(_In_opt_ ID3D11ShaderResourceView* value);
-        void __cdecl SetSourceTexture2(_In_opt_ ID3D11ShaderResourceView* value);
-
-        // Sets parameters for Merge
-        void __cdecl SetMergeParameters(float weight1, float weight2);
-
-        // Sets parameters for BloomCombine
-        void __cdecl SetBloomCombineParameters(float bloom, float base, float bloomSaturation, float baseSaturation);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
-
-
-    //----------------------------------------------------------------------------------
-    // Tone-map post-process
-    class ToneMapPostProcess : public IPostProcess
-    {
-    public:
-        // Tone-mapping operator
-        enum Operator : unsigned int
+        //------------------------------------------------------------------------------
+        // Dual-texure post-process
+        class DualPostProcess : public IPostProcess
         {
-            None,               // Pass-through
-            Saturate,           // Clamp [0,1]
-            Reinhard,           // x/(1+x)
-            ACESFilmic,
-            Operator_Max
+        public:
+            enum Effect : unsigned int
+            {
+                Merge,
+                BloomCombine,
+                Effect_Max
+            };
+
+            explicit DualPostProcess(_In_ ID3D11Device* device);
+
+            DualPostProcess(DualPostProcess&&) noexcept;
+            DualPostProcess& operator= (DualPostProcess&&) noexcept;
+
+            DualPostProcess(DualPostProcess const&) = delete;
+            DualPostProcess& operator= (DualPostProcess const&) = delete;
+
+            ~DualPostProcess() override;
+
+            // IPostProcess methods.
+            void __cdecl Process(_In_ ID3D11DeviceContext* deviceContext,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) override;
+
+            // Shader control
+            void __cdecl SetEffect(Effect fx);
+
+            // Properties
+            void __cdecl SetSourceTexture(_In_opt_ ID3D11ShaderResourceView* value);
+            void __cdecl SetSourceTexture2(_In_opt_ ID3D11ShaderResourceView* value);
+
+            // Sets parameters for Merge
+            void __cdecl SetMergeParameters(float weight1, float weight2);
+
+            // Sets parameters for BloomCombine
+            void __cdecl SetBloomCombineParameters(float bloom, float base, float bloomSaturation, float baseSaturation);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
         };
 
-        // Electro-Optical Transfer Function (EOTF)
-        enum TransferFunction : unsigned int
+
+        //------------------------------------------------------------------------------
+        // Tone-map post-process
+        class ToneMapPostProcess : public IPostProcess
         {
-            Linear,             // Pass-through
-            SRGB,               // sRGB (Rec.709 and approximate sRGB display curve)
-            ST2084,             // HDR10 (Rec.2020 color primaries and ST.2084 display curve)
-            TransferFunction_Max
+        public:
+            // Tone-mapping operator
+            enum Operator : unsigned int
+            {
+                None,               // Pass-through
+                Saturate,           // Clamp [0,1]
+                Reinhard,           // x/(1+x)
+                ACESFilmic,
+                Operator_Max
+            };
+
+            // Electro-Optical Transfer Function (EOTF)
+            enum TransferFunction : unsigned int
+            {
+                Linear,             // Pass-through
+                SRGB,               // sRGB (Rec.709 and approximate sRGB display curve)
+                ST2084,             // HDR10 (Rec.2020 color primaries and ST.2084 display curve)
+                TransferFunction_Max
+            };
+
+            // Color Rotation Transform for HDR10
+            enum ColorPrimaryRotation : unsigned int
+            {
+                HDTV_to_UHDTV,       // Rec.709 to Rec.2020
+                DCI_P3_D65_to_UHDTV, // DCI-P3-D65 (a.k.a Display P3 or P3D65) to Rec.2020
+                HDTV_to_DCI_P3_D65,  // Rec.709 to DCI-P3-D65 (a.k.a Display P3 or P3D65)
+            };
+
+            explicit ToneMapPostProcess(_In_ ID3D11Device* device);
+
+            ToneMapPostProcess(ToneMapPostProcess&&) noexcept;
+            ToneMapPostProcess& operator= (ToneMapPostProcess&&) noexcept;
+
+            ToneMapPostProcess(ToneMapPostProcess const&) = delete;
+            ToneMapPostProcess& operator= (ToneMapPostProcess const&) = delete;
+
+            ~ToneMapPostProcess() override;
+
+            // IPostProcess methods.
+            void __cdecl Process(_In_ ID3D11DeviceContext* deviceContext,
+                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) override;
+
+            // Shader control
+            void __cdecl SetOperator(Operator op);
+
+            void __cdecl SetTransferFunction(TransferFunction func);
+
+        #if defined(_XBOX_ONE) && defined(_TITLE)
+            // Uses Multiple Render Targets to generate both HDR10 and GameDVR SDR signals
+            void __cdecl SetMRTOutput(bool value = true);
+        #endif
+
+            // Properties
+            void __cdecl SetHDRSourceTexture(_In_opt_ ID3D11ShaderResourceView* value);
+
+            // Sets the Color Rotation Transform for HDR10 signal output
+            void __cdecl SetColorRotation(ColorPrimaryRotation value);
+            void __cdecl SetColorRotation(CXMMATRIX value);
+
+            // Sets exposure value for LDR tonemap operators
+            void __cdecl SetExposure(float exposureValue);
+
+            // Sets ST.2084 parameter for how bright white should be in nits
+            void __cdecl SetST2084Parameter(float paperWhiteNits);
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
         };
-
-        // Color Rotation Transform for HDR10
-        enum ColorPrimaryRotation : unsigned int
-        {
-            HDTV_to_UHDTV,       // Rec.709 to Rec.2020
-            DCI_P3_D65_to_UHDTV, // DCI-P3-D65 (a.k.a Display P3 or P3D65) to Rec.2020
-            HDTV_to_DCI_P3_D65,  // Rec.709 to DCI-P3-D65 (a.k.a Display P3 or P3D65)
-        };
-
-        explicit ToneMapPostProcess(_In_ ID3D11Device* device);
-
-        ToneMapPostProcess(ToneMapPostProcess&&) noexcept;
-        ToneMapPostProcess& operator= (ToneMapPostProcess&&) noexcept;
-
-        ToneMapPostProcess(ToneMapPostProcess const&) = delete;
-        ToneMapPostProcess& operator= (ToneMapPostProcess const&) = delete;
-
-        ~ToneMapPostProcess() override;
-
-        // IPostProcess methods.
-        void __cdecl Process(_In_ ID3D11DeviceContext* deviceContext,
-            _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) override;
-
-        // Shader control
-        void __cdecl SetOperator(Operator op);
-
-        void __cdecl SetTransferFunction(TransferFunction func);
-
-    #if defined(_XBOX_ONE) && defined(_TITLE)
-        // Uses Multiple Render Targets to generate both HDR10 and GameDVR SDR signals
-        void __cdecl SetMRTOutput(bool value = true);
-    #endif
-
-        // Properties
-        void __cdecl SetHDRSourceTexture(_In_opt_ ID3D11ShaderResourceView* value);
-
-        // Sets the Color Rotation Transform for HDR10 signal output
-        void __cdecl SetColorRotation(ColorPrimaryRotation value);
-        void __cdecl SetColorRotation(CXMMATRIX value);
-
-        // Sets exposure value for LDR tonemap operators
-        void __cdecl SetExposure(float exposureValue);
-
-        // Sets ST.2084 parameter for how bright white should be in nits
-        void __cdecl SetST2084Parameter(float paperWhiteNits);
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-    };
+    }
 }

--- a/Inc/PrimitiveBatch.h
+++ b/Inc/PrimitiveBatch.h
@@ -24,115 +24,117 @@
 
 namespace DirectX
 {
-    namespace Internal
+    inline namespace DX11
     {
-        // Base class, not to be used directly: clients should access this via the derived PrimitiveBatch<T>.
-        class PrimitiveBatchBase
+        namespace Private
         {
-        protected:
-            PrimitiveBatchBase(_In_ ID3D11DeviceContext* deviceContext, size_t maxIndices, size_t maxVertices, size_t vertexSize);
+        // Base class, not to be used directly: clients should access this via the derived PrimitiveBatch<T>.
+            class PrimitiveBatchBase
+            {
+            protected:
+                PrimitiveBatchBase(_In_ ID3D11DeviceContext* deviceContext, size_t maxIndices, size_t maxVertices, size_t vertexSize);
 
-            PrimitiveBatchBase(PrimitiveBatchBase&&) noexcept;
-            PrimitiveBatchBase& operator= (PrimitiveBatchBase&&) noexcept;
+                PrimitiveBatchBase(PrimitiveBatchBase&&) noexcept;
+                PrimitiveBatchBase& operator= (PrimitiveBatchBase&&) noexcept;
 
-            PrimitiveBatchBase(PrimitiveBatchBase const&) = delete;
-            PrimitiveBatchBase& operator= (PrimitiveBatchBase const&) = delete;
+                PrimitiveBatchBase(PrimitiveBatchBase const&) = delete;
+                PrimitiveBatchBase& operator= (PrimitiveBatchBase const&) = delete;
 
-            virtual ~PrimitiveBatchBase();
+                virtual ~PrimitiveBatchBase();
+
+            public:
+                // Begin/End a batch of primitive drawing operations.
+                void __cdecl Begin();
+                void __cdecl End();
+
+            protected:
+                // Internal, untyped drawing method.
+                void __cdecl Draw(D3D11_PRIMITIVE_TOPOLOGY topology, bool isIndexed, _In_opt_count_(indexCount) uint16_t const* indices, size_t indexCount, size_t vertexCount, _Out_ void** pMappedVertices);
+
+            private:
+                // Private implementation.
+                class Impl;
+
+                std::unique_ptr<Impl> pImpl;
+            };
+        }
+
+        // Template makes the API typesafe, eg. PrimitiveBatch<VertexPositionColor>.
+        template<typename TVertex>
+        class PrimitiveBatch : public Private::PrimitiveBatchBase
+        {
+            static constexpr size_t DefaultBatchSize = 2048;
 
         public:
-            // Begin/End a batch of primitive drawing operations.
-            void __cdecl Begin();
-            void __cdecl End();
+            explicit PrimitiveBatch(_In_ ID3D11DeviceContext* deviceContext, size_t maxIndices = DefaultBatchSize * 3, size_t maxVertices = DefaultBatchSize)
+                : PrimitiveBatchBase(deviceContext, maxIndices, maxVertices, sizeof(TVertex))
+            {
+            }
 
-        protected:
-            // Internal, untyped drawing method.
-            void __cdecl Draw(D3D11_PRIMITIVE_TOPOLOGY topology, bool isIndexed, _In_opt_count_(indexCount) uint16_t const* indices, size_t indexCount, size_t vertexCount, _Out_ void** pMappedVertices);
+            PrimitiveBatch(PrimitiveBatch&&) = default;
+            PrimitiveBatch& operator= (PrimitiveBatch&&) = default;
 
-        private:
-            // Private implementation.
-            class Impl;
+            PrimitiveBatch(PrimitiveBatch const&) = delete;
+            PrimitiveBatch& operator= (PrimitiveBatch const&) = delete;
 
-            std::unique_ptr<Impl> pImpl;
+            // Similar to the D3D9 API DrawPrimitiveUP.
+            void Draw(D3D11_PRIMITIVE_TOPOLOGY topology, _In_reads_(vertexCount) TVertex const* vertices, size_t vertexCount)
+            {
+                void* mappedVertices;
+
+                PrimitiveBatchBase::Draw(topology, false, nullptr, 0, vertexCount, &mappedVertices);
+
+                memcpy(mappedVertices, vertices, vertexCount * sizeof(TVertex));
+            }
+
+
+            // Similar to the D3D9 API DrawIndexedPrimitiveUP.
+            void DrawIndexed(D3D11_PRIMITIVE_TOPOLOGY topology, _In_reads_(indexCount) uint16_t const* indices, size_t indexCount, _In_reads_(vertexCount) TVertex const* vertices, size_t vertexCount)
+            {
+                void* mappedVertices;
+
+                PrimitiveBatchBase::Draw(topology, true, indices, indexCount, vertexCount, &mappedVertices);
+
+                memcpy(mappedVertices, vertices, vertexCount * sizeof(TVertex));
+            }
+
+
+            void DrawLine(TVertex const& v1, TVertex const& v2)
+            {
+                TVertex* mappedVertices;
+
+                PrimitiveBatchBase::Draw(D3D11_PRIMITIVE_TOPOLOGY_LINELIST, false, nullptr, 0, 2, reinterpret_cast<void**>(&mappedVertices));
+
+                mappedVertices[0] = v1;
+                mappedVertices[1] = v2;
+            }
+
+
+            void DrawTriangle(TVertex const& v1, TVertex const& v2, TVertex const& v3)
+            {
+                TVertex* mappedVertices;
+
+                PrimitiveBatchBase::Draw(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST, false, nullptr, 0, 3, reinterpret_cast<void**>(&mappedVertices));
+
+                mappedVertices[0] = v1;
+                mappedVertices[1] = v2;
+                mappedVertices[2] = v3;
+            }
+
+
+            void DrawQuad(TVertex const& v1, TVertex const& v2, TVertex const& v3, TVertex const& v4)
+            {
+                static const uint16_t quadIndices[] = { 0, 1, 2, 0, 2, 3 };
+
+                TVertex* mappedVertices;
+
+                PrimitiveBatchBase::Draw(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST, true, quadIndices, 6, 4, reinterpret_cast<void**>(&mappedVertices));
+
+                mappedVertices[0] = v1;
+                mappedVertices[1] = v2;
+                mappedVertices[2] = v3;
+                mappedVertices[3] = v4;
+            }
         };
     }
-
-
-    // Template makes the API typesafe, eg. PrimitiveBatch<VertexPositionColor>.
-    template<typename TVertex>
-    class PrimitiveBatch : public Internal::PrimitiveBatchBase
-    {
-        static constexpr size_t DefaultBatchSize = 2048;
-
-    public:
-        explicit PrimitiveBatch(_In_ ID3D11DeviceContext* deviceContext, size_t maxIndices = DefaultBatchSize * 3, size_t maxVertices = DefaultBatchSize)
-            : PrimitiveBatchBase(deviceContext, maxIndices, maxVertices, sizeof(TVertex))
-        {
-        }
-
-        PrimitiveBatch(PrimitiveBatch&&) = default;
-        PrimitiveBatch& operator= (PrimitiveBatch&&) = default;
-
-        PrimitiveBatch(PrimitiveBatch const&) = delete;
-        PrimitiveBatch& operator= (PrimitiveBatch const&) = delete;
-
-        // Similar to the D3D9 API DrawPrimitiveUP.
-        void Draw(D3D11_PRIMITIVE_TOPOLOGY topology, _In_reads_(vertexCount) TVertex const* vertices, size_t vertexCount)
-        {
-            void* mappedVertices;
-
-            PrimitiveBatchBase::Draw(topology, false, nullptr, 0, vertexCount, &mappedVertices);
-
-            memcpy(mappedVertices, vertices, vertexCount * sizeof(TVertex));
-        }
-
-
-        // Similar to the D3D9 API DrawIndexedPrimitiveUP.
-        void DrawIndexed(D3D11_PRIMITIVE_TOPOLOGY topology, _In_reads_(indexCount) uint16_t const* indices, size_t indexCount, _In_reads_(vertexCount) TVertex const* vertices, size_t vertexCount)
-        {
-            void* mappedVertices;
-
-            PrimitiveBatchBase::Draw(topology, true, indices, indexCount, vertexCount, &mappedVertices);
-
-            memcpy(mappedVertices, vertices, vertexCount * sizeof(TVertex));
-        }
-
-
-        void DrawLine(TVertex const& v1, TVertex const& v2)
-        {
-            TVertex* mappedVertices;
-
-            PrimitiveBatchBase::Draw(D3D11_PRIMITIVE_TOPOLOGY_LINELIST, false, nullptr, 0, 2, reinterpret_cast<void**>(&mappedVertices));
-
-            mappedVertices[0] = v1;
-            mappedVertices[1] = v2;
-        }
-
-
-        void DrawTriangle(TVertex const& v1, TVertex const& v2, TVertex const& v3)
-        {
-            TVertex* mappedVertices;
-
-            PrimitiveBatchBase::Draw(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST, false, nullptr, 0, 3, reinterpret_cast<void**>(&mappedVertices));
-
-            mappedVertices[0] = v1;
-            mappedVertices[1] = v2;
-            mappedVertices[2] = v3;
-        }
-
-
-        void DrawQuad(TVertex const& v1, TVertex const& v2, TVertex const& v3, TVertex const& v4)
-        {
-            static const uint16_t quadIndices[] = { 0, 1, 2, 0, 2, 3 };
-
-            TVertex* mappedVertices;
-
-            PrimitiveBatchBase::Draw(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST, true, quadIndices, 6, 4, reinterpret_cast<void**>(&mappedVertices));
-
-            mappedVertices[0] = v1;
-            mappedVertices[1] = v2;
-            mappedVertices[2] = v3;
-            mappedVertices[3] = v4;
-        }
-    };
 }

--- a/Inc/SpriteBatch.h
+++ b/Inc/SpriteBatch.h
@@ -26,76 +26,77 @@
 
 namespace DirectX
 {
-    enum SpriteSortMode
+    inline namespace DX11
     {
-        SpriteSortMode_Deferred,
-        SpriteSortMode_Immediate,
-        SpriteSortMode_Texture,
-        SpriteSortMode_BackToFront,
-        SpriteSortMode_FrontToBack,
-    };
+        enum SpriteSortMode
+        {
+            SpriteSortMode_Deferred,
+            SpriteSortMode_Immediate,
+            SpriteSortMode_Texture,
+            SpriteSortMode_BackToFront,
+            SpriteSortMode_FrontToBack,
+        };
 
+        enum SpriteEffects : uint32_t
+        {
+            SpriteEffects_None = 0,
+            SpriteEffects_FlipHorizontally = 1,
+            SpriteEffects_FlipVertically = 2,
+            SpriteEffects_FlipBoth = SpriteEffects_FlipHorizontally | SpriteEffects_FlipVertically,
+        };
 
-    enum SpriteEffects : uint32_t
-    {
-        SpriteEffects_None = 0,
-        SpriteEffects_FlipHorizontally = 1,
-        SpriteEffects_FlipVertically = 2,
-        SpriteEffects_FlipBoth = SpriteEffects_FlipHorizontally | SpriteEffects_FlipVertically,
-    };
+        class SpriteBatch
+        {
+        public:
+            explicit SpriteBatch(_In_ ID3D11DeviceContext* deviceContext);
 
+            SpriteBatch(SpriteBatch&&) noexcept;
+            SpriteBatch& operator= (SpriteBatch&&) noexcept;
 
-    class SpriteBatch
-    {
-    public:
-        explicit SpriteBatch(_In_ ID3D11DeviceContext* deviceContext);
+            SpriteBatch(SpriteBatch const&) = delete;
+            SpriteBatch& operator= (SpriteBatch const&) = delete;
 
-        SpriteBatch(SpriteBatch&&) noexcept;
-        SpriteBatch& operator= (SpriteBatch&&) noexcept;
+            virtual ~SpriteBatch();
 
-        SpriteBatch(SpriteBatch const&) = delete;
-        SpriteBatch& operator= (SpriteBatch const&) = delete;
+            // Begin/End a batch of sprite drawing operations.
+            void XM_CALLCONV Begin(SpriteSortMode sortMode = SpriteSortMode_Deferred,
+                _In_opt_ ID3D11BlendState* blendState = nullptr,
+                _In_opt_ ID3D11SamplerState* samplerState = nullptr,
+                _In_opt_ ID3D11DepthStencilState* depthStencilState = nullptr,
+                _In_opt_ ID3D11RasterizerState* rasterizerState = nullptr,
+                _In_opt_ std::function<void __cdecl()> setCustomShaders = nullptr,
+                FXMMATRIX transformMatrix = MatrixIdentity);
+            void __cdecl End();
 
-        virtual ~SpriteBatch();
+            // Draw overloads specifying position, origin and scale as XMFLOAT2.
+            void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, XMFLOAT2 const& position, FXMVECTOR color = Colors::White);
+            void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, XMFLOAT2 const& position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
+            void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, XMFLOAT2 const& position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
 
-        // Begin/End a batch of sprite drawing operations.
-        void XM_CALLCONV Begin(SpriteSortMode sortMode = SpriteSortMode_Deferred,
-            _In_opt_ ID3D11BlendState* blendState = nullptr,
-            _In_opt_ ID3D11SamplerState* samplerState = nullptr,
-            _In_opt_ ID3D11DepthStencilState* depthStencilState = nullptr,
-            _In_opt_ ID3D11RasterizerState* rasterizerState = nullptr,
-            _In_opt_ std::function<void __cdecl()> setCustomShaders = nullptr,
-            FXMMATRIX transformMatrix = MatrixIdentity);
-        void __cdecl End();
+            // Draw overloads specifying position, origin and scale via the first two components of an XMVECTOR.
+            void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, FXMVECTOR position, FXMVECTOR color = Colors::White);
+            void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, FXMVECTOR position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
+            void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, FXMVECTOR position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
 
-        // Draw overloads specifying position, origin and scale as XMFLOAT2.
-        void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, XMFLOAT2 const& position, FXMVECTOR color = Colors::White);
-        void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, XMFLOAT2 const& position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
-        void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, XMFLOAT2 const& position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
+            // Draw overloads specifying position as a RECT.
+            void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, RECT const& destinationRectangle, FXMVECTOR color = Colors::White);
+            void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, RECT const& destinationRectangle, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
 
-        // Draw overloads specifying position, origin and scale via the first two components of an XMVECTOR.
-        void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, FXMVECTOR position, FXMVECTOR color = Colors::White);
-        void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, FXMVECTOR position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
-        void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, FXMVECTOR position, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
+            // Rotation mode to be applied to the sprite transformation
+            void __cdecl SetRotation(DXGI_MODE_ROTATION mode);
+            DXGI_MODE_ROTATION __cdecl GetRotation() const noexcept;
 
-        // Draw overloads specifying position as a RECT.
-        void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, RECT const& destinationRectangle, FXMVECTOR color = Colors::White);
-        void XM_CALLCONV Draw(_In_ ID3D11ShaderResourceView* texture, RECT const& destinationRectangle, _In_opt_ RECT const* sourceRectangle, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0);
+            // Set viewport for sprite transformation
+            void __cdecl SetViewport(const D3D11_VIEWPORT& viewPort);
 
-        // Rotation mode to be applied to the sprite transformation
-        void __cdecl SetRotation(DXGI_MODE_ROTATION mode);
-        DXGI_MODE_ROTATION __cdecl GetRotation() const noexcept;
+        private:
+            // Private implementation.
+            struct Impl;
 
-        // Set viewport for sprite transformation
-        void __cdecl SetViewport(const D3D11_VIEWPORT& viewPort);
+            std::unique_ptr<Impl> pImpl;
 
-    private:
-        // Private implementation.
-        struct Impl;
-
-        std::unique_ptr<Impl> pImpl;
-
-        static const XMMATRIX MatrixIdentity;
-        static const XMFLOAT2 Float2Zero;
-    };
+            static const XMMATRIX MatrixIdentity;
+            static const XMFLOAT2 Float2Zero;
+        };
+    }
 }

--- a/Inc/SpriteFont.h
+++ b/Inc/SpriteFont.h
@@ -18,76 +18,79 @@
 
 namespace DirectX
 {
-    class SpriteFont
+    inline namespace DX11
     {
-    public:
-        struct Glyph;
-
-        SpriteFont(_In_ ID3D11Device* device, _In_z_ wchar_t const* fileName, bool forceSRGB = false);
-        SpriteFont(_In_ ID3D11Device* device, _In_reads_bytes_(dataSize) uint8_t const* dataBlob, _In_ size_t dataSize, bool forceSRGB = false);
-        SpriteFont(_In_ ID3D11ShaderResourceView* texture, _In_reads_(glyphCount) Glyph const* glyphs, _In_ size_t glyphCount, _In_ float lineSpacing);
-
-        SpriteFont(SpriteFont&&) noexcept;
-        SpriteFont& operator= (SpriteFont&&) noexcept;
-
-        SpriteFont(SpriteFont const&) = delete;
-        SpriteFont& operator= (SpriteFont const&) = delete;
-
-        virtual ~SpriteFont();
-
-        // Wide-character / UTF-16LE
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, FXMVECTOR position, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-
-        XMVECTOR XM_CALLCONV MeasureString(_In_z_ wchar_t const* text, bool ignoreWhitespace = true) const;
-
-        RECT __cdecl MeasureDrawBounds(_In_z_ wchar_t const* text, XMFLOAT2 const& position, bool ignoreWhitespace = true) const;
-        RECT XM_CALLCONV MeasureDrawBounds(_In_z_ wchar_t const* text, FXMVECTOR position, bool ignoreWhitespace = true) const;
-
-        // UTF-8
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, XMFLOAT2 const& position, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, FXMVECTOR position, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-        void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
-
-        XMVECTOR XM_CALLCONV MeasureString(_In_z_ char const* text, bool ignoreWhitespace = true) const;
-
-        RECT __cdecl MeasureDrawBounds(_In_z_ char const* text, XMFLOAT2 const& position, bool ignoreWhitespace = true) const;
-        RECT XM_CALLCONV MeasureDrawBounds(_In_z_ char const* text, FXMVECTOR position, bool ignoreWhitespace = true) const;
-
-        // Spacing properties
-        float __cdecl GetLineSpacing() const noexcept;
-        void __cdecl SetLineSpacing(float spacing);
-
-        // Font properties
-        wchar_t __cdecl GetDefaultCharacter() const noexcept;
-        void __cdecl SetDefaultCharacter(wchar_t character);
-
-        bool __cdecl ContainsCharacter(wchar_t character) const;
-
-        // Custom layout/rendering
-        Glyph const* __cdecl FindGlyph(wchar_t character) const;
-        void __cdecl GetSpriteSheet(ID3D11ShaderResourceView** texture) const;
-
-        // Describes a single character glyph.
-        struct Glyph
+        class SpriteFont
         {
-            uint32_t Character;
-            RECT Subrect;
-            float XOffset;
-            float YOffset;
-            float XAdvance;
+        public:
+            struct Glyph;
+
+            SpriteFont(_In_ ID3D11Device* device, _In_z_ wchar_t const* fileName, bool forceSRGB = false);
+            SpriteFont(_In_ ID3D11Device* device, _In_reads_bytes_(dataSize) uint8_t const* dataBlob, _In_ size_t dataSize, bool forceSRGB = false);
+            SpriteFont(_In_ ID3D11ShaderResourceView* texture, _In_reads_(glyphCount) Glyph const* glyphs, _In_ size_t glyphCount, _In_ float lineSpacing);
+
+            SpriteFont(SpriteFont&&) noexcept;
+            SpriteFont& operator= (SpriteFont&&) noexcept;
+
+            SpriteFont(SpriteFont const&) = delete;
+            SpriteFont& operator= (SpriteFont const&) = delete;
+
+            virtual ~SpriteFont();
+
+            // Wide-character / UTF-16LE
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, FXMVECTOR position, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ wchar_t const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+
+            XMVECTOR XM_CALLCONV MeasureString(_In_z_ wchar_t const* text, bool ignoreWhitespace = true) const;
+
+            RECT __cdecl MeasureDrawBounds(_In_z_ wchar_t const* text, XMFLOAT2 const& position, bool ignoreWhitespace = true) const;
+            RECT XM_CALLCONV MeasureDrawBounds(_In_z_ wchar_t const* text, FXMVECTOR position, bool ignoreWhitespace = true) const;
+
+            // UTF-8
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, XMFLOAT2 const& position, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, FXMVECTOR position, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ char const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+
+            XMVECTOR XM_CALLCONV MeasureString(_In_z_ char const* text, bool ignoreWhitespace = true) const;
+
+            RECT __cdecl MeasureDrawBounds(_In_z_ char const* text, XMFLOAT2 const& position, bool ignoreWhitespace = true) const;
+            RECT XM_CALLCONV MeasureDrawBounds(_In_z_ char const* text, FXMVECTOR position, bool ignoreWhitespace = true) const;
+
+            // Spacing properties
+            float __cdecl GetLineSpacing() const noexcept;
+            void __cdecl SetLineSpacing(float spacing);
+
+            // Font properties
+            wchar_t __cdecl GetDefaultCharacter() const noexcept;
+            void __cdecl SetDefaultCharacter(wchar_t character);
+
+            bool __cdecl ContainsCharacter(wchar_t character) const;
+
+            // Custom layout/rendering
+            Glyph const* __cdecl FindGlyph(wchar_t character) const;
+            void __cdecl GetSpriteSheet(ID3D11ShaderResourceView** texture) const;
+
+            // Describes a single character glyph.
+            struct Glyph
+            {
+                uint32_t Character;
+                RECT Subrect;
+                float XOffset;
+                float YOffset;
+                float XAdvance;
+            };
+
+
+        private:
+            // Private implementation.
+            class Impl;
+
+            std::unique_ptr<Impl> pImpl;
+
+            static const XMFLOAT2 Float2Zero;
         };
-
-
-    private:
-        // Private implementation.
-        class Impl;
-
-        std::unique_ptr<Impl> pImpl;
-
-        static const XMFLOAT2 Float2Zero;
-    };
+    }
 }

--- a/Inc/VertexTypes.h
+++ b/Inc/VertexTypes.h
@@ -22,480 +22,483 @@
 
 namespace DirectX
 {
+    inline namespace DX11
+    {
     // Vertex struct holding position information.
-    struct VertexPosition
-    {
-        VertexPosition() = default;
-
-        VertexPosition(const VertexPosition&) = default;
-        VertexPosition& operator=(const VertexPosition&) = default;
-
-        VertexPosition(VertexPosition&&) = default;
-        VertexPosition& operator=(VertexPosition&&) = default;
-
-        VertexPosition(XMFLOAT3 const& iposition) noexcept
-            : position(iposition)
+        struct VertexPosition
         {
-        }
+            VertexPosition() = default;
 
-        VertexPosition(FXMVECTOR iposition) noexcept
+            VertexPosition(const VertexPosition&) = default;
+            VertexPosition& operator=(const VertexPosition&) = default;
+
+            VertexPosition(VertexPosition&&) = default;
+            VertexPosition& operator=(VertexPosition&&) = default;
+
+            VertexPosition(XMFLOAT3 const& iposition) noexcept
+                : position(iposition)
+            {
+            }
+
+            VertexPosition(FXMVECTOR iposition) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+            }
+
+            XMFLOAT3 position;
+
+            static constexpr unsigned int InputElementCount = 1;
+            static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
+
+
+        // Vertex struct holding position and color information.
+        struct VertexPositionColor
         {
-            XMStoreFloat3(&this->position, iposition);
-        }
+            VertexPositionColor() = default;
 
-        XMFLOAT3 position;
+            VertexPositionColor(const VertexPositionColor&) = default;
+            VertexPositionColor& operator=(const VertexPositionColor&) = default;
 
-        static constexpr unsigned int InputElementCount = 1;
-        static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+            VertexPositionColor(VertexPositionColor&&) = default;
+            VertexPositionColor& operator=(VertexPositionColor&&) = default;
+
+            VertexPositionColor(XMFLOAT3 const& iposition, XMFLOAT4 const& icolor) noexcept
+                : position(iposition),
+                color(icolor)
+            {
+            }
+
+            VertexPositionColor(FXMVECTOR iposition, FXMVECTOR icolor) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat4(&this->color, icolor);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT4 color;
+
+            static constexpr unsigned int InputElementCount = 2;
+            static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
 
 
-    // Vertex struct holding position and color information.
-    struct VertexPositionColor
-    {
-        VertexPositionColor() = default;
-
-        VertexPositionColor(const VertexPositionColor&) = default;
-        VertexPositionColor& operator=(const VertexPositionColor&) = default;
-
-        VertexPositionColor(VertexPositionColor&&) = default;
-        VertexPositionColor& operator=(VertexPositionColor&&) = default;
-
-        VertexPositionColor(XMFLOAT3 const& iposition, XMFLOAT4 const& icolor) noexcept
-            : position(iposition),
-            color(icolor)
+        // Vertex struct holding position and texture mapping information.
+        struct VertexPositionTexture
         {
-        }
+            VertexPositionTexture() = default;
 
-        VertexPositionColor(FXMVECTOR iposition, FXMVECTOR icolor) noexcept
+            VertexPositionTexture(const VertexPositionTexture&) = default;
+            VertexPositionTexture& operator=(const VertexPositionTexture&) = default;
+
+            VertexPositionTexture(VertexPositionTexture&&) = default;
+            VertexPositionTexture& operator=(VertexPositionTexture&&) = default;
+
+            VertexPositionTexture(XMFLOAT3 const& iposition, XMFLOAT2 const& itextureCoordinate) noexcept
+                : position(iposition),
+                textureCoordinate(itextureCoordinate)
+            {
+            }
+
+            VertexPositionTexture(FXMVECTOR iposition, FXMVECTOR itextureCoordinate) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT2 textureCoordinate;
+
+            static constexpr unsigned int InputElementCount = 2;
+            static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
+
+
+        // Vertex struct holding position and dual texture mapping information.
+        struct VertexPositionDualTexture
         {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat4(&this->color, icolor);
-        }
+            VertexPositionDualTexture() = default;
 
-        XMFLOAT3 position;
-        XMFLOAT4 color;
+            VertexPositionDualTexture(const VertexPositionDualTexture&) = default;
+            VertexPositionDualTexture& operator=(const VertexPositionDualTexture&) = default;
 
-        static constexpr unsigned int InputElementCount = 2;
-        static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+            VertexPositionDualTexture(VertexPositionDualTexture&&) = default;
+            VertexPositionDualTexture& operator=(VertexPositionDualTexture&&) = default;
+
+            VertexPositionDualTexture(
+                XMFLOAT3 const& iposition,
+                XMFLOAT2 const& itextureCoordinate0,
+                XMFLOAT2 const& itextureCoordinate1) noexcept
+                : position(iposition),
+                textureCoordinate0(itextureCoordinate0),
+                textureCoordinate1(itextureCoordinate1)
+            {
+            }
+
+            VertexPositionDualTexture(
+                FXMVECTOR iposition,
+                FXMVECTOR itextureCoordinate0,
+                FXMVECTOR itextureCoordinate1) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat2(&this->textureCoordinate0, itextureCoordinate0);
+                XMStoreFloat2(&this->textureCoordinate1, itextureCoordinate1);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT2 textureCoordinate0;
+            XMFLOAT2 textureCoordinate1;
+
+            static constexpr unsigned int InputElementCount = 3;
+            static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
 
 
-    // Vertex struct holding position and texture mapping information.
-    struct VertexPositionTexture
-    {
-        VertexPositionTexture() = default;
-
-        VertexPositionTexture(const VertexPositionTexture&) = default;
-        VertexPositionTexture& operator=(const VertexPositionTexture&) = default;
-
-        VertexPositionTexture(VertexPositionTexture&&) = default;
-        VertexPositionTexture& operator=(VertexPositionTexture&&) = default;
-
-        VertexPositionTexture(XMFLOAT3 const& iposition, XMFLOAT2 const& itextureCoordinate) noexcept
-            : position(iposition),
-            textureCoordinate(itextureCoordinate)
+        // Vertex struct holding position and normal vector.
+        struct VertexPositionNormal
         {
-        }
+            VertexPositionNormal() = default;
 
-        VertexPositionTexture(FXMVECTOR iposition, FXMVECTOR itextureCoordinate) noexcept
+            VertexPositionNormal(const VertexPositionNormal&) = default;
+            VertexPositionNormal& operator=(const VertexPositionNormal&) = default;
+
+            VertexPositionNormal(VertexPositionNormal&&) = default;
+            VertexPositionNormal& operator=(VertexPositionNormal&&) = default;
+
+            VertexPositionNormal(XMFLOAT3 const& iposition, XMFLOAT3 const& inormal) noexcept
+                : position(iposition),
+                normal(inormal)
+            {
+            }
+
+            VertexPositionNormal(FXMVECTOR iposition, FXMVECTOR inormal) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat3(&this->normal, inormal);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT3 normal;
+
+            static constexpr unsigned int InputElementCount = 2;
+            static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
+
+
+        // Vertex struct holding position, color, and texture mapping information.
+        struct VertexPositionColorTexture
         {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
-        }
+            VertexPositionColorTexture() = default;
 
-        XMFLOAT3 position;
-        XMFLOAT2 textureCoordinate;
+            VertexPositionColorTexture(const VertexPositionColorTexture&) = default;
+            VertexPositionColorTexture& operator=(const VertexPositionColorTexture&) = default;
 
-        static constexpr unsigned int InputElementCount = 2;
-        static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+            VertexPositionColorTexture(VertexPositionColorTexture&&) = default;
+            VertexPositionColorTexture& operator=(VertexPositionColorTexture&&) = default;
+
+            VertexPositionColorTexture(XMFLOAT3 const& iposition, XMFLOAT4 const& icolor, XMFLOAT2 const& itextureCoordinate) noexcept
+                : position(iposition),
+                color(icolor),
+                textureCoordinate(itextureCoordinate)
+            {
+            }
+
+            VertexPositionColorTexture(FXMVECTOR iposition, FXMVECTOR icolor, FXMVECTOR itextureCoordinate) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat4(&this->color, icolor);
+                XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT4 color;
+            XMFLOAT2 textureCoordinate;
+
+            static constexpr unsigned int InputElementCount = 3;
+            static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
 
 
-    // Vertex struct holding position and dual texture mapping information.
-    struct VertexPositionDualTexture
-    {
-        VertexPositionDualTexture() = default;
-
-        VertexPositionDualTexture(const VertexPositionDualTexture&) = default;
-        VertexPositionDualTexture& operator=(const VertexPositionDualTexture&) = default;
-
-        VertexPositionDualTexture(VertexPositionDualTexture&&) = default;
-        VertexPositionDualTexture& operator=(VertexPositionDualTexture&&) = default;
-
-        VertexPositionDualTexture(
-            XMFLOAT3 const& iposition,
-            XMFLOAT2 const& itextureCoordinate0,
-            XMFLOAT2 const& itextureCoordinate1) noexcept
-            : position(iposition),
-            textureCoordinate0(itextureCoordinate0),
-            textureCoordinate1(itextureCoordinate1)
+        // Vertex struct holding position, normal vector, and color information.
+        struct VertexPositionNormalColor
         {
-        }
+            VertexPositionNormalColor() = default;
 
-        VertexPositionDualTexture(
-            FXMVECTOR iposition,
-            FXMVECTOR itextureCoordinate0,
-            FXMVECTOR itextureCoordinate1) noexcept
+            VertexPositionNormalColor(const VertexPositionNormalColor&) = default;
+            VertexPositionNormalColor& operator=(const VertexPositionNormalColor&) = default;
+
+            VertexPositionNormalColor(VertexPositionNormalColor&&) = default;
+            VertexPositionNormalColor& operator=(VertexPositionNormalColor&&) = default;
+
+            VertexPositionNormalColor(XMFLOAT3 const& iposition, XMFLOAT3 const& inormal, XMFLOAT4 const& icolor) noexcept
+                : position(iposition),
+                normal(inormal),
+                color(icolor)
+            {
+            }
+
+            VertexPositionNormalColor(FXMVECTOR iposition, FXMVECTOR inormal, FXMVECTOR icolor) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat3(&this->normal, inormal);
+                XMStoreFloat4(&this->color, icolor);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT3 normal;
+            XMFLOAT4 color;
+
+            static constexpr unsigned int InputElementCount = 3;
+            static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
+
+
+        // Vertex struct holding position, normal vector, and texture mapping information.
+        struct VertexPositionNormalTexture
         {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat2(&this->textureCoordinate0, itextureCoordinate0);
-            XMStoreFloat2(&this->textureCoordinate1, itextureCoordinate1);
-        }
+            VertexPositionNormalTexture() = default;
 
-        XMFLOAT3 position;
-        XMFLOAT2 textureCoordinate0;
-        XMFLOAT2 textureCoordinate1;
+            VertexPositionNormalTexture(const VertexPositionNormalTexture&) = default;
+            VertexPositionNormalTexture& operator=(const VertexPositionNormalTexture&) = default;
 
-        static constexpr unsigned int InputElementCount = 3;
-        static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+            VertexPositionNormalTexture(VertexPositionNormalTexture&&) = default;
+            VertexPositionNormalTexture& operator=(VertexPositionNormalTexture&&) = default;
+
+            VertexPositionNormalTexture(XMFLOAT3 const& iposition, XMFLOAT3 const& inormal, XMFLOAT2 const& itextureCoordinate) noexcept
+                : position(iposition),
+                normal(inormal),
+                textureCoordinate(itextureCoordinate)
+            {
+            }
+
+            VertexPositionNormalTexture(FXMVECTOR iposition, FXMVECTOR inormal, FXMVECTOR itextureCoordinate) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat3(&this->normal, inormal);
+                XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT3 normal;
+            XMFLOAT2 textureCoordinate;
+
+            static constexpr unsigned int InputElementCount = 3;
+            static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
 
 
-    // Vertex struct holding position and normal vector.
-    struct VertexPositionNormal
-    {
-        VertexPositionNormal() = default;
-
-        VertexPositionNormal(const VertexPositionNormal&) = default;
-        VertexPositionNormal& operator=(const VertexPositionNormal&) = default;
-
-        VertexPositionNormal(VertexPositionNormal&&) = default;
-        VertexPositionNormal& operator=(VertexPositionNormal&&) = default;
-
-        VertexPositionNormal(XMFLOAT3 const& iposition, XMFLOAT3 const& inormal) noexcept
-            : position(iposition),
-            normal(inormal)
+        // Vertex struct holding position, normal vector, color, and texture mapping information.
+        struct VertexPositionNormalColorTexture
         {
-        }
+            VertexPositionNormalColorTexture() = default;
 
-        VertexPositionNormal(FXMVECTOR iposition, FXMVECTOR inormal) noexcept
+            VertexPositionNormalColorTexture(const VertexPositionNormalColorTexture&) = default;
+            VertexPositionNormalColorTexture& operator=(const VertexPositionNormalColorTexture&) = default;
+
+            VertexPositionNormalColorTexture(VertexPositionNormalColorTexture&&) = default;
+            VertexPositionNormalColorTexture& operator=(VertexPositionNormalColorTexture&&) = default;
+
+            VertexPositionNormalColorTexture(
+                XMFLOAT3 const& iposition,
+                XMFLOAT3 const& inormal,
+                XMFLOAT4 const& icolor,
+                XMFLOAT2 const& itextureCoordinate) noexcept
+                : position(iposition),
+                normal(inormal),
+                color(icolor),
+                textureCoordinate(itextureCoordinate)
+            {
+            }
+
+            VertexPositionNormalColorTexture(FXMVECTOR iposition, FXMVECTOR inormal, FXMVECTOR icolor, CXMVECTOR itextureCoordinate) noexcept
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat3(&this->normal, inormal);
+                XMStoreFloat4(&this->color, icolor);
+                XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
+            }
+
+            XMFLOAT3 position;
+            XMFLOAT3 normal;
+            XMFLOAT4 color;
+            XMFLOAT2 textureCoordinate;
+
+            static constexpr unsigned int InputElementCount = 4;
+            static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
+
+
+        // Vertex struct for Visual Studio Shader Designer (DGSL) holding position, normal,
+        // tangent, color (RGBA), and texture mapping information
+        struct VertexPositionNormalTangentColorTexture
         {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat3(&this->normal, inormal);
-        }
+            VertexPositionNormalTangentColorTexture() = default;
 
-        XMFLOAT3 position;
-        XMFLOAT3 normal;
+            VertexPositionNormalTangentColorTexture(const VertexPositionNormalTangentColorTexture&) = default;
+            VertexPositionNormalTangentColorTexture& operator=(const VertexPositionNormalTangentColorTexture&) = default;
 
-        static constexpr unsigned int InputElementCount = 2;
-        static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+            VertexPositionNormalTangentColorTexture(VertexPositionNormalTangentColorTexture&&) = default;
+            VertexPositionNormalTangentColorTexture& operator=(VertexPositionNormalTangentColorTexture&&) = default;
+
+            XMFLOAT3 position;
+            XMFLOAT3 normal;
+            XMFLOAT4 tangent;
+            uint32_t color;
+            XMFLOAT2 textureCoordinate;
+
+            VertexPositionNormalTangentColorTexture(
+                XMFLOAT3 const& iposition,
+                XMFLOAT3 const& inormal,
+                XMFLOAT4 const& itangent,
+                uint32_t irgba,
+                XMFLOAT2 const& itextureCoordinate) noexcept
+                : position(iposition),
+                normal(inormal),
+                tangent(itangent),
+                color(irgba),
+                textureCoordinate(itextureCoordinate)
+            {
+            }
+
+            VertexPositionNormalTangentColorTexture(
+                FXMVECTOR iposition,
+                FXMVECTOR inormal,
+                FXMVECTOR itangent,
+                uint32_t irgba,
+                CXMVECTOR itextureCoordinate) noexcept
+                : color(irgba)
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat3(&this->normal, inormal);
+                XMStoreFloat4(&this->tangent, itangent);
+                XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
+            }
+
+            VertexPositionNormalTangentColorTexture(
+                XMFLOAT3 const& iposition,
+                XMFLOAT3 const& inormal,
+                XMFLOAT4 const& itangent,
+                XMFLOAT4 const& icolor,
+                XMFLOAT2 const& itextureCoordinate) noexcept
+                : position(iposition),
+                normal(inormal),
+                tangent(itangent),
+                color{},
+                textureCoordinate(itextureCoordinate)
+            {
+                SetColor(icolor);
+            }
+
+            VertexPositionNormalTangentColorTexture(
+                FXMVECTOR iposition,
+                FXMVECTOR inormal,
+                FXMVECTOR itangent,
+                CXMVECTOR icolor,
+                CXMVECTOR itextureCoordinate) noexcept
+                : color{}
+            {
+                XMStoreFloat3(&this->position, iposition);
+                XMStoreFloat3(&this->normal, inormal);
+                XMStoreFloat4(&this->tangent, itangent);
+                XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
+
+                SetColor(icolor);
+            }
+
+            void __cdecl SetColor(XMFLOAT4 const& icolor) noexcept { SetColor(XMLoadFloat4(&icolor)); }
+            void XM_CALLCONV SetColor(FXMVECTOR icolor) noexcept;
+
+            static constexpr unsigned int InputElementCount = 5;
+            static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
 
 
-    // Vertex struct holding position, color, and texture mapping information.
-    struct VertexPositionColorTexture
-    {
-        VertexPositionColorTexture() = default;
-
-        VertexPositionColorTexture(const VertexPositionColorTexture&) = default;
-        VertexPositionColorTexture& operator=(const VertexPositionColorTexture&) = default;
-
-        VertexPositionColorTexture(VertexPositionColorTexture&&) = default;
-        VertexPositionColorTexture& operator=(VertexPositionColorTexture&&) = default;
-
-        VertexPositionColorTexture(XMFLOAT3 const& iposition, XMFLOAT4 const& icolor, XMFLOAT2 const& itextureCoordinate) noexcept
-            : position(iposition),
-            color(icolor),
-            textureCoordinate(itextureCoordinate)
+        // Vertex struct for Visual Studio Shader Designer (DGSL) holding position, normal,
+        // tangent, color (RGBA), texture mapping information, and skinning weights
+        struct VertexPositionNormalTangentColorTextureSkinning : public VertexPositionNormalTangentColorTexture
         {
-        }
+            VertexPositionNormalTangentColorTextureSkinning() = default;
 
-        VertexPositionColorTexture(FXMVECTOR iposition, FXMVECTOR icolor, FXMVECTOR itextureCoordinate) noexcept
-        {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat4(&this->color, icolor);
-            XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
-        }
+            VertexPositionNormalTangentColorTextureSkinning(const VertexPositionNormalTangentColorTextureSkinning&) = default;
+            VertexPositionNormalTangentColorTextureSkinning& operator=(const VertexPositionNormalTangentColorTextureSkinning&) = default;
 
-        XMFLOAT3 position;
-        XMFLOAT4 color;
-        XMFLOAT2 textureCoordinate;
+            VertexPositionNormalTangentColorTextureSkinning(VertexPositionNormalTangentColorTextureSkinning&&) = default;
+            VertexPositionNormalTangentColorTextureSkinning& operator=(VertexPositionNormalTangentColorTextureSkinning&&) = default;
 
-        static constexpr unsigned int InputElementCount = 3;
-        static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+            uint32_t indices;
+            uint32_t weights;
 
+            VertexPositionNormalTangentColorTextureSkinning(
+                XMFLOAT3 const& iposition,
+                XMFLOAT3 const& inormal,
+                XMFLOAT4 const& itangent,
+                uint32_t irgba,
+                XMFLOAT2 const& itextureCoordinate,
+                XMUINT4 const& iindices,
+                XMFLOAT4 const& iweights) noexcept
+                : VertexPositionNormalTangentColorTexture(iposition, inormal, itangent, irgba, itextureCoordinate),
+                indices{},
+                weights{}
+            {
+                SetBlendIndices(iindices);
+                SetBlendWeights(iweights);
+            }
 
-    // Vertex struct holding position, normal vector, and color information.
-    struct VertexPositionNormalColor
-    {
-        VertexPositionNormalColor() = default;
+            VertexPositionNormalTangentColorTextureSkinning(
+                FXMVECTOR iposition,
+                FXMVECTOR inormal,
+                FXMVECTOR itangent,
+                uint32_t irgba,
+                CXMVECTOR itextureCoordinate,
+                XMUINT4 const& iindices,
+                CXMVECTOR iweights) noexcept
+                : VertexPositionNormalTangentColorTexture(iposition, inormal, itangent, irgba, itextureCoordinate),
+                indices{},
+                weights{}
+            {
+                SetBlendIndices(iindices);
+                SetBlendWeights(iweights);
+            }
 
-        VertexPositionNormalColor(const VertexPositionNormalColor&) = default;
-        VertexPositionNormalColor& operator=(const VertexPositionNormalColor&) = default;
+            VertexPositionNormalTangentColorTextureSkinning(
+                XMFLOAT3 const& iposition,
+                XMFLOAT3 const& inormal,
+                XMFLOAT4 const& itangent,
+                XMFLOAT4 const& icolor,
+                XMFLOAT2 const& itextureCoordinate,
+                XMUINT4 const& iindices,
+                XMFLOAT4 const& iweights) noexcept
+                : VertexPositionNormalTangentColorTexture(iposition, inormal, itangent, icolor, itextureCoordinate),
+                indices{},
+                weights{}
+            {
+                SetBlendIndices(iindices);
+                SetBlendWeights(iweights);
+            }
 
-        VertexPositionNormalColor(VertexPositionNormalColor&&) = default;
-        VertexPositionNormalColor& operator=(VertexPositionNormalColor&&) = default;
+            VertexPositionNormalTangentColorTextureSkinning(
+                FXMVECTOR iposition,
+                FXMVECTOR inormal,
+                FXMVECTOR itangent,
+                CXMVECTOR icolor,
+                CXMVECTOR itextureCoordinate,
+                XMUINT4 const& iindices,
+                CXMVECTOR iweights) noexcept
+                : VertexPositionNormalTangentColorTexture(iposition, inormal, itangent, icolor, itextureCoordinate),
+                indices{},
+                weights{}
+            {
+                SetBlendIndices(iindices);
+                SetBlendWeights(iweights);
+            }
 
-        VertexPositionNormalColor(XMFLOAT3 const& iposition, XMFLOAT3 const& inormal, XMFLOAT4 const& icolor) noexcept
-            : position(iposition),
-            normal(inormal),
-            color(icolor)
-        {
-        }
+            void __cdecl SetBlendIndices(XMUINT4 const& iindices) noexcept;
 
-        VertexPositionNormalColor(FXMVECTOR iposition, FXMVECTOR inormal, FXMVECTOR icolor) noexcept
-        {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat3(&this->normal, inormal);
-            XMStoreFloat4(&this->color, icolor);
-        }
+            void __cdecl SetBlendWeights(XMFLOAT4 const& iweights) noexcept { SetBlendWeights(XMLoadFloat4(&iweights)); }
+            void XM_CALLCONV SetBlendWeights(FXMVECTOR iweights) noexcept;
 
-        XMFLOAT3 position;
-        XMFLOAT3 normal;
-        XMFLOAT4 color;
-
-        static constexpr unsigned int InputElementCount = 3;
-        static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
-
-
-    // Vertex struct holding position, normal vector, and texture mapping information.
-    struct VertexPositionNormalTexture
-    {
-        VertexPositionNormalTexture() = default;
-
-        VertexPositionNormalTexture(const VertexPositionNormalTexture&) = default;
-        VertexPositionNormalTexture& operator=(const VertexPositionNormalTexture&) = default;
-
-        VertexPositionNormalTexture(VertexPositionNormalTexture&&) = default;
-        VertexPositionNormalTexture& operator=(VertexPositionNormalTexture&&) = default;
-
-        VertexPositionNormalTexture(XMFLOAT3 const& iposition, XMFLOAT3 const& inormal, XMFLOAT2 const& itextureCoordinate) noexcept
-            : position(iposition),
-            normal(inormal),
-            textureCoordinate(itextureCoordinate)
-        {
-        }
-
-        VertexPositionNormalTexture(FXMVECTOR iposition, FXMVECTOR inormal, FXMVECTOR itextureCoordinate) noexcept
-        {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat3(&this->normal, inormal);
-            XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
-        }
-
-        XMFLOAT3 position;
-        XMFLOAT3 normal;
-        XMFLOAT2 textureCoordinate;
-
-        static constexpr unsigned int InputElementCount = 3;
-        static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
-
-
-    // Vertex struct holding position, normal vector, color, and texture mapping information.
-    struct VertexPositionNormalColorTexture
-    {
-        VertexPositionNormalColorTexture() = default;
-
-        VertexPositionNormalColorTexture(const VertexPositionNormalColorTexture&) = default;
-        VertexPositionNormalColorTexture& operator=(const VertexPositionNormalColorTexture&) = default;
-
-        VertexPositionNormalColorTexture(VertexPositionNormalColorTexture&&) = default;
-        VertexPositionNormalColorTexture& operator=(VertexPositionNormalColorTexture&&) = default;
-
-        VertexPositionNormalColorTexture(
-            XMFLOAT3 const& iposition,
-            XMFLOAT3 const& inormal,
-            XMFLOAT4 const& icolor,
-            XMFLOAT2 const& itextureCoordinate) noexcept
-            : position(iposition),
-            normal(inormal),
-            color(icolor),
-            textureCoordinate(itextureCoordinate)
-        {
-        }
-
-        VertexPositionNormalColorTexture(FXMVECTOR iposition, FXMVECTOR inormal, FXMVECTOR icolor, CXMVECTOR itextureCoordinate) noexcept
-        {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat3(&this->normal, inormal);
-            XMStoreFloat4(&this->color, icolor);
-            XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
-        }
-
-        XMFLOAT3 position;
-        XMFLOAT3 normal;
-        XMFLOAT4 color;
-        XMFLOAT2 textureCoordinate;
-
-        static constexpr unsigned int InputElementCount = 4;
-        static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
-
-
-    // Vertex struct for Visual Studio Shader Designer (DGSL) holding position, normal,
-    // tangent, color (RGBA), and texture mapping information
-    struct VertexPositionNormalTangentColorTexture
-    {
-        VertexPositionNormalTangentColorTexture() = default;
-
-        VertexPositionNormalTangentColorTexture(const VertexPositionNormalTangentColorTexture&) = default;
-        VertexPositionNormalTangentColorTexture& operator=(const VertexPositionNormalTangentColorTexture&) = default;
-
-        VertexPositionNormalTangentColorTexture(VertexPositionNormalTangentColorTexture&&) = default;
-        VertexPositionNormalTangentColorTexture& operator=(VertexPositionNormalTangentColorTexture&&) = default;
-
-        XMFLOAT3 position;
-        XMFLOAT3 normal;
-        XMFLOAT4 tangent;
-        uint32_t color;
-        XMFLOAT2 textureCoordinate;
-
-        VertexPositionNormalTangentColorTexture(
-            XMFLOAT3 const& iposition,
-            XMFLOAT3 const& inormal,
-            XMFLOAT4 const& itangent,
-            uint32_t irgba,
-            XMFLOAT2 const& itextureCoordinate) noexcept
-            : position(iposition),
-            normal(inormal),
-            tangent(itangent),
-            color(irgba),
-            textureCoordinate(itextureCoordinate)
-        {
-        }
-
-        VertexPositionNormalTangentColorTexture(
-            FXMVECTOR iposition,
-            FXMVECTOR inormal,
-            FXMVECTOR itangent,
-            uint32_t irgba,
-            CXMVECTOR itextureCoordinate) noexcept
-            : color(irgba)
-        {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat3(&this->normal, inormal);
-            XMStoreFloat4(&this->tangent, itangent);
-            XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
-        }
-
-        VertexPositionNormalTangentColorTexture(
-            XMFLOAT3 const& iposition,
-            XMFLOAT3 const& inormal,
-            XMFLOAT4 const& itangent,
-            XMFLOAT4 const& icolor,
-            XMFLOAT2 const& itextureCoordinate) noexcept
-            : position(iposition),
-            normal(inormal),
-            tangent(itangent),
-            color{},
-            textureCoordinate(itextureCoordinate)
-        {
-            SetColor(icolor);
-        }
-
-        VertexPositionNormalTangentColorTexture(
-            FXMVECTOR iposition,
-            FXMVECTOR inormal,
-            FXMVECTOR itangent,
-            CXMVECTOR icolor,
-            CXMVECTOR itextureCoordinate) noexcept
-            : color{}
-        {
-            XMStoreFloat3(&this->position, iposition);
-            XMStoreFloat3(&this->normal, inormal);
-            XMStoreFloat4(&this->tangent, itangent);
-            XMStoreFloat2(&this->textureCoordinate, itextureCoordinate);
-
-            SetColor(icolor);
-        }
-
-        void __cdecl SetColor(XMFLOAT4 const& icolor) noexcept { SetColor(XMLoadFloat4(&icolor)); }
-        void XM_CALLCONV SetColor(FXMVECTOR icolor) noexcept;
-
-        static constexpr unsigned int InputElementCount = 5;
-        static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
-
-
-    // Vertex struct for Visual Studio Shader Designer (DGSL) holding position, normal,
-    // tangent, color (RGBA), texture mapping information, and skinning weights
-    struct VertexPositionNormalTangentColorTextureSkinning : public VertexPositionNormalTangentColorTexture
-    {
-        VertexPositionNormalTangentColorTextureSkinning() = default;
-
-        VertexPositionNormalTangentColorTextureSkinning(const VertexPositionNormalTangentColorTextureSkinning&) = default;
-        VertexPositionNormalTangentColorTextureSkinning& operator=(const VertexPositionNormalTangentColorTextureSkinning&) = default;
-
-        VertexPositionNormalTangentColorTextureSkinning(VertexPositionNormalTangentColorTextureSkinning&&) = default;
-        VertexPositionNormalTangentColorTextureSkinning& operator=(VertexPositionNormalTangentColorTextureSkinning&&) = default;
-
-        uint32_t indices;
-        uint32_t weights;
-
-        VertexPositionNormalTangentColorTextureSkinning(
-            XMFLOAT3 const& iposition,
-            XMFLOAT3 const& inormal,
-            XMFLOAT4 const& itangent,
-            uint32_t irgba,
-            XMFLOAT2 const& itextureCoordinate,
-            XMUINT4 const& iindices,
-            XMFLOAT4 const& iweights) noexcept
-            : VertexPositionNormalTangentColorTexture(iposition, inormal, itangent, irgba, itextureCoordinate),
-            indices{},
-            weights{}
-        {
-            SetBlendIndices(iindices);
-            SetBlendWeights(iweights);
-        }
-
-        VertexPositionNormalTangentColorTextureSkinning(
-            FXMVECTOR iposition,
-            FXMVECTOR inormal,
-            FXMVECTOR itangent,
-            uint32_t irgba,
-            CXMVECTOR itextureCoordinate,
-            XMUINT4 const& iindices,
-            CXMVECTOR iweights) noexcept
-            : VertexPositionNormalTangentColorTexture(iposition, inormal, itangent, irgba, itextureCoordinate),
-            indices{},
-            weights{}
-        {
-            SetBlendIndices(iindices);
-            SetBlendWeights(iweights);
-        }
-
-        VertexPositionNormalTangentColorTextureSkinning(
-            XMFLOAT3 const& iposition,
-            XMFLOAT3 const& inormal,
-            XMFLOAT4 const& itangent,
-            XMFLOAT4 const& icolor,
-            XMFLOAT2 const& itextureCoordinate,
-            XMUINT4 const& iindices,
-            XMFLOAT4 const& iweights) noexcept
-            : VertexPositionNormalTangentColorTexture(iposition, inormal, itangent, icolor, itextureCoordinate),
-            indices{},
-            weights{}
-        {
-            SetBlendIndices(iindices);
-            SetBlendWeights(iweights);
-        }
-
-        VertexPositionNormalTangentColorTextureSkinning(
-            FXMVECTOR iposition,
-            FXMVECTOR inormal,
-            FXMVECTOR itangent,
-            CXMVECTOR icolor,
-            CXMVECTOR itextureCoordinate,
-            XMUINT4 const& iindices,
-            CXMVECTOR iweights) noexcept
-            : VertexPositionNormalTangentColorTexture(iposition, inormal, itangent, icolor, itextureCoordinate),
-            indices{},
-            weights{}
-        {
-            SetBlendIndices(iindices);
-            SetBlendWeights(iweights);
-        }
-
-        void __cdecl SetBlendIndices(XMUINT4 const& iindices) noexcept;
-
-        void __cdecl SetBlendWeights(XMFLOAT4 const& iweights) noexcept { SetBlendWeights(XMLoadFloat4(&iweights)); }
-        void XM_CALLCONV SetBlendWeights(FXMVECTOR iweights) noexcept;
-
-        static constexpr unsigned int InputElementCount = 7;
-        static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
-    };
+            static constexpr unsigned int InputElementCount = 7;
+            static const D3D11_INPUT_ELEMENT_DESC InputElements[InputElementCount];
+        };
+    }
 }

--- a/Inc/WICTextureLoader.h
+++ b/Inc/WICTextureLoader.h
@@ -37,16 +37,19 @@
 
 namespace DirectX
 {
-    enum WIC_LOADER_FLAGS : uint32_t
+    inline namespace DX11
     {
-        WIC_LOADER_DEFAULT = 0,
-        WIC_LOADER_FORCE_SRGB = 0x1,
-        WIC_LOADER_IGNORE_SRGB = 0x2,
-        WIC_LOADER_SRGB_DEFAULT = 0x4,
-        WIC_LOADER_FIT_POW2 = 0x20,
-        WIC_LOADER_MAKE_SQUARE = 0x40,
-        WIC_LOADER_FORCE_RGBA32 = 0x80,
-    };
+        enum WIC_LOADER_FLAGS : uint32_t
+        {
+            WIC_LOADER_DEFAULT = 0,
+            WIC_LOADER_FORCE_SRGB = 0x1,
+            WIC_LOADER_IGNORE_SRGB = 0x2,
+            WIC_LOADER_SRGB_DEFAULT = 0x4,
+            WIC_LOADER_FIT_POW2 = 0x20,
+            WIC_LOADER_MAKE_SQUARE = 0x40,
+            WIC_LOADER_FORCE_RGBA32 = 0x80,
+        };
+    }
 
     // Standard version
     HRESULT __cdecl CreateWICTextureFromMemory(
@@ -161,7 +164,10 @@ namespace DirectX
 #pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
 #endif
 
-    DEFINE_ENUM_FLAG_OPERATORS(WIC_LOADER_FLAGS);
+    inline namespace DX11
+    {
+        DEFINE_ENUM_FLAG_OPERATORS(WIC_LOADER_FLAGS);
+    }
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ For the latest version of DirectXTK, bug reports, etc. please visit the project 
 
 ## Release Notes
 
+* As of the September 2022 release, the library makes use of C++11 inline namespaces for differing types that have the same names in the DirectX 11 and DirectX 12 version of the *DirectX Tool Kit*. This provides a link-unique name such as ``DirectX::DX11::SpriteBatch`` that will appear in linker output messages. In most use cases, however, there is no need to add explicit ``DX11`` namespace resolution in client code.
+
 * Starting with the July 2022 release, the ``bool forceSRGB`` parameter for DDSTextureLoader ``Ex`` functions is now a ``DDS_LOADER_FLAGS`` typed enum bitmask flag parameter. This may have a *breaking change* impact to client code. Replace ``true`` with ``DDS_LOADER_FORCE_SRGB`` and ``false`` with ``DDS_LOADER_DEFAULT``.
 
 * As of the March 2022 release, legacy Xbox One XDK support requires the XDK April 2018 release or later.

--- a/Src/BufferHelpers.cpp
+++ b/Src/BufferHelpers.cpp
@@ -355,7 +355,7 @@ HRESULT DirectX::CreateTextureFromMemory(
 
 //--------------------------------------------------------------------------------------
 _Use_decl_annotations_
-void Internal::ConstantBufferBase::CreateBuffer(
+void Private::ConstantBufferBase::CreateBuffer(
     ID3D11Device* device,
     size_t bytes,
     ID3D11Buffer** pBuffer)

--- a/Src/PrimitiveBatch.cpp
+++ b/Src/PrimitiveBatch.cpp
@@ -14,7 +14,7 @@
 #include "PlatformHelpers.h"
 
 using namespace DirectX;
-using namespace DirectX::Internal;
+using namespace DirectX::DX11::Private;
 using Microsoft::WRL::ComPtr;
 
 

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -345,7 +345,7 @@ HRESULT DirectX::SaveDDSTextureToFile(
 //--------------------------------------------------------------------------------------
 namespace DirectX
 {
-    namespace DX11
+    inline namespace DX11
     {
         namespace Internal
         {

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -345,10 +345,13 @@ HRESULT DirectX::SaveDDSTextureToFile(
 //--------------------------------------------------------------------------------------
 namespace DirectX
 {
-    namespace Internal
+    namespace DX11
     {
-        extern bool IsWIC2() noexcept;
-        extern IWICImagingFactory* GetWIC() noexcept;
+        namespace Internal
+        {
+            extern bool IsWIC2() noexcept;
+            extern IWICImagingFactory* GetWIC() noexcept;
+        }
     }
 }
 
@@ -362,7 +365,7 @@ HRESULT DirectX::SaveWICTextureToFile(
     std::function<void(IPropertyBag2*)> setCustomProps,
     bool forceSRGB)
 {
-    using namespace Internal;
+    using namespace DX11::Internal;
 
     if (!fileName)
         return E_INVALIDARG;

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -184,20 +184,23 @@ namespace
 //--------------------------------------------------------------------------------------
 namespace DirectX
 {
-    namespace Internal
+    namespace DX11
     {
-        bool IsWIC2() noexcept;
-        IWICImagingFactory* GetWIC() noexcept;
-        // Also used by ScreenGrab
+        namespace Internal
+        {
+            bool IsWIC2() noexcept;
+            IWICImagingFactory* GetWIC() noexcept;
+            // Also used by ScreenGrab
+        }
     }
 }
 
-bool DirectX::Internal::IsWIC2() noexcept
+bool DirectX::DX11::Internal::IsWIC2() noexcept
 {
     return g_WIC2;
 }
 
-IWICImagingFactory* DirectX::Internal::GetWIC() noexcept
+IWICImagingFactory* DirectX::DX11::Internal::GetWIC() noexcept
 {
     static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
@@ -214,7 +217,7 @@ IWICImagingFactory* DirectX::Internal::GetWIC() noexcept
     return factory;
 }
 
-using namespace Internal;
+using namespace DirectX::DX11::Internal;
 
 namespace
 {

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -184,7 +184,7 @@ namespace
 //--------------------------------------------------------------------------------------
 namespace DirectX
 {
-    namespace DX11
+    inline namespace DX11
     {
         namespace Internal
         {


### PR DESCRIPTION
This adds use of C++11 inline namespaces to wrap types that have *DirectX Tool Kit for DX12* equivalents with the same name. This would allow for 'mixed' use of the *DirectX Tool Kit for DX11* and *DirectX Tool Kit for DX12* in the same exe without link-time conflicts.

It has no client-code impacts, although all client code would need rebuilt to link against a static library build with these changes.