### PR TITLE
CMake update for version 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,3 +402,10 @@ endif()
 if(BUILD_TOOLS AND (NOT WINDOWS_STORE))
   set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT xwbtool)
 endif()
+
+#--- Test suite
+include(CTest)
+if(BUILD_TESTING AND WIN32 AND (NOT WINDOWS_STORE) AND (EXISTS "${CMAKE_CURRENT_LIST_DIR}/Tests/CMakeLists.txt"))
+  enable_testing()
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/Tests)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -213,5 +213,20 @@
     { "name": "x64-Release-MinGW", "description": "MinG-W64 (Release)", "inherits": [ "base", "x64", "Release", "GNUC", "VCPKG", "MinGW64", "Win7" ] },
     { "name": "x86-Debug-MinGW"  , "description": "MinG-W32 (Debug)", "inherits": [ "base", "x86", "Debug", "GNUC", "VCPKG", "MinGW32", "Win7" ] },
     { "name": "x86-Release-MinGW", "description": "MinG-W32 (Release)", "inherits": [ "base", "x86", "Release", "GNUC", "VCPKG", "MinGW32", "Win7" ] }
+  ],
+  "testPresets": [
+    { "name": "x64-Debug"    , "configurePreset": "x64-Debug" },
+    { "name": "x64-Release"  , "configurePreset": "x64-Release" },
+    { "name": "x86-Debug"    , "configurePreset": "x86-Debug" },
+    { "name": "x86-Release"  , "configurePreset": "x86-Release" },
+    { "name": "arm64-Debug"  , "configurePreset": "arm64-Debug-Win10" },
+    { "name": "arm64-Release", "configurePreset": "arm64-Release-Win10" },
+
+    { "name": "x64-Debug-Clang"    , "configurePreset": "x64-Debug-Clang" },
+    { "name": "x64-Release-Clang"  , "configurePreset": "x64-Release-Clang" },
+    { "name": "x86-Debug-Clang"    , "configurePreset": "x86-Debug-Clang" },
+    { "name": "x86-Release-Clang"  , "configurePreset": "x86-Release-Clang" },
+    { "name": "arm64-Debug-Clang"  , "configurePreset": "arm64-Debug-Win10-Clang" },
+    { "name": "arm64-Release-Clang", "configurePreset": "arm64-Release-Win10-Clang" }
   ]
 }


### PR DESCRIPTION
CMake 3.20 allows the removal of some string hacks for ``/Wall`` and ``/GR-`` for ``CMAKE_CXX_FLAGS``.

Also integrates the test suite if present. CTest support added to the test suite in this PR: https://github.com/walbourn/directxtktest/pull/35