### PR TITLE
Added explicit GAMEINPUT vs. WGI vs. XINPUT preprocessor overrides

### DIFF
--- a/Inc/GamePad.h
+++ b/Inc/GamePad.h
@@ -10,31 +10,42 @@
 
 #pragma once
 
+#if !defined(USING_XINPUT) && !defined(USING_GAMEINPUT) && !defined(USING_WINDOWS_GAMING_INPUT)
+
 #ifdef _GAMING_DESKTOP
 #include <grdk.h>
 #endif
 
 #if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)) || (defined(_GAMING_DESKTOP) && (_GRDK_EDITION >= 220600))
-#ifndef USING_GAMEINPUT
 #define USING_GAMEINPUT
-#endif
 #elif (_WIN32_WINNT >= 0x0A00 /*_WIN32_WINNT_WIN10*/) && !defined(_GAMING_DESKTOP) && !defined(__MINGW32__)
-#ifndef USING_WINDOWS_GAMING_INPUT
 #define USING_WINDOWS_GAMING_INPUT
+#elif !defined(_XBOX_ONE)
+#define USING_XINPUT
 #endif
-#endif
+
+#endif // !USING_XINPUT && !USING_GAMEINPUT && !USING_WINDOWS_GAMING_INPUT
 
 #ifdef USING_GAMEINPUT
 interface IGameInputDevice;
+#ifndef _XBOX_GAMING
+#pragma comment(lib,"gameinput.lib")
+#endif
+
 #elif defined(USING_WINDOWS_GAMING_INPUT)
 #pragma comment(lib,"runtimeobject.lib")
 #include <string>
-#elif !defined(_XBOX_ONE)
+
+#elif defined(_XBOX_ONE)
+// Legacy Xbox One XDK uses Windows::Xbox::Input
+
+#elif defined(USING_XINPUT)
 #if (_WIN32_WINNT >= 0x0602 /*_WIN32_WINNT_WIN8*/ )
 #pragma comment(lib,"xinput.lib")
 #else
 #pragma comment(lib,"xinput9_1_0.lib")
 #endif
+
 #endif
 
 #include <cstdint>

--- a/Inc/GamePad.h
+++ b/Inc/GamePad.h
@@ -28,7 +28,7 @@
 
 #ifdef USING_GAMEINPUT
 interface IGameInputDevice;
-#ifndef _XBOX_GAMING
+#ifndef _GAMING_XBOX
 #pragma comment(lib,"gameinput.lib")
 #endif
 

--- a/Inc/Keyboard.h
+++ b/Inc/Keyboard.h
@@ -24,7 +24,7 @@
 
 #endif // !USING_XINPUT && !USING_GAMEINPUT && !USING_WINDOWS_GAMING_INPUT
 
-#if defined(USING_GAMEINPUT) && !defined(_XBOX_GAMING)
+#if defined(USING_GAMEINPUT) && !defined(_GAMING_XBOX)
 #pragma comment(lib,"gameinput.lib")
 #endif
 

--- a/Inc/Keyboard.h
+++ b/Inc/Keyboard.h
@@ -10,10 +10,22 @@
 
 #pragma once
 
-#if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)) || (defined(_XBOX_ONE) && defined(_TITLE))
-#ifndef USING_COREWINDOW
+#if !defined(USING_XINPUT) && !defined(USING_GAMEINPUT) && !defined(USING_COREWINDOW)
+
+#ifdef _GAMING_DESKTOP
+#include <grdk.h>
+#endif
+
+#if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)) || (defined(_GAMING_DESKTOP) && (_GRDK_EDITION >= 220600))
+#define USING_GAMEINPUT
+#elif (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)) || (defined(_XBOX_ONE) && defined(_TITLE))
 #define USING_COREWINDOW
 #endif
+
+#endif // !USING_XINPUT && !USING_GAMEINPUT && !USING_WINDOWS_GAMING_INPUT
+
+#if defined(USING_GAMEINPUT) && !defined(_XBOX_GAMING)
+#pragma comment(lib,"gameinput.lib")
 #endif
 
 #include <cstdint>

--- a/Inc/Mouse.h
+++ b/Inc/Mouse.h
@@ -24,7 +24,7 @@
 
 #endif // !USING_XINPUT && !USING_GAMEINPUT && !USING_WINDOWS_GAMING_INPUT
 
-#if defined(USING_GAMEINPUT) && !defined(_XBOX_GAMING)
+#if defined(USING_GAMEINPUT) && !defined(_GAMING_XBOX)
 #pragma comment(lib,"gameinput.lib")
 #endif
 

--- a/Inc/Mouse.h
+++ b/Inc/Mouse.h
@@ -10,10 +10,22 @@
 
 #pragma once
 
-#if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)) || (defined(_XBOX_ONE) && defined(_TITLE))
-#ifndef USING_COREWINDOW
+#if !defined(USING_XINPUT) && !defined(USING_GAMEINPUT) && !defined(USING_COREWINDOW)
+
+#ifdef _GAMING_DESKTOP
+#include <grdk.h>
+#endif
+
+#if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)) || (defined(_GAMING_DESKTOP) && (_GRDK_EDITION >= 220600))
+#define USING_GAMEINPUT
+#elif (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)) || (defined(_XBOX_ONE) && defined(_TITLE))
 #define USING_COREWINDOW
 #endif
+
+#endif // !USING_XINPUT && !USING_GAMEINPUT && !USING_WINDOWS_GAMING_INPUT
+
+#if defined(USING_GAMEINPUT) && !defined(_XBOX_GAMING)
+#pragma comment(lib,"gameinput.lib")
 #endif
 
 #include <memory>

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -1250,7 +1250,7 @@ void GamePad::RegisterEvents(HANDLE ctrlChanged, HANDLE userChanged) noexcept
 }
 
 
-#else
+#elif defined(USING_XINPUT)
 
 //======================================================================================
 // XInput
@@ -1601,6 +1601,10 @@ private:
 };
 
 GamePad::Impl* GamePad::Impl::s_gamePad = nullptr;
+
+#else
+
+#error Unknown GamePad implementation
 
 #endif
 #pragma endregion

--- a/Src/Keyboard.cpp
+++ b/Src/Keyboard.cpp
@@ -49,7 +49,7 @@ namespace
 
 
 #pragma region Implementations
-#if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)) || (defined(_GAMING_DESKTOP) && (_GRDK_EDITION >= 220600))
+#ifdef USING_GAMEINPUT
 
 #include <GameInput.h>
 

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -17,7 +17,7 @@ using namespace DirectX;
 using Microsoft::WRL::ComPtr;
 
 #pragma region Implementations
-#if (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES)) || (defined(_GAMING_DESKTOP) && (_GRDK_EDITION >= 220600))
+#ifdef USING_GAMEINPUT
 
 #include <GameInput.h>
 


### PR DESCRIPTION
By default the input implementation choice is made by the platform defines. This allows the ``USING_GAMEINPUT``, ``USING_WINDOWS_GAMING_INPUT``, and ``USING_XINPUT`` defines to override this rather than just indicating the choice.

The defines can also be used to force the header when used in client code to match whatever choice was used to build the library in cases where the defaults don't match.
