### PR TITLE
xwbtool updated to support long path names with Windows 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,7 @@ if(BUILD_TOOLS AND WIN32)
   add_executable(xwbtool
     xwbtool/xwbtool.cpp
     xwbtool/xwbtool.rc
+    xwbtool/settings.manifest
     Audio/WAVFileReader.cpp
     Audio/WAVFileReader.h)
   target_include_directories(xwbtool PRIVATE Audio Src)

--- a/XWBTool/settings.manifest
+++ b/XWBTool/settings.manifest
@@ -1,0 +1,21 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" >
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 10 / Windows 11 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+        </application>
+    </compatibility>
+    <asmv3:application>
+        <asmv3:windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+            <ws2:longPathAware>true</ws2:longPathAware>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+</assembly>

--- a/XWBTool/xwbtool.cpp
+++ b/XWBTool/xwbtool.cpp
@@ -1043,7 +1043,7 @@ namespace
         wchar_t version[32] = {};
 
         wchar_t appName[_MAX_PATH] = {};
-        if (GetModuleFileNameW(nullptr, appName, static_cast<DWORD>(std::size(appName))))
+        if (GetModuleFileNameW(nullptr, appName, _MAX_PATH))
         {
             DWORD size = GetFileVersionInfoSizeW(appName, nullptr);
             if (size > 0)

--- a/XWBTool/xwbtool_Desktop_2019.vcxproj
+++ b/XWBTool/xwbtool_Desktop_2019.vcxproj
@@ -256,6 +256,9 @@
   <ItemGroup>
     <ResourceCompile Include="xwbtool.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="settings.manifest" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/XWBTool/xwbtool_Desktop_2019.vcxproj.filters
+++ b/XWBTool/xwbtool_Desktop_2019.vcxproj.filters
@@ -7,4 +7,19 @@
   <ItemGroup>
     <ClInclude Include="..\Audio\WAVFileReader.h" />
   </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{a82dd41b-2b9b-4027-8047-cc6f092c2213}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="settings.manifest">
+      <Filter>Resource Files</Filter>
+    </Manifest>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="xwbtool.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
 </Project>

--- a/XWBTool/xwbtool_Desktop_2022.vcxproj
+++ b/XWBTool/xwbtool_Desktop_2022.vcxproj
@@ -260,6 +260,9 @@
   <ItemGroup>
     <ResourceCompile Include="xwbtool.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="settings.manifest" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/XWBTool/xwbtool_Desktop_2022.vcxproj.filters
+++ b/XWBTool/xwbtool_Desktop_2022.vcxproj.filters
@@ -8,6 +8,18 @@
     <ClInclude Include="..\Audio\WAVFileReader.h" />
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="xwbtool.rc" />
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{b97e6e90-0253-4558-b6d8-ce1701c2ecb0}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="xwbtool.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="settings.manifest">
+      <Filter>Resource Files</Filter>
+    </Manifest>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates **xwbtool** to support very long file names with Windows 10 (Version 1607) or later.

> Note that the tool does not support UNC style ``\\?\`` long paths as those are not supported by ``std::filesystem``.
