### PR TITLE
Rework audio device enumeration for XAudio2.9

### DIFF
--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1743,6 +1743,7 @@ namespace
 {
     void GetDeviceOutputFormat(const wchar_t*, WAVEFORMATEX& wfx)
     {
+        wfx.nSamplesPerSec = 48000;
         wfx.wBitsPerSample = 24;
     }
 }

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1342,6 +1342,7 @@ WAVEFORMATEXTENSIBLE AudioEngine::GetOutputFormat() const noexcept
 
     wfx.Format = pImpl->mOutputFormat;
     wfx.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
+    wfx.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
 
     wfx.Samples.wValidBitsPerSample = wfx.Format.wBitsPerSample;
     wfx.dwChannelMask = pImpl->masterChannelMask;

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1488,6 +1488,10 @@ X3DAUDIO_HANDLE& AudioEngine::Get3DHandle() const noexcept
 
 #include <wrl.h>
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif
+
 namespace
 {
     const wchar_t* c_PKEY_AudioEngine_DeviceFormat = L"{f19f064d-082c-4e27-bc73-6882a1bb8e4c} 0";

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1499,9 +1499,15 @@ namespace
 
     class PropertyIterator : public Microsoft::WRL::RuntimeClass<ABI::Windows::Foundation::Collections::IIterator<HSTRING>>
     {
+    #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
+        InspectableClass(L"AudioEngine.PropertyIterator", FullTrust)
+    #else
         InspectableClass(L"AudioEngine.PropertyIterator", BaseTrust)
+    #endif
 
     public:
+        PropertyIterator() : mFirst(true), mString(c_PKEY_AudioEngine_DeviceFormat) {}
+
         HRESULT STDMETHODCALLTYPE get_Current(HSTRING *current) override
         {
             if (!current)
@@ -1509,7 +1515,7 @@ namespace
 
             if (mFirst)
             {
-                *current = Microsoft::WRL::Wrappers::HStringReference(c_PKEY_AudioEngine_DeviceFormat).Get();
+                *current = mString.Get();
             }
 
             return S_OK;
@@ -1535,12 +1541,19 @@ namespace
         }
 
     private:
-        bool mFirst = true;
+        bool mFirst;
+        Microsoft::WRL::Wrappers::HStringReference mString;
+
+        ~PropertyIterator() = default;
     };
 
     class PropertyList : public Microsoft::WRL::RuntimeClass<ABI::Windows::Foundation::Collections::IIterable<HSTRING>>
     {
+    #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
+        InspectableClass(L"AudioEngine.PropertyList", FullTrust)
+    #else
         InspectableClass(L"AudioEngine.PropertyList", BaseTrust)
+    #endif
 
     public:
         HRESULT STDMETHODCALLTYPE First(ABI::Windows::Foundation::Collections::IIterator<HSTRING> **first) override
@@ -1552,6 +1565,9 @@ namespace
             *first = p.Detach();
             return S_OK;
         }
+
+    private:
+        ~PropertyList() = default;
     };
 
     void GetDeviceOutputFormat(const wchar_t* deviceId, WAVEFORMATEX& wfx)

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1490,36 +1490,6 @@ std::vector<AudioEngine::RendererDetail> AudioEngine::GetRendererDetails()
 {
     std::vector<RendererDetail> list;
 
-#if defined(__cplusplus_winrt)
-
-    // Enumerating with WinRT using C++/CX (Windows Store apps)
-    using Windows::Devices::Enumeration::DeviceClass;
-    using Windows::Devices::Enumeration::DeviceInformation;
-    using Windows::Devices::Enumeration::DeviceInformationCollection;
-
-    auto operation = DeviceInformation::FindAllAsync(DeviceClass::AudioRender);
-    while (operation->Status == Windows::Foundation::AsyncStatus::Started) { Sleep(100); }
-    if (operation->Status != Windows::Foundation::AsyncStatus::Completed)
-    {
-        throw std::runtime_error("FindAllAsync");
-    }
-
-    DeviceInformationCollection^ devices = operation->GetResults();
-
-    for (unsigned i = 0; i < devices->Size; ++i)
-    {
-        using Windows::Devices::Enumeration::DeviceInformation;
-
-        DeviceInformation^ d = devices->GetAt(i);
-
-        RendererDetail device;
-        device.deviceId = d->Id->Data();
-        device.description = d->Name->Data();
-        list.emplace_back(device);
-    }
-
-#else
-
     // Enumerating with WinRT using WRL (Win32 desktop app for Windows 8.x)
     using namespace Microsoft::WRL;
     using namespace Microsoft::WRL::Wrappers;
@@ -1594,7 +1564,6 @@ std::vector<AudioEngine::RendererDetail> AudioEngine::GetRendererDetails()
             list.emplace_back(device);
         }
     }
-#endif
 
     return list;
 }

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1464,7 +1464,8 @@ X3DAUDIO_HANDLE& AudioEngine::Get3DHandle() const noexcept
 // Note that this form of enumeration would also be needed for XAudio2.9 prior to Windows 10 (18362).
 //
 // If you care about supporting Windows 10 (17763), Windows Server 2019, or earlier Windows 10 builds,
-// you will need to modify the library to use this codepath for Windows desktop -or- use XAudio 2.8.
+// you will need to modify the library to use this codepath for Windows desktop -or-
+// -or- use XAudio2Redist -or- use XAudio 2.8.
 
 #pragma comment(lib,"runtimeobject.lib")
 #pragma warning(push)

--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1464,7 +1464,7 @@ X3DAUDIO_HANDLE& AudioEngine::Get3DHandle() const noexcept
 // Note that this form of enumeration would also be needed for XAudio2.9 prior to Windows 10 (18362).
 //
 // If you care about supporting Windows 10 (17763), Windows Server 2019, or earlier Windows 10 builds,
-// you will need to modify the library to use this codepath for Windows desktop -or-
+// you will need to modify the library to use this codepath for Windows desktop
 // -or- use XAudio2Redist -or- use XAudio 2.8.
 
 #pragma comment(lib,"runtimeobject.lib")

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -242,13 +242,16 @@ namespace DirectX
             // Gathers audio engine statistics
 
         WAVEFORMATEXTENSIBLE __cdecl GetOutputFormat() const noexcept;
-            // Returns the format consumed by the mastering voice (which is the same as the device output if defaults are used)
+            // Returns the format of the audio output device associated with the mastering voice.
 
         uint32_t __cdecl GetChannelMask() const noexcept;
             // Returns the output channel mask
 
+        int __cdecl GetOutputSampleRate() const noexcept;
+            // Returns the sample rate going into the mastering voice
+
         unsigned int __cdecl GetOutputChannels() const noexcept;
-            // Returns the number of output channels
+            // Returns the number of channels going into the mastering voice
 
         bool __cdecl IsAudioDevicePresent() const noexcept;
             // Returns true if the audio graph is operating normally, false if in 'silent mode'


### PR DESCRIPTION
XAudio 2.8 on Windows 8 required the use of Windows Runtime APIs for device enumeration. XAudio2.9 on Windows 10 (18362)  or later and all versions of XAudio2Redist support both Windows Runtime device ids -and- standard WASAPI device ids.

This PR reworks the device enumeration to use WASAPI enumeration for most cases, and WinRT enumeration for the UWP platform and for XAudio 2.8 scenarios only.

In addition, this PR returns correct values for ``GetOutputFormat().Format.wBitsPerSample`` where possible. It previously always returned a value of 16.

> For Windows Server 2019 (17763) or other older Windows 10 scenarios, the recommendation is to use XAudio2Redist instead of the built-in XAudio 2.9.