### PR TITLE
Rename Internal namespace to ToolKitInternal for some conformance issues

### DIFF
--- a/Src/ScreenGrab.cpp
+++ b/Src/ScreenGrab.cpp
@@ -347,7 +347,7 @@ namespace DirectX
 {
     inline namespace DX11
     {
-        namespace Internal
+        namespace ToolKitInternal
         {
             extern bool IsWIC2() noexcept;
             extern IWICImagingFactory* GetWIC() noexcept;
@@ -365,7 +365,7 @@ HRESULT DirectX::SaveWICTextureToFile(
     std::function<void(IPropertyBag2*)> setCustomProps,
     bool forceSRGB)
 {
-    using namespace DX11::Internal;
+    using namespace DX11::ToolKitInternal;
 
     if (!fileName)
         return E_INVALIDARG;

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -194,7 +194,7 @@ namespace DirectX
 {
     inline namespace DX11
     {
-        namespace Internal
+        namespace ToolKitInternal
         {
             bool IsWIC2() noexcept;
             IWICImagingFactory* GetWIC() noexcept;
@@ -203,12 +203,12 @@ namespace DirectX
     }
 }
 
-bool DirectX::DX11::Internal::IsWIC2() noexcept
+bool DirectX::DX11::ToolKitInternal::IsWIC2() noexcept
 {
     return g_WIC2;
 }
 
-IWICImagingFactory* DirectX::DX11::Internal::GetWIC() noexcept
+IWICImagingFactory* DirectX::DX11::ToolKitInternal::GetWIC() noexcept
 {
     static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
 
@@ -225,7 +225,7 @@ IWICImagingFactory* DirectX::DX11::Internal::GetWIC() noexcept
     return factory;
 }
 
-using namespace DirectX::DX11::Internal;
+using namespace DirectX::DX11::ToolKitInternal;
 
 namespace
 {


### PR DESCRIPTION
I used the ``DirectX::Internal`` namespace in some other contents, and in particular I used an inline namespace ``DirectX::DX11`` with an ``Internal`` namespace. This confuses some compilers and resulted in build failures. As a solution, I just renamed the internal namespaces to something more unique.