### PR TITLE
CMake target file fix

### DIFF
--- a/build/DirectXTK-config.cmake.in
+++ b/build/DirectXTK-config.cmake.in
@@ -10,7 +10,7 @@ if (BUILD_XAUDIO_WIN7 AND (NOT BUILD_XAUDIO_WIN10) AND (NOT BUILD_XAUDIO_WIN8) A
     find_dependency(xaudio2redist CONFIG)
 endif()
 
-if(MINGW OR VCPKG_TOOLCHAIN)
+if(MINGW)
     find_dependency(directxmath CONFIG)
 endif()
 


### PR DESCRIPTION
The CMakeLists.txt no longer mandates the **directxmath** package be found unless building with MinGW. This fixes the behavior for CMake clients consuming this package from VCPKG.