### PR TITLE
Add NO_WCHAR_T build option to CMake

### DIFF
--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1897,3 +1897,26 @@ std::vector<AudioEngine::RendererDetail> AudioEngine::GetRendererDetails()
 #else
 #error DirectX Tool Kit for Audio not supported on this platform
 #endif
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+AudioEngine::AudioEngine(
+    AUDIO_ENGINE_FLAGS flags,
+    const WAVEFORMATEX* wfx,
+    const __wchar_t* deviceId,
+    AUDIO_STREAM_CATEGORY category) noexcept(false) :
+        AudioEngine(flags, wfx, reinterpret_cast<const unsigned short*>(deviceId), category)
+{
+}
+
+_Use_decl_annotations_
+bool AudioEngine::Reset(const WAVEFORMATEX* wfx, const __wchar_t* deviceId)
+{
+    return Reset(wfx, reinterpret_cast<const unsigned short*>(deviceId));
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/Audio/SoundEffect.cpp
+++ b/Audio/SoundEffect.cpp
@@ -614,3 +614,16 @@ void SoundEffect::FillSubmitBuffer(_Out_ XAUDIO2_BUFFER& buffer) const
 }
 
 #endif
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+SoundEffect::SoundEffect(AudioEngine* engine, const __wchar_t* waveFileName) :
+    SoundEffect(engine, reinterpret_cast<const unsigned short*>(waveFileName))
+{
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/Audio/WaveBank.cpp
+++ b/Audio/WaveBank.cpp
@@ -603,3 +603,16 @@ bool WaveBank::GetPrivateData(unsigned int index, void* data, size_t datasize)
             return false;
     }
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+WaveBank::WaveBank(AudioEngine* engine, const __wchar_t* wbFileName) :
+    WaveBank(engine, reinterpret_cast<const unsigned short*>(wbFileName))
+{
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ option(ENABLE_CODE_ANALYSIS "Use Static Code Analysis on build" OFF)
 
 option(USE_PREBUILT_SHADERS "Use externally built HLSL shaders" OFF)
 
+option(NO_WCHAR_T "Use legacy wide-character as unsigned short" OFF)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -398,6 +400,13 @@ if(MSVC)
       foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
         target_compile_options(${t} PRIVATE "$<$<NOT:$<CONFIG:DEBUG>>:/guard:ehcont>")
         target_link_options(${t} PRIVATE "$<$<NOT:$<CONFIG:DEBUG>>:/guard:ehcont>")
+      endforeach()
+    endif()
+
+    if(NO_WCHAR_T)
+      message(STATUS "Using non-native wchar_t as unsigned short")
+      foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
+        target_compile_options(${t} PRIVATE "/Zc:wchar_t-")
       endforeach()
     endif()
 else()

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -296,6 +296,16 @@ namespace DirectX
         static std::vector<RendererDetail> __cdecl GetRendererDetails();
             // Returns a list of valid audio endpoint devices
 
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+        explicit AudioEngine(
+            AUDIO_ENGINE_FLAGS flags = AudioEngine_Default,
+            _In_opt_ const WAVEFORMATEX* wfx = nullptr,
+            _In_opt_z_ const __wchar_t* deviceId = nullptr,
+            AUDIO_STREAM_CATEGORY category = AudioCategory_GameEffects) noexcept(false);
+
+        bool __cdecl Reset(_In_opt_ const WAVEFORMATEX* wfx = nullptr, _In_opt_z_ const __wchar_t* deviceId = nullptr);
+#endif
+
     private:
         // Private implementation.
         class Impl;
@@ -363,6 +373,10 @@ namespace DirectX
 
         bool __cdecl GetPrivateData(unsigned int index, _Out_writes_bytes_(datasize) void* data, size_t datasize);
 
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+        WaveBank(_In_ AudioEngine* engine, _In_z_ const __wchar_t* wbFileName);
+#endif
+
     private:
         // Private implementation.
         class Impl;
@@ -425,6 +439,10 @@ namespace DirectX
     #endif
 
         void __cdecl UnregisterInstance(_In_ IVoiceNotify* instance);
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+        SoundEffect(_In_ AudioEngine* engine, _In_z_ const __wchar_t* waveFileName);
+#endif
 
     private:
         // Private implementation.
@@ -730,7 +748,7 @@ namespace DirectX
     {
     public:
         DynamicSoundEffectInstance(_In_ AudioEngine* engine,
-            _In_opt_ std::function<void __cdecl(DynamicSoundEffectInstance*)> bufferNeeded,
+            _In_ std::function<void __cdecl(DynamicSoundEffectInstance*)> bufferNeeded,
             int sampleRate, int channels, int sampleBits = 16,
             SOUND_EFFECT_INSTANCE_FLAGS flags = SoundEffectInstance_Default);
 

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -9,6 +9,9 @@
 
 #pragma once
 
+#ifndef __DIRECTXTK_EFFECTS_H__
+#define __DIRECTXTK_EFFECTS_H__
+
 #if defined(_XBOX_ONE) && defined(_TITLE)
 #include <d3d11_x.h>
 #else
@@ -1027,3 +1030,5 @@ namespace DirectX
         };
     }
 }
