### PR TITLE
fix warning for MSVC pragma syntax

### DIFF
--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -1480,15 +1480,19 @@ X3DAUDIO_HANDLE& AudioEngine::Get3DHandle() const noexcept
 // you will need to modify the library to use this codepath for Windows desktop
 // -or- use XAudio2Redist -or- use XAudio 2.8.
 
+#ifdef _MSC_VER
 #pragma comment(lib,"runtimeobject.lib")
 #pragma warning(push)
 #pragma warning(disable: 4471 5204 5256)
+#endif
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wnonportable-system-include-path"
 #endif
 #include <Windows.Devices.Enumeration.h>
 #include <Windows.Media.Devices.h>
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 #include <wrl.h>
 

--- a/Audio/DynamicSoundEffectInstance.cpp
+++ b/Audio/DynamicSoundEffectInstance.cpp
@@ -237,7 +237,9 @@ void DynamicSoundEffectInstance::Impl::OnUpdate()
 // DynamicSoundEffectInstance
 //--------------------------------------------------------------------------------------
 
+#ifdef _MSC_VER
 #pragma warning( disable : 4355 )
+#endif
 
 // Public constructors
 _Use_decl_annotations_

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -29,7 +29,9 @@ using namespace DirectX;
 #pragma clang diagnostic ignored "-Wcovered-switch-default"
 #endif
 
+#ifdef _MSC_VER
 #pragma warning(disable : 4061 4062)
+#endif
 
 //#define VERBOSE_TRACE
 

--- a/Audio/WaveBankReader.cpp
+++ b/Audio/WaveBankReader.cpp
@@ -100,7 +100,9 @@ namespace
         }
     };
 
+#ifdef _MSC_VER
 #pragma warning( disable : 4201 4203 )
+#endif
 
     union MINIWAVEFORMAT
     {

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -25,7 +25,9 @@
 
 #if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
 #include <xma2defs.h>
+#ifdef _MSC_VER
 #pragma comment(lib,"acphal.lib")
+#endif
 #endif
 
 #ifndef XAUDIO2_HELPER_FUNCTIONS
@@ -45,14 +47,18 @@
 #include <xaudio2.h>
 #include <xaudio2fx.h>
 
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4619 4616 5246)
+#endif
 #include <x3daudio.h>
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 #include <xapofx.h>
 
-#ifndef USING_XAUDIO2_REDIST
+#if !defined(USING_XAUDIO2_REDIST) && defined(_MSC_VER)
 #if defined(USING_XAUDIO2_8) && defined(NTDDI_WIN10) && !defined(_M_IX86)
 // The xaudio2_8.lib in the Windows 10 SDK for x86 is incorrectly annotated as __cdecl instead of __stdcall, so avoid using it in this case.
 #pragma comment(lib,"xaudio2_8.lib")

--- a/Inc/DirectXHelpers.h
+++ b/Inc/DirectXHelpers.h
@@ -15,9 +15,11 @@
 #include <d3d11_1.h>
 #endif
 
+#ifdef _MSC_VER
 #if !defined(NO_D3D11_DEBUG_NAME) && ( defined(_DEBUG) || defined(PROFILE) )
 #if !defined(_XBOX_ONE) || !defined(_TITLE)
 #pragma comment(lib,"dxguid.lib")
+#endif
 #endif
 #endif
 

--- a/Inc/GamePad.h
+++ b/Inc/GamePad.h
@@ -28,24 +28,27 @@
 
 #ifdef USING_GAMEINPUT
 #include <GameInput.h>
-#ifndef _GAMING_XBOX
+#if !defined(_GAMING_XBOX) && defined(_MSC_VER)
 #pragma comment(lib,"gameinput.lib")
 #endif
 
 #elif defined(USING_WINDOWS_GAMING_INPUT)
+#ifdef _MSC_VER
 #pragma comment(lib,"runtimeobject.lib")
+#endif
 #include <string>
 
 #elif defined(_XBOX_ONE)
 // Legacy Xbox One XDK uses Windows::Xbox::Input
 
 #elif defined(USING_XINPUT)
+#ifdef _MSC_VER
 #if (_WIN32_WINNT >= 0x0602 /*_WIN32_WINNT_WIN8*/ )
 #pragma comment(lib,"xinput.lib")
 #else
 #pragma comment(lib,"xinput9_1_0.lib")
 #endif
-
+#endif
 #endif
 
 #include <cstdint>

--- a/Inc/Keyboard.h
+++ b/Inc/Keyboard.h
@@ -24,7 +24,7 @@
 
 #endif // !USING_XINPUT && !USING_GAMEINPUT && !USING_WINDOWS_GAMING_INPUT
 
