### PR TITLE
Update compiler build settings for CMake

### DIFF
--- a/build/CompilerAndLinker.cmake
+++ b/build/CompilerAndLinker.cmake
@@ -66,6 +66,10 @@ elseif(NOT (${DIRECTX_ARCH} MATCHES "^arm"))
         set(ARCH_SSE2 $<$<NOT:$<CXX_COMPILER_ID:MSVC,Intel>>:-msse2>)
     endif()
 
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        list(APPEND ARCH_SSE2 -mfpmath=sse)
+    endif()
+
     list(APPEND COMPILER_SWITCHES ${ARCH_SSE2})
 endif()
 

--- a/build/DirectXTK-GitHub-Dev17.yml
+++ b/build/DirectXTK-GitHub-Dev17.yml
@@ -13,13 +13,21 @@ schedules:
     - main
 
 trigger: none
-pr: none
+
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/DirectXTK-GitHub-Dev17.yml
 
 resources:
   repositories:
   - repository: self
     type: git
     ref: refs/heads/main
+    trigger: none
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 

--- a/build/DirectXTK-GitHub-GDK-Dev17.yml
+++ b/build/DirectXTK-GitHub-GDK-Dev17.yml
@@ -13,13 +13,21 @@ schedules:
     - main
 
 trigger: none
-pr: none
+
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/DirectXTK-GitHub-GDK-Dev17.yml
 
 resources:
   repositories:
   - repository: self
     type: git
     ref: refs/heads/main
+    trigger: none
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 

--- a/build/DirectXTK-GitHub-Test-Dev17.yml
+++ b/build/DirectXTK-GitHub-Test-Dev17.yml
@@ -13,13 +13,21 @@ schedules:
     - main
 
 trigger: none
-pr: none
+
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - build/DirectXTK-GitHub-Test-Dev17.yml
 
 resources:
   repositories:
   - repository: self
     type: git
     ref: refs/heads/main
+    trigger: none
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 

--- a/build/DirectXTK-GitHub-WSL-11.yml
+++ b/build/DirectXTK-GitHub-WSL-11.yml
@@ -13,7 +13,17 @@ schedules:
     - main
 
 trigger: none
-pr: none
+
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - CMake*
+    - build/*.cmake
+    - build/*.in
+    - build/DirectXTK-GitHub-WSL-11.yml
 
 resources:
   repositories:


### PR DESCRIPTION

* GNU still defaults to x87 math code-gen on x86, so this opts into SSE/SSE2 math generation.