+
+#endif // __DIRECTXTK_EFFECTS_H__

--- a/Inc/GeometricPrimitive.h
+++ b/Inc/GeometricPrimitive.h
@@ -74,20 +74,20 @@ namespace DirectX
                 FXMVECTOR color = Colors::White,
                 _In_opt_ ID3D11ShaderResourceView* texture = nullptr,
                 bool wireframe = false,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
             // Draw the primitive using a custom effect.
             void __cdecl Draw(_In_ IEffect* effect,
                 _In_ ID3D11InputLayout* inputLayout,
                 bool alpha = false, bool wireframe = false,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
             void __cdecl DrawInstanced(_In_ IEffect* effect,
                 _In_ ID3D11InputLayout* inputLayout,
                 uint32_t instanceCount,
                 bool alpha = false, bool wireframe = false,
                 uint32_t startInstanceLocation = 0,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
            // Create input layout for drawing with a custom effect.
             void __cdecl CreateInputLayout(_In_ IEffect* effect, _Outptr_ ID3D11InputLayout** inputLayout) const;

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -319,12 +319,12 @@ namespace DirectX
             static std::unique_ptr<Model> __cdecl CreateFromVBO(
                 _In_ ID3D11Device* device,
                 _In_reads_bytes_(dataSize) const uint8_t* meshData, _In_ size_t dataSize,
-                _In_opt_ std::shared_ptr<IEffect> ieffect = nullptr,
+                _In_ std::shared_ptr<IEffect> ieffect = nullptr,
                 ModelLoaderFlags flags = ModelLoader_Clockwise);
             static std::unique_ptr<Model> __cdecl CreateFromVBO(
                 _In_ ID3D11Device* device,
                 _In_z_ const wchar_t* szFileName,
-                _In_opt_ std::shared_ptr<IEffect> ieffect = nullptr,
+                _In_ std::shared_ptr<IEffect> ieffect = nullptr,
                 ModelLoaderFlags flags = ModelLoader_Clockwise);
 
 #if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
@@ -344,7 +344,7 @@ namespace DirectX
             static std::unique_ptr<Model> __cdecl CreateFromVBO(
                 _In_ ID3D11Device* device,
                 _In_z_ const __wchar_t* szFileName,
-                _In_opt_ std::shared_ptr<IEffect> ieffect = nullptr,
+                _In_ std::shared_ptr<IEffect> ieffect = nullptr,
                 ModelLoaderFlags flags = ModelLoader_Clockwise);
 #endif // !_NATIVE_WCHAR_T_DEFINED
 

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -132,7 +132,7 @@ namespace DirectX
                 _In_ ID3D11DeviceContext* deviceContext,
                 _In_ IEffect* ieffect,
                 _In_ ID3D11InputLayout* iinputLayout,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
             void __cdecl DrawInstanced(
                 _In_ ID3D11DeviceContext* deviceContext,
@@ -140,7 +140,7 @@ namespace DirectX
                 _In_ ID3D11InputLayout* iinputLayout,
                 uint32_t instanceCount,
                 uint32_t startInstanceLocation = 0,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
            // Create input layout for drawing with a custom effect.
             void __cdecl CreateInputLayout(_In_ ID3D11Device* device, _In_ IEffect* ieffect, _Outptr_ ID3D11InputLayout** iinputLayout) const;
@@ -188,7 +188,7 @@ namespace DirectX
                 _In_ ID3D11DeviceContext* deviceContext,
                 FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
                 bool alpha = false,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
             // Draw the mesh using model bones
             void XM_CALLCONV Draw(
@@ -196,7 +196,7 @@ namespace DirectX
                 size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
                 FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
                 bool alpha = false,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
             // Draw the mesh using skinning
             void XM_CALLCONV DrawSkinned(
@@ -204,7 +204,7 @@ namespace DirectX
                 size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
                 FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
                 bool alpha = false,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
             static void SetDepthBufferMode(bool reverseZ)
             {
@@ -243,7 +243,7 @@ namespace DirectX
                 const CommonStates& states,
                 FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
                 bool wireframe = false,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
             // Draw all the meshes using model bones
             void XM_CALLCONV Draw(
@@ -252,7 +252,7 @@ namespace DirectX
                 size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
                 FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
                 bool wireframe = false,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
             // Draw all the meshes using skinning
             void XM_CALLCONV DrawSkinned(
@@ -261,7 +261,7 @@ namespace DirectX
                 size_t nbones, _In_reads_(nbones) const XMMATRIX* boneTransforms,
                 FXMMATRIX world, CXMMATRIX view, CXMMATRIX projection,
                 bool wireframe = false,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) const;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) const;
 
             // Compute bone positions based on heirarchy and transform matrices
             void __cdecl CopyAbsoluteBoneTransformsTo(
@@ -326,6 +326,27 @@ namespace DirectX
                 _In_z_ const wchar_t* szFileName,
                 _In_opt_ std::shared_ptr<IEffect> ieffect = nullptr,
                 ModelLoaderFlags flags = ModelLoader_Clockwise);
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+            static std::unique_ptr<Model> __cdecl CreateFromCMO(
+                _In_ ID3D11Device* device,
+                _In_z_ const __wchar_t* szFileName,
+                _In_ IEffectFactory& fxFactory,
+                ModelLoaderFlags flags = ModelLoader_CounterClockwise,
+                _Out_opt_ size_t* animsOffset = nullptr);
+
+            static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
+                _In_ ID3D11Device* device,
+                _In_z_ const __wchar_t* szFileName,
+                _In_ IEffectFactory& fxFactory,
+                ModelLoaderFlags flags = ModelLoader_Clockwise);
+
+            static std::unique_ptr<Model> __cdecl CreateFromVBO(
+                _In_ ID3D11Device* device,
+                _In_z_ const __wchar_t* szFileName,
+                _In_opt_ std::shared_ptr<IEffect> ieffect = nullptr,
+                ModelLoaderFlags flags = ModelLoader_Clockwise);
+#endif // !_NATIVE_WCHAR_T_DEFINED
 
         private:
             std::set<IEffect*>  mEffectCache;

--- a/Inc/PostProcess.h
+++ b/Inc/PostProcess.h
@@ -36,7 +36,7 @@ namespace DirectX
             IPostProcess& operator=(const IPostProcess&) = delete;
 
             virtual void __cdecl Process(_In_ ID3D11DeviceContext* deviceContext,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) = 0;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) = 0;
 
         protected:
             IPostProcess() = default;
@@ -76,7 +76,7 @@ namespace DirectX
             // IPostProcess methods.
             void __cdecl Process(
                 _In_ ID3D11DeviceContext* deviceContext,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) override;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) override;
 
             // Shader control
             void __cdecl SetEffect(Effect fx);
@@ -125,7 +125,7 @@ namespace DirectX
 
             // IPostProcess methods.
             void __cdecl Process(_In_ ID3D11DeviceContext* deviceContext,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) override;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) override;
 
             // Shader control
             void __cdecl SetEffect(Effect fx);
@@ -192,7 +192,7 @@ namespace DirectX
 
             // IPostProcess methods.
             void __cdecl Process(_In_ ID3D11DeviceContext* deviceContext,
-                _In_opt_ std::function<void __cdecl()> setCustomState = nullptr) override;
+                _In_ std::function<void __cdecl()> setCustomState = nullptr) override;
 
             // Shader control
             void __cdecl SetOperator(Operator op);

--- a/Inc/ScreenGrab.h
+++ b/Inc/ScreenGrab.h
@@ -47,6 +47,6 @@ namespace DirectX
         _In_ REFGUID guidContainerFormat,
         _In_z_ const wchar_t* fileName,
         _In_opt_ const GUID* targetFormat = nullptr,
-        _In_opt_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr,
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr,
         _In_ bool forceSRGB = false);
 }