-#if defined(USING_GAMEINPUT) && !defined(_GAMING_XBOX)
+#if defined(USING_GAMEINPUT) && !defined(_GAMING_XBOX) && defined(_MSC_VER)
 #pragma comment(lib,"gameinput.lib")
 #endif
 

--- a/Inc/Mouse.h
+++ b/Inc/Mouse.h
@@ -24,7 +24,7 @@
 
 #endif // !USING_XINPUT && !USING_GAMEINPUT && !USING_WINDOWS_GAMING_INPUT
 
-#if defined(USING_GAMEINPUT) && !defined(_GAMING_XBOX)
+#if defined(USING_GAMEINPUT) && !defined(_GAMING_XBOX) && defined(_MSC_VER)
 #pragma comment(lib,"gameinput.lib")
 #endif
 

--- a/Inc/ScreenGrab.h
+++ b/Inc/ScreenGrab.h
@@ -31,7 +31,9 @@
 #include <OCIdl.h>
 #endif
 
+#ifdef _MSC_VER
 #pragma comment(lib,"uuid.lib")
+#endif
 
 
 namespace DirectX

--- a/Inc/WICTextureLoader.h
+++ b/Inc/WICTextureLoader.h
@@ -32,7 +32,9 @@
 #include <cstddef>
 #include <cstdint>
 
+#ifdef _MSC_VER
 #pragma comment(lib,"uuid.lib")
+#endif
 
 
 namespace DirectX

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -420,10 +420,14 @@ bool GamePad::GetDevice(int player, _Outptr_ IGameInputDevice * *device) noexcep
 // Windows::Gaming::Input (Windows 10)
 //======================================================================================
 
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4471 5204 5256)
+#endif
 #include <windows.gaming.input.h>
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 class GamePad::Impl
 {
@@ -1624,7 +1628,9 @@ GamePad::Impl* GamePad::Impl::s_gamePad = nullptr;
 #endif
 #pragma endregion
 
+#ifdef _MSC_VER
 #pragma warning( disable : 4355 )
+#endif
 
 // Public constructor.
 GamePad::GamePad() noexcept(false)

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -269,7 +269,9 @@ GraphicsMemory::Impl* GraphicsMemory::Impl::s_graphicsMemory = nullptr;
 
 //--------------------------------------------------------------------------------------
 
+#ifdef _MSC_VER
 #pragma warning( disable : 4355 )
+#endif
 
 // Public constructor.
 #if defined(_XBOX_ONE) && defined(_TITLE)

--- a/Src/Keyboard.cpp
+++ b/Src/Keyboard.cpp
@@ -589,7 +589,9 @@ void Keyboard::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
 #endif
 #pragma endregion
 
+#ifdef _MSC_VER
 #pragma warning( disable : 4355 )
+#endif
 
 // Public constructor.
 Keyboard::Keyboard() noexcept(false)

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -1541,7 +1541,9 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
 #endif
 #pragma endregion
 
+#ifdef _MSC_VER
 #pragma warning( disable : 4355 )
+#endif
 
 // Public constructor.
 Mouse::Mouse() noexcept(false)

--- a/Src/PlatformHelpers.h
+++ b/Src/PlatformHelpers.h
@@ -10,7 +10,9 @@
 
 #pragma once
 
+#ifdef _MSC_VER
 #pragma warning(disable : 4324)
+#endif
 
 #include <exception>
 #include <memory>

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#ifdef _MSC_VER
 // Off by default warnings
 #pragma warning(disable : 4619 4616 4061 4265 4365 4571 4623 4625 4626 4628 4668 4710 4711 4746 4774 4820 4987 5026 5027 5031 5032 5039 5045 5219 5264 26812)
 // C4619/4616 #pragma warning warnings
@@ -47,6 +48,7 @@
 #pragma warning(disable : 4643 5043)
 // C4643 Forward declaring in namespace std is not permitted by the C++ Standard
 // C5043 exception specification does not match previous declaration
+#endif
 
 #ifdef __INTEL_COMPILER
 #pragma warning(disable : 161 2960 3280)

--- a/XWBTool/xwbtool.cpp
+++ b/XWBTool/xwbtool.cpp
@@ -14,8 +14,10 @@
 // http://go.microsoft.com/fwlink/?LinkId=248929
 //--------------------------------------------------------------------------------------
 
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4005)
+#endif
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #define NODRAWTEXT
@@ -24,7 +26,9 @@
 #define NOMCX
 #define NOSERVICE
 #define NOHELP
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 #include <Windows.h>
 
@@ -170,7 +174,9 @@ namespace
         REGION      Segments[SEGIDX_COUNT]; // Segment lookup table
     };
 
+#ifdef _MSC_VER
 #pragma warning( disable : 4201 4203 )
+#endif
 
     union MINIWAVEFORMAT
     {


### PR DESCRIPTION
Guard pragmas specific to MSVC-like compilers