### PR TITLE
Suppress some additional clang v16 warnings when upgrading to clangcl

### DIFF
--- a/Src/pch.h
+++ b/Src/pch.h
@@ -73,6 +73,8 @@
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-const-variable"
 #pragma clang diagnostic ignored "-Wunused-member-function"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #endif
 
 #ifndef WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
The CMake scenario already disables the new clang v16 warning, but if you upgrade the VCXPROJ project to clangcl, it reappears.