--- a/Inc/SpriteBatch.h
+++ b/Inc/SpriteBatch.h
@@ -64,7 +64,7 @@ namespace DirectX
                 _In_opt_ ID3D11SamplerState* samplerState = nullptr,
                 _In_opt_ ID3D11DepthStencilState* depthStencilState = nullptr,
                 _In_opt_ ID3D11RasterizerState* rasterizerState = nullptr,
-                _In_opt_ std::function<void __cdecl()> setCustomShaders = nullptr,
+                _In_ std::function<void __cdecl()> setCustomShaders = nullptr,
                 FXMMATRIX transformMatrix = MatrixIdentity);
             void __cdecl End();
 

--- a/Inc/SpriteFont.h
+++ b/Inc/SpriteFont.h
@@ -83,6 +83,26 @@ namespace DirectX
                 float XAdvance;
             };
 
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+            SpriteFont(_In_ ID3D11Device* device, _In_z_ __wchar_t const* fileName, bool forceSRGB = false);
+
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color = Colors::White, float rotation = 0, XMFLOAT2 const& origin = Float2Zero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, FXMVECTOR position, FXMVECTOR color = Colors::White, float rotation = 0, FXMVECTOR origin = g_XMZero, float scale = 1, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+            void XM_CALLCONV DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects = SpriteEffects_None, float layerDepth = 0) const;
+
+            XMVECTOR XM_CALLCONV MeasureString(_In_z_ __wchar_t const* text, bool ignoreWhitespace = true) const;
+
+            RECT __cdecl MeasureDrawBounds(_In_z_ __wchar_t const* text, XMFLOAT2 const& position, bool ignoreWhitespace = true) const;
+            RECT XM_CALLCONV MeasureDrawBounds(_In_z_ __wchar_t const* text, FXMVECTOR position, bool ignoreWhitespace = true) const;
+
+            void __cdecl SetDefaultCharacter(__wchar_t character);
+
+            bool __cdecl ContainsCharacter(__wchar_t character) const;
+
+            Glyph const* __cdecl FindGlyph(__wchar_t character) const;
+#endif // !_NATIVE_WCHAR_T_DEFINED
 
         private:
             // Private implementation.

