### PR TITLE
Workaround clang/LLVM bug with /fp:fast+SSE+float_control

### DIFF
--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -950,6 +950,9 @@ void AudioEngine::Impl::AllocateVoice(
                         CreateXMA2(wfmt, sizeof(buff), defaultRate, wfx->nChannels, 65536, 2, 0);
                         break;
                     #endif
+
+                    default:
+                        throw std::invalid_argument("Unsupported wave format");
                     }
 
                 #ifdef VERBOSE_TRACE

--- a/Audio/DynamicSoundEffectInstance.cpp
+++ b/Audio/DynamicSoundEffectInstance.cpp
@@ -214,6 +214,7 @@ void DynamicSoundEffectInstance::Impl::OnUpdate()
     const DWORD result = WaitForSingleObjectEx(mBufferEvent.get(), 0, FALSE);
     switch (result)
     {
+    default:
     case WAIT_TIMEOUT:
         break;
 

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -237,6 +237,7 @@ public:
         HANDLE events[] = { mBufferRead.get(), mBufferEnd.get() };
         switch (WaitForMultipleObjectsEx(static_cast<DWORD>(std::size(events)), events, FALSE, 0, FALSE))
         {
+        default:
         case WAIT_TIMEOUT:
             break;
 

--- a/Audio/WaveBankReader.cpp
+++ b/Audio/WaveBankReader.cpp
@@ -184,6 +184,9 @@ namespace
                         return aWMABlockAlign[dwBlockAlignIndex];
                 }
                 break;
+
+            default:
+                break;
             }
 
             return 0;
@@ -224,6 +227,9 @@ namespace
                     if (dwBytesPerSecIndex < 7)
                         return aWMAAvgBytesPerSec[dwBytesPerSecIndex];
                 }
+                break;
+
+            default:
                 break;
             }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,7 +377,7 @@ endif()
 # Model uses dynamic_cast, so we need /GR (Enable RTTI)
 if(MSVC)
     foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-      target_compile_options(${t} PRIVATE /Wall /GR /fp:fast "$<$<NOT:$<CONFIG:DEBUG>>:/guard:cf>")
+      target_compile_options(${t} PRIVATE /Wall /GR "$<$<NOT:$<CONFIG:DEBUG>>:/guard:cf>")
       target_link_options(${t} PRIVATE /DYNAMICBASE /NXCOMPAT /INCREMENTAL:NO)
     endforeach()
 
@@ -452,7 +452,7 @@ if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
     endif()
     target_compile_options(${PROJECT_NAME} PRIVATE ${WarningsLib})
 
-    set(WarningsEXE ${WarningsLib} "-Wno-c++98-compat" "-Wno-c++98-compat-pedantic"
+    set(WarningsEXE ${WarningsLib} "-Wno-c++98-compat" "-Wno-c++98-compat-pedantic" "-Wno-switch-default"
         "-Wno-double-promotion" "-Wno-exit-time-destructors" "-Wno-gnu-anonymous-struct"
         "-Wno-missing-prototypes" "-Wno-nested-anon-types" "-Wno-unused-const-variable")
     foreach(t IN LISTS TOOL_EXES)
@@ -464,7 +464,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     endforeach()
 elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-      target_compile_options(${t} PRIVATE /sdl /permissive- /JMC- /Zc:__cplusplus /Zc:inline)
+      target_compile_options(${t} PRIVATE /sdl /permissive- /JMC- /Zc:__cplusplus /Zc:inline /fp:fast)
     endforeach()
 
     if(ENABLE_CODE_ANALYSIS)

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -363,6 +363,9 @@ namespace
                 }
             }
             break;
+
+        default:
+            return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
         }
 
         return hr;

--- a/Src/Keyboard.cpp
+++ b/Src/Keyboard.cpp
@@ -571,6 +571,9 @@ void Keyboard::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
             vk = LOWORD(MapVirtualKeyW(static_cast<UINT>(scanCode), MAPVK_VSC_TO_VK_EX));
         }
         break;
+
+    default:
+        break;
     }
 
     if (down)

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -781,6 +781,9 @@ namespace DirectX
 
                     // No 3:3:2 or paletted DXGI formats aka D3DFMT_R3G3B2, D3DFMT_P8
                     break;
+
+                default:
+                    return DXGI_FORMAT_UNKNOWN;
                 }
             }
             else if (ddpf.flags & DDS_LUMINANCE)
@@ -811,6 +814,9 @@ namespace DirectX
                         return DXGI_FORMAT_R8G8_UNORM; // Some DDS writers assume the bitcount should be 8 instead of 16
                     }
                     break;
+
+                default:
+                    return DXGI_FORMAT_UNKNOWN;
                 }
             }
             else if (ddpf.flags & DDS_ALPHA)
@@ -843,6 +849,9 @@ namespace DirectX
                         return DXGI_FORMAT_R8G8_SNORM; // D3DX10/11 writes this out as DX10 extension
                     }
                     break;
+
+                default:
+                    return DXGI_FORMAT_UNKNOWN;
                 }
 
                 // No DXGI format maps to DDPF_BUMPLUMINANCE aka D3DFMT_L6V5U5, D3DFMT_X8L8V8U8
@@ -943,6 +952,9 @@ namespace DirectX
                     return DXGI_FORMAT_R32G32B32A32_FLOAT;
 
                 // No DXGI format maps to D3DFMT_CxV8U8
+
+                default:
+                    return DXGI_FORMAT_UNKNOWN;
                 }
             }
 

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -1497,6 +1497,9 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
         case XBUTTON2:
             pImpl->mState.xButton2 = true;
             break;
+
+        default:
+            break;
         }
         break;
 
@@ -1509,6 +1512,9 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
 
         case XBUTTON2:
             pImpl->mState.xButton2 = false;
+            break;
+
+        default:
             break;
         }
         break;


### PR DESCRIPTION
The clang/LLVM toolset currently does not respect the ``float_control`` pragma for SSE instrinsics. Therefore, the use of ``/fp:fast`` is not recommended on clang/LLVM until this issue is fixed. See [55713](https://github.com/llvm/llvm-project/issues/55713).

Also includes a minor update for warnings found under clang v18.1.0 RC
