### PR TITLE
Update for XAudio2Redist 1.2.11

### DIFF
--- a/.nuget/directxtk_desktop_2019.nuspec
+++ b/.nuget/directxtk_desktop_2019.nuspec
@@ -42,7 +42,7 @@ DirectX Tool Kit for Audio in this package uses XAudio2Redist NuGet package to s
         <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
         <tags>DirectX DirectXTK native nativepackage</tags>
         <dependencies>
-            <dependency id="Microsoft.XAudio2.Redist" version="1.2.10" />
+            <dependency id="Microsoft.XAudio2.Redist" version="1.2.11" />
         </dependencies>
     </metadata>
 

--- a/Audio/DirectXTKAudio_Desktop_2019_Win7.vcxproj
+++ b/Audio/DirectXTKAudio_Desktop_2019_Win7.vcxproj
@@ -205,12 +205,12 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.XAudio2.Redist.1.2.10\build\native\Microsoft.XAudio2.Redist.targets" Condition="Exists('..\packages\Microsoft.XAudio2.Redist.1.2.10\build\native\Microsoft.XAudio2.Redist.targets')" />
+    <Import Project="..\packages\Microsoft.XAudio2.Redist.1.2.11\build\native\Microsoft.XAudio2.Redist.targets" Condition="Exists('..\packages\Microsoft.XAudio2.Redist.1.2.11\build\native\Microsoft.XAudio2.Redist.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.XAudio2.Redist.1.2.10\build\native\Microsoft.XAudio2.Redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.XAudio2.Redist.1.2.10\build\native\Microsoft.XAudio2.Redist.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.XAudio2.Redist.1.2.11\build\native\Microsoft.XAudio2.Redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.XAudio2.Redist.1.2.11\build\native\Microsoft.XAudio2.Redist.targets'))" />
   </Target>
 </Project>

--- a/Audio/DirectXTKAudio_Desktop_2022_Win7.vcxproj
+++ b/Audio/DirectXTKAudio_Desktop_2022_Win7.vcxproj
@@ -205,12 +205,12 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.XAudio2.Redist.1.2.10\build\native\Microsoft.XAudio2.Redist.targets" Condition="Exists('..\packages\Microsoft.XAudio2.Redist.1.2.10\build\native\Microsoft.XAudio2.Redist.targets')" />
+    <Import Project="..\packages\Microsoft.XAudio2.Redist.1.2.11\build\native\Microsoft.XAudio2.Redist.targets" Condition="Exists('..\packages\Microsoft.XAudio2.Redist.1.2.11\build\native\Microsoft.XAudio2.Redist.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.XAudio2.Redist.1.2.10\build\native\Microsoft.XAudio2.Redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.XAudio2.Redist.1.2.10\build\native\Microsoft.XAudio2.Redist.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.XAudio2.Redist.1.2.11\build\native\Microsoft.XAudio2.Redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.XAudio2.Redist.1.2.11\build\native\Microsoft.XAudio2.Redist.targets'))" />
   </Target>
 </Project>

--- a/Audio/packages.config
+++ b/Audio/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.XAudio2.Redist" version="1.2.10" targetFramework="native" />
+  <package id="Microsoft.XAudio2.Redist" version="1.2.11" targetFramework="native" />
 </packages>

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -222,6 +222,11 @@
     { "name": "arm64-Debug"  , "configurePreset": "arm64-Debug-Win10" },
     { "name": "arm64-Release", "configurePreset": "arm64-Release-Win10" },
 
+    { "name": "x64-Debug-Win7"    , "configurePreset": "x64-Debug-Win7" },
+    { "name": "x64-Release-Win7"  , "configurePreset": "x64-Release-Win7" },
+    { "name": "x86-Debug-Win7"    , "configurePreset": "x86-Debug-Win7" },
+    { "name": "x86-Release-Win7"  , "configurePreset": "x86-Release-Win7" },
+
     { "name": "x64-Debug-Clang"    , "configurePreset": "x64-Debug-Clang" },
     { "name": "x64-Release-Clang"  , "configurePreset": "x64-Release-Clang" },
     { "name": "x86-Debug-Clang"    , "configurePreset": "x86-Debug-Clang" },

--- a/build/DirectXTK-GitHub-MinGW.yml
+++ b/build/DirectXTK-GitHub-MinGW.yml
@@ -96,14 +96,13 @@ jobs:
       filename: Src/Shaders/CompileShaders.cmd
       workingFolder: $(Build.SourcesDirectory)\Src\Shaders
   - task: CmdLine@2
-    # The error checks are commented out due to a bug with vcpkg not returning 0 on success.
     displayName: VCPKG install headers
     inputs:
       script: |
         call vcpkg install directxmath
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install xaudio2redist
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         :finish
         @echo --- VCPKG COMPLETE ---
         exit /b 0
@@ -192,11 +191,11 @@ jobs:
     inputs:
       script: |
         call vcpkg install directxmath
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install directx-headers
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         call vcpkg install xaudio2redist
-        REM @if ERRORLEVEL 1 goto error
+        @if ERRORLEVEL 1 goto error
         :finish
         @echo --- VCPKG COMPLETE ---
         exit /b 0
@@ -206,11 +205,10 @@ jobs:
 
       workingDirectory: $(Build.SourcesDirectory)\vcpkg
   - task: CMake@1
-    # We are building with audio off until the GUID+MinGW linker issues are fixed in the xaudio2redist port.
     displayName: CMake (MinGW-W64)
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\Src\Shaders\Compiled -DBUILD_XAUDIO_WIN7=OFF
+      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\Src\Shaders\Compiled -DBUILD_XAUDIO_WIN7=ON
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build
     inputs:

--- a/build/DirectXTK-GitHub-MinGW.yml
+++ b/build/DirectXTK-GitHub-MinGW.yml
@@ -35,17 +35,20 @@ variables:
 
 jobs:
 - job: MINGW32_BUILD
-  displayName: 'Minimalist GNU for Windows (MinGW32)'
+  displayName: 'Minimalist GNU for Windows (MinGW32) BUILD_TESTING=ON'
   steps:
   - checkout: self
     clean: true
     fetchTags: false
   - task: CmdLine@2
-    # We can use the preinstalled vcpkg instead of the latest when MS Hosted updates their vcpkg to the newer DirectX-Headers
     displayName: Fetch VCPKG
     inputs:
       script: git clone --quiet https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
       workingDirectory: $(Build.SourcesDirectory)
+  - task: CmdLine@2
+    displayName: Fetch Tests
+    inputs:
+      script: git clone --quiet https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
     inputs:
@@ -96,10 +99,13 @@ jobs:
       filename: Src/Shaders/CompileShaders.cmd
       workingFolder: $(Build.SourcesDirectory)\Src\Shaders
   - task: CmdLine@2
+    # Test suite for DirectX Tool Kit for DX11 needs DX12 headers for the simplemath test.
     displayName: VCPKG install headers
     inputs:
       script: |
         call vcpkg install directxmath
+        @if ERRORLEVEL 1 goto error
+        call vcpkg install directx-headers
         @if ERRORLEVEL 1 goto error
         call vcpkg install xaudio2redist
         @if ERRORLEVEL 1 goto error
@@ -186,7 +192,6 @@ jobs:
     inputs:
       script: g++ --version
   - task: CmdLine@2
-    # Test suite for DirectX Tool Kit for DX11 needs DX12 headers for the simplemath test.
     displayName: VCPKG install headers
     inputs:
       script: |


### PR DESCRIPTION
Update for latest XAudio2Redist NuGet release. 1.2.11 includes bug fixes to make the headers link correctly when using the MinGW toolset.