--- a/Src/BasicPostProcess.cpp
+++ b/Src/BasicPostProcess.cpp
@@ -484,7 +484,7 @@ BasicPostProcess::~BasicPostProcess() = default;
 // IPostProcess methods.
 void BasicPostProcess::Process(
     _In_ ID3D11DeviceContext* deviceContext,
-    _In_opt_ std::function<void __cdecl()> setCustomState)
+    _In_ std::function<void __cdecl()> setCustomState)
 {
     pImpl->Process(deviceContext, setCustomState);
 }

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -1368,3 +1368,88 @@ HRESULT DirectX::CreateDDSTextureFromFileEx(
 
     return hr;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+namespace DirectX
+{
+    HRESULT __cdecl CreateDDSTextureFromFile(
+        _In_ ID3D11Device* d3dDevice,
+        _In_z_ const __wchar_t* szFileName,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _In_ size_t maxsize,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode) noexcept
+    {
+        return CreateDDSTextureFromFile(d3dDevice,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            texture, textureView, maxsize, alphaMode);
+    }
+
+    HRESULT __cdecl CreateDDSTextureFromFile(
+#if defined(_XBOX_ONE) && defined(_TITLE)
+        _In_ ID3D11DeviceX* d3dDevice,
+        _In_opt_ ID3D11DeviceContextX* d3dContext,
+#else
+        _In_ ID3D11Device* d3dDevice,
+        _In_opt_ ID3D11DeviceContext* d3dContext,
+#endif
+        _In_z_ const __wchar_t* szFileName,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _In_ size_t maxsize,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode) noexcept
+    {
+        return CreateDDSTextureFromFile(d3dDevice, d3dContext,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            texture, textureView, maxsize, alphaMode);
+    }
+
+    HRESULT __cdecl CreateDDSTextureFromFileEx(
+        _In_ ID3D11Device* d3dDevice,
+        _In_z_ const __wchar_t* szFileName,
+        _In_ size_t maxsize,
+        _In_ D3D11_USAGE usage,
+        _In_ unsigned int bindFlags,
+        _In_ unsigned int cpuAccessFlags,
+        _In_ unsigned int miscFlags,
+        _In_ DDS_LOADER_FLAGS loadFlags,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode) noexcept
+    {
+        return CreateDDSTextureFromFileEx(d3dDevice,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            maxsize, usage, bindFlags, cpuAccessFlags, miscFlags, loadFlags, texture, textureView, alphaMode);
+    }
+
+    HRESULT __cdecl CreateDDSTextureFromFileEx(
+#if defined(_XBOX_ONE) && defined(_TITLE)
+        _In_ ID3D11DeviceX* d3dDevice,
+        _In_opt_ ID3D11DeviceContextX* d3dContext,
+#else
+        _In_ ID3D11Device* d3dDevice,
+        _In_opt_ ID3D11DeviceContext* d3dContext,
+#endif
+        _In_z_ const __wchar_t* szFileName,
+        _In_ size_t maxsize,
+        _In_ D3D11_USAGE usage,
+        _In_ unsigned int bindFlags,
+        _In_ unsigned int cpuAccessFlags,
+        _In_ unsigned int miscFlags,
+        _In_ DDS_LOADER_FLAGS loadFlags,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode) noexcept
+    {
+        return CreateDDSTextureFromFileEx(d3dDevice, d3dContext,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            maxsize, usage, bindFlags, cpuAccessFlags, miscFlags, loadFlags, texture, textureView, alphaMode);
+    }
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/Src/DualPostProcess.cpp
+++ b/Src/DualPostProcess.cpp
@@ -283,7 +283,7 @@ DualPostProcess::~DualPostProcess() = default;
 // IPostProcess methods.
 void DualPostProcess::Process(
     _In_ ID3D11DeviceContext* deviceContext,
-    _In_opt_ std::function<void __cdecl()> setCustomState)
+    _In_ std::function<void __cdecl()> setCustomState)
 {
     pImpl->Process(deviceContext, setCustomState);
 }

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -974,3 +974,22 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
 
     return model;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+std::unique_ptr<Model> Model::CreateFromCMO(
+    ID3D11Device* device,
+    const __wchar_t* szFileName,
+    IEffectFactory& fxFactory,
+    ModelLoaderFlags flags,
+    size_t* animsOffset)
+{
+    return Model::CreateFromCMO(device, reinterpret_cast<const unsigned short*>(szFileName), fxFactory, flags, animsOffset);
+}
+
+#endif

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -808,3 +808,22 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
 
     return model;
 }
