### PR TITLE
June 4, 2024

### DIFF
--- a/.nuget/directxtk_desktop_2019.nuspec
+++ b/.nuget/directxtk_desktop_2019.nuspec
@@ -30,7 +30,7 @@ SpriteBatch - simple &amp; efficient 2D sprite rendering
 SpriteFont - bitmap based text rendering
 VertexTypes - structures for commonly used vertex data formats
 WICTextureLoader - WIC-based image file texture loader</description>
-        <releaseNotes>Matches the February 21, 2024 release on GitHub.
+        <releaseNotes>Matches the June 4, 2024 release on GitHub.
 
 DirectX Tool Kit for Audio in this package uses XAudio2Redist NuGet package to support Windows 7 or later.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkId=248929</projectUrl>

--- a/.nuget/directxtk_desktop_win10.nuspec
+++ b/.nuget/directxtk_desktop_win10.nuspec
@@ -30,7 +30,7 @@ SpriteBatch - simple &amp; efficient 2D sprite rendering
 SpriteFont - bitmap based text rendering
 VertexTypes - structures for commonly used vertex data formats
 WICTextureLoader - WIC-based image file texture loader</description>
-        <releaseNotes>Matches the February 21, 2024 release on GitHub.
+        <releaseNotes>Matches the June 4, 2024 release on GitHub.
 
 DirectX Tool Kit for Audio in this package uses XAudio 2.9 which requires Windows 10 or later.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkId=248929</projectUrl>

--- a/.nuget/directxtk_uwp.nuspec
+++ b/.nuget/directxtk_uwp.nuspec
@@ -30,7 +30,7 @@ SpriteBatch - simple &amp; efficient 2D sprite rendering
 SpriteFont - bitmap based text rendering
 VertexTypes - structures for commonly used vertex data formats
 WICTextureLoader - WIC-based image file texture loader</description>
-        <releaseNotes>Matches the February 21, 2024 release on GitHub.</releaseNotes>
+        <releaseNotes>Matches the June 4, 2024 release on GitHub.</releaseNotes>
         <projectUrl>http://go.microsoft.com/fwlink/?LinkId=248929</projectUrl>
         <repository type="git" url="https://github.com/microsoft/DirectXTK.git" />
         <icon>images\icon.jpg</icon>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Release available for download on [GitHub](https://github.com/microsoft/DirectXT
 
 ## Release History
 
+### June 4, 2024
+* Renamed Internal namespace to ToolKitInternal for some conformance issues
+* CMake project updates
+* Retired VS 2019 projects for the UWP platform
+
 ### February 21, 2024
 * Project updates for GDK validation
 * CMake project updates and refactor including pkg-config file generation

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ http://go.microsoft.com/fwlink/?LinkId=248929
 
 Copyright (c) Microsoft Corporation.
 
-**February 21, 2024**
+**June 4, 2024**
 
 This package contains the "DirectX Tool Kit", a collection of helper classes for writing Direct3D 11 C++ code for Universal Windows Platform (UWP) apps for Windows 11, Windows 10, Xbox One, and Win32 desktop applications for Windows 7 Service Pack 1 or later.
 


### PR DESCRIPTION
* Renamed Internal namespace to ToolKitInternal for some conformance issues
* CMake project updates
* Retired VS 2019 projects for the UWP platform