+
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
+    ID3D11Device* device,
+    const __wchar_t* szFileName,
+    IEffectFactory& fxFactory,
+    ModelLoaderFlags flags)
+{
+    return Model::CreateFromSDKMESH(device, reinterpret_cast<const unsigned short*>(szFileName), fxFactory, flags);
+}
+
+#endif

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -200,3 +200,21 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
 
     return model;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+_Use_decl_annotations_
+std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
+    ID3D11Device* device,
+    const __wchar_t* szFileName,
+    std::shared_ptr<IEffect> ieffect,
+    ModelLoaderFlags flags)
+{
+    return Model::CreateFromVBO(device, reinterpret_cast<const unsigned short*>(szFileName), ieffect, flags);
+}
+
+#endif

--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -692,3 +692,37 @@ HRESULT DirectX::SaveWICTextureToFile(
 
     return S_OK;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+namespace DirectX
+{
+    HRESULT __cdecl SaveDDSTextureToFile(
+        _In_ ID3D11DeviceContext* pContext,
+        _In_ ID3D11Resource* pSource,
+        _In_z_ const __wchar_t* fileName) noexcept
+    {
+        return SaveDDSTextureToFile(pContext, pSource,
+            reinterpret_cast<const unsigned short*>(fileName));
+    }
+
+    HRESULT __cdecl SaveWICTextureToFile(
+        _In_ ID3D11DeviceContext* pContext,
+        _In_ ID3D11Resource* pSource,
+        _In_ REFGUID guidContainerFormat,
+        _In_z_ const __wchar_t* fileName,
+        _In_opt_ const GUID* targetFormat,
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps,
+        _In_ bool forceSRGB)
+    {
+        return SaveWICTextureToFile(pContext, pSource, guidContainerFormat,
+            reinterpret_cast<const unsigned short*>(fileName),
+            targetFormat, setCustomProps, forceSRGB);
+    }
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -636,3 +636,71 @@ void SpriteFont::GetSpriteSheet(ID3D11ShaderResourceView** texture) const
 
     ThrowIfFailed(pImpl->texture.CopyTo(texture));
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+SpriteFont::SpriteFont(_In_ ID3D11Device* device, _In_z_ __wchar_t const* fileName, bool forceSRGB) :
+    SpriteFont(device, reinterpret_cast<const unsigned short*>(fileName), forceSRGB)
+{
+}
+
+void SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, float scale, SpriteEffects effects, float layerDepth) const
+{
+    DrawString(spriteBatch, reinterpret_cast<const unsigned short*>(text), XMLoadFloat2(&position), color, rotation, XMLoadFloat2(&origin), XMVectorReplicate(scale), effects, layerDepth);
+}
+
+void SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, XMFLOAT2 const& position, FXMVECTOR color, float rotation, XMFLOAT2 const& origin, XMFLOAT2 const& scale, SpriteEffects effects, float layerDepth) const
+{
+    DrawString(spriteBatch, reinterpret_cast<const unsigned short*>(text), XMLoadFloat2(&position), color, rotation, XMLoadFloat2(&origin), XMLoadFloat2(&scale), effects, layerDepth);
+}
+
+void SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, float scale, SpriteEffects effects, float layerDepth) const
+{
+    DrawString(spriteBatch, reinterpret_cast<const unsigned short*>(text), position, color, rotation, origin, XMVectorReplicate(scale), effects, layerDepth);
+}
+
+void XM_CALLCONV SpriteFont::DrawString(_In_ SpriteBatch* spriteBatch, _In_z_ __wchar_t const* text, FXMVECTOR position, FXMVECTOR color, float rotation, FXMVECTOR origin, GXMVECTOR scale, SpriteEffects effects, float layerDepth) const
+{
+    DrawString(spriteBatch, reinterpret_cast<const unsigned short*>(text), position, color, rotation, origin, scale, effects, layerDepth);
+}
+
+XMVECTOR SpriteFont::MeasureString(_In_z_ __wchar_t const* text, bool ignoreWhitespace) const
+{
+    return MeasureString(reinterpret_cast<const unsigned short*>(text), ignoreWhitespace);
+}
+
+RECT SpriteFont::MeasureDrawBounds(_In_z_ __wchar_t const* text, XMFLOAT2 const& position, bool ignoreWhitespace) const
+{
+    return MeasureDrawBounds(reinterpret_cast<const unsigned short*>(text), position, ignoreWhitespace);
+}
+
+RECT SpriteFont::MeasureDrawBounds(_In_z_ __wchar_t const* text, FXMVECTOR position, bool ignoreWhitespace) const
+{
+    XMFLOAT2 pos;
+    XMStoreFloat2(&pos, position);
+
+    return MeasureDrawBounds(reinterpret_cast<const unsigned short*>(text), pos, ignoreWhitespace);
+}
+
+// Can't do this for GetDefaultCharacter since it only differs by return type.
+
+void SpriteFont::SetDefaultCharacter(__wchar_t character)
+{
+    pImpl->SetDefaultCharacter(static_cast<unsigned short>(character));
+}
+
+bool SpriteFont::ContainsCharacter(__wchar_t character) const
+{
+    return ContainsCharacter(static_cast<unsigned short>(character));
+}
+
+SpriteFont::Glyph const* SpriteFont::FindGlyph(__wchar_t character) const
+{
+    return pImpl->FindGlyph(static_cast<unsigned short>(character));
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -396,7 +396,7 @@ ToneMapPostProcess::~ToneMapPostProcess() = default;
 // IPostProcess methods.
 void ToneMapPostProcess::Process(
     _In_ ID3D11DeviceContext* deviceContext,
-    _In_opt_ std::function<void __cdecl()> setCustomState)
+    _In_ std::function<void __cdecl()> setCustomState)
 {
     pImpl->Process(deviceContext, setCustomState);
 }

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -1222,3 +1222,84 @@ HRESULT DirectX::CreateWICTextureFromFileEx(
 
     return hr;
 }
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+namespace DirectX
+{
+    HRESULT __cdecl CreateWICTextureFromFile(
+        _In_ ID3D11Device* d3dDevice,
+        _In_z_ const __wchar_t* szFileName,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _In_ size_t maxsize) noexcept
+    {
+        return CreateWICTextureFromFile(d3dDevice,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            texture, textureView, maxsize);
+    }
+
+    HRESULT __cdecl CreateWICTextureFromFile(
+#if defined(_XBOX_ONE) && defined(_TITLE)
+        _In_ ID3D11DeviceX* d3dDevice,
+        _In_opt_ ID3D11DeviceContextX* d3dContext,
+#else
+        _In_ ID3D11Device* d3dDevice,
+        _In_opt_ ID3D11DeviceContext* d3dContext,
+#endif
+        _In_z_ const __wchar_t* szFileName,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _In_ size_t maxsize) noexcept
+    {
+        return CreateWICTextureFromFile(d3dDevice, d3dContext,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            texture, textureView, maxsize);
+    }
+
+    HRESULT __cdecl CreateWICTextureFromFileEx(
+        _In_ ID3D11Device* d3dDevice,
+        _In_z_ const __wchar_t* szFileName,
+        _In_ size_t maxsize,
+        _In_ D3D11_USAGE usage,
+        _In_ unsigned int bindFlags,
+        _In_ unsigned int cpuAccessFlags,
+        _In_ unsigned int miscFlags,
+        _In_ WIC_LOADER_FLAGS loadFlags,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept
+    {
+        return CreateWICTextureFromFileEx(d3dDevice,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            maxsize, usage, bindFlags, cpuAccessFlags, miscFlags, loadFlags, texture, textureView);
+    }
+
+    HRESULT __cdecl CreateWICTextureFromFileEx(
+#if defined(_XBOX_ONE) && defined(_TITLE)
+        _In_ ID3D11DeviceX* d3dDevice,
+        _In_opt_ ID3D11DeviceContextX* d3dContext,
+#else
+        _In_ ID3D11Device* d3dDevice,
+        _In_opt_ ID3D11DeviceContext* d3dContext,
+#endif
+        _In_z_ const __wchar_t* szFileName,
+        _In_ size_t maxsize,
+        _In_ D3D11_USAGE usage,
+        _In_ unsigned int bindFlags,
+        _In_ unsigned int cpuAccessFlags,
+        _In_ unsigned int miscFlags,
+        _In_ WIC_LOADER_FLAGS loadFlags,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept
+    {
+        return CreateWICTextureFromFileEx(d3dDevice, d3dContext,
+            reinterpret_cast<const unsigned short*>(szFileName),
+            maxsize, usage, bindFlags, cpuAccessFlags, miscFlags, loadFlags, texture, textureView);
+    }
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/build/DirectXTK-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTK-GitHub-CMake-Dev17.yml
@@ -190,3 +190,13 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out11 -v --config RelWithDebInfo
+  - task: CMake@1
+    displayName: 'CMake (NO_WCHAR_T): Config'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out12 -DNO_WCHAR_T=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
+  - task: CMake@1
+    displayName: 'CMake (NO_WCHAR_T): Build'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out12 -v --config Debug

--- a/build/DirectXTK-GitHub-CMake.yml
+++ b/build/DirectXTK-GitHub-CMake.yml
@@ -202,3 +202,13 @@ jobs:
     inputs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out11 -v --config RelWithDebInfo
+  - task: CMake@1
+    displayName: 'CMake (NO_WCHAR_T): Config'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out12 -DNO_WCHAR_T=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
+  - task: CMake@1
+    displayName: 'CMake (NO_WCHAR_T): Build'
+    inputs:
+      cwd: '$(Build.SourcesDirectory)'
+      cmakeArgs: --build out12 -v --config Debug


### PR DESCRIPTION
Some usage scenarios build the library with ``/Zc:wchar_t-`` but mix both ``unsigned short*`` and ``wchar_t*`` client usage. For this *opt-in* build scenario, the library will link with both the non-native and native ``wchar_t``.

Note this works for general use, but not necessarily all use cases. For example, all the effect factory virtual methods are defined only using the type that matches the compiler setting for the library, as there's no easy way to provide an adapter for these. There are also some edge-cases like ``SpriteFont::GetDefaultCharacter`` that you can't use a link-time adapter because the overloading rules don't allow only differing by return type.

> Also fixes some Code Analysis warnings as you can't use ``_In_opt_`` with ``std::function<>`` or ``std::shared_ptr<>``.