### PR TITLE
Added GitHub Actions for build and security analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,11 +48,11 @@ jobs:
         build-mode: manual
 
     - name: 'Configure CMake'
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
       run: cmake --preset=x64-Debug
 
     - name: 'Build'
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
       run: cmake --build out\build\x64-Debug
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248929
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
+  schedule:
+    - cron: '31 2 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze (C/C++)
+    runs-on: windows-latest
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      packages: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: c-cpp
+        build-mode: manual
+
+    - name: 'Configure CMake'
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: cmake --preset=x64-Debug
+
+    - name: 'Build'
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: cmake --build out\build\x64-Debug
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:c-cpp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,18 +25,24 @@ on:
 
 jobs:
   analyze:
-    name: Analyze (C/C++)
+    name: Analyze (${{ matrix.language }})
     runs-on: windows-latest
     timeout-minutes: 360
     permissions:
       security-events: write
       packages: read
 
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [c-cpp, csharp]
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: 'Install Ninja'
+    - if: matrix.language == 'c-cpp'
+      name: 'Install Ninja'
       run: choco install ninja
 
     - uses: ilammy/msvc-dev-cmd@v1
@@ -44,18 +50,25 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
-        languages: c-cpp
+        languages: ${{ matrix.language }}
         build-mode: manual
 
-    - name: 'Configure CMake'
+    - if: matrix.language == 'c-cpp'
+      name: 'Configure CMake (C/C++)'
       working-directory: ${{ github.workspace }}
       run: cmake --preset=x64-Debug
 
-    - name: 'Build'
+    - if: matrix.language == 'c-cpp'
+      name: 'Build (C/C++)'
       working-directory: ${{ github.workspace }}
       run: cmake --build out\build\x64-Debug
+
+    - if: matrix.language == 'csharp'
+      name: 'Build (C#)'
+      working-directory: ./MakeSpriteFont
+      run: msbuild MakeSpriteFont.csproj /p:Configuration=Debug /p:Platform=AnyCPU
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:
-        category: "/language:c-cpp"
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,3 +87,13 @@ jobs:
     - name: 'Build'
       working-directory: ${{ github.workspace }}
       run: cmake --build out\build\${{ matrix.build_type }}
+
+    - if: matrix.arch != 'amd64_arm64'
+      name: 'Configure CMake (Spectre)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --preset=${{ matrix.build_type }} -DENABLE_SPECTRE_MITIGATION=ON
+
+    - if: matrix.arch != 'amd64_arm64'
+      name: 'Build (Spectre)'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,16 +58,16 @@ jobs:
             build_type: x86-Release-Clang
             arch: amd64_x86
           - os: windows-2022
-            build_type: arm64-Debug-Win10
+            build_type: arm64-Debug
             arch: amd64_arm64
           - os: windows-2022
-            build_type: arm64-Release-Win10
+            build_type: arm64-Release
             arch: amd64_arm64
           - os: windows-2022
-            build_type: arm64ec-Debug-Win10
+            build_type: arm64ec-Debug
             arch: amd64_arm64
           - os: windows-2022
-            build_type: arm64ec-Release-Win10
+            build_type: arm64ec-Release
             arch: amd64_arm64
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,89 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248929
+
+name: 'CMake (Windows)'
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props      
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [windows-2019, windows-2022]
+        build_type: [x64-Debug, x64-Release, x64-Debug-Clang, x64-Release-Clang]
+        arch: [amd64]
+        include:
+          - os: windows-2019
+            build_type: x86-Debug
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Release
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Release-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Debug
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Release
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Release-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: arm64-Debug-Win10
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64-Release-Win10
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Debug-Win10
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Release-Win10
+            arch: amd64_arm64
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.arch }}
+
+    - name: 'Configure CMake'
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: cmake --preset=${{ matrix.build_type }}
+
+    - name: 'Build'
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ on:
       - '.nuget/*'
       - build/*.cmd
       - build/*.json
-      - build/*.props      
+      - build/*.props
       - build/*.ps1
       - build/*.targets
       - build/*.yml
@@ -81,9 +81,9 @@ jobs:
         arch: ${{ matrix.arch }}
 
     - name: 'Configure CMake'
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
       run: cmake --preset=${{ matrix.build_type }}
 
     - name: 'Build'
-      working-directory: ${{env.GITHUB_WORKSPACE}}
+      working-directory: ${{ github.workspace }}
       run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -60,3 +60,13 @@ jobs:
       name: 'Build (UWP)'
       working-directory: ${{ github.workspace }}
       run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Windows10_2022.sln
+
+    - if: matrix.platform != 'ARM64'
+      name: 'Build (Spectre)'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:SpectreMitigation=Spectre /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Desktop_${{ matrix.vs }}.sln
+
+    - if: matrix.platform != 'ARM64'
+      name: 'Build (Spectre Windows 10)'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:SpectreMitigation=Spectre /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Desktop_${{ matrix.vs }}_Win10.sln

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,62 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248929
+
+name: MSBuild
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-${{ matrix.vs }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        vs: [2019, 2022]
+        build_type: [Debug, Release]
+        platform: [x86, x64, ARM64]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - if: matrix.platform != 'ARM64'
+      name: Build
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Desktop_${{ matrix.vs }}.sln
+
+    - name: 'Build (Windows 10)'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Desktop_${{ matrix.vs }}_Win10.sln
+
+    - if: matrix.platform != 'ARM64'
+      name: Restore NuGet packages
+      working-directory: ${{ github.workspace }}
+      run: nuget restore ./DirectXTK_Desktop_${{ matrix.vs }}_Win7.sln
+
+    - if: matrix.platform != 'ARM64'
+      name: 'Build (Windows 7)'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Desktop_${{ matrix.vs }}_Win7.sln
+
+    - if: matrix.vs == '2022'
+      name: 'Build (UWP)'
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./DirectXTK_Windows10_2022.sln

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -40,8 +40,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure CMake
-        working-directory: ${{env.GITHUB_WORKSPACE}}
+        working-directory: ${{ github.workspace }}
         run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+
+      - name: 'Build Shaders'
+        shell: cmd
+        working-directory: ./Src/Shaders
+        run: CompileShaders.cmd
+        env:
+          CompileShadersOutput: ${{ github.workspace }}/out/Shaders/Compiled
 
       - name: Initialize MSVC Code Analysis
         uses: microsoft/msvc-code-analysis-action@v0.1.1

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -39,6 +39,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64
+
       - name: Configure CMake
         working-directory: ${{ github.workspace }}
         run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -16,7 +16,7 @@ on:
       - '.nuget/*'
       - build/*.cmd
       - build/*.json
-      - build/*.props      
+      - build/*.props
       - build/*.ps1
       - build/*.targets
       - build/*.yml

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248929
+
+name: Microsoft C++ Code Analysis
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props      
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
+  schedule:
+    - cron: '25 15 * * 5'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    name: Analyze
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        run: cmake -B out -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+
+      - name: Initialize MSVC Code Analysis
+        uses: microsoft/msvc-code-analysis-action@v0.1.1
+        id: run-analysis
+        with:
+          cmakeBuildDirectory: ./out
+          buildConfiguration: Debug
+          ruleset: NativeRecommendedRules.ruleset
+
+      # Upload SARIF file to GitHub Code Scanning Alerts
+      - name: Upload SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.run-analysis.outputs.sarif }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}
-      run: cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON -DBUILD_TOOLS=OFF
 
     - name: 'Build'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,103 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248929
+
+name: 'CTest (Windows)'
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
+      - build/*.yml
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [windows-2019, windows-2022]
+        build_type: [x64-Debug, x64-Release, x64-Debug-Clang, x64-Release-Clang]
+        arch: [amd64]
+        include:
+          - os: windows-2019
+            build_type: x86-Debug
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Release
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - os: windows-2019
+            build_type: x86-Release-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Debug
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Release
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Debug-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: x86-Release-Clang
+            arch: amd64_x86
+          - os: windows-2022
+            build_type: arm64-Debug
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64-Release
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Debug
+            arch: amd64_arm64
+          - os: windows-2022
+            build_type: arm64ec-Release
+            arch: amd64_arm64
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Clone test repository
+      uses: actions/checkout@v4
+      with:
+        repository: walbourn/directxtktest
+        path: Tests
+        ref: main
+
+    - name: 'Install Ninja'
+      run: choco install ninja
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.arch }}
+
+    - name: 'Configure CMake'
+      working-directory: ${{ github.workspace }}
+      run: cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON
+
+    - name: 'Build'
+      working-directory: ${{ github.workspace }}
+      run: cmake --build out\build\${{ matrix.build_type }}
+
+    - if: (matrix.build_type == 'x64-Release') || (matrix.build_type == 'x86-Release')
+      timeout-minutes: 10
+      name: 'Test (Math only)'
+      working-directory: ${{ github.workspace }}
+      run: ctest --preset=${{ matrix.build_type }} -L Math

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,16 +59,16 @@ jobs:
             build_type: x86-Release-Clang
             arch: amd64_x86
           - os: windows-2022
-            build_type: arm64-Debug-Win10
+            build_type: arm64-Debug
             arch: amd64_arm64
           - os: windows-2022
-            build_type: arm64-Release-Win10
+            build_type: arm64-Release
             arch: amd64_arm64
           - os: windows-2022
-            build_type: arm64ec-Debug-Win10
+            build_type: arm64ec-Debug
             arch: amd64_arm64
           - os: windows-2022
-            build_type: arm64ec-Release-Win10
+            build_type: arm64ec-Release
             arch: amd64_arm64
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,16 +59,16 @@ jobs:
             build_type: x86-Release-Clang
             arch: amd64_x86
           - os: windows-2022
-            build_type: arm64-Debug
+            build_type: arm64-Debug-Win10
             arch: amd64_arm64
           - os: windows-2022
-            build_type: arm64-Release
+            build_type: arm64-Release-Win10
             arch: amd64_arm64
           - os: windows-2022
-            build_type: arm64ec-Debug
+            build_type: arm64ec-Debug-Win10
             arch: amd64_arm64
           - os: windows-2022
-            build_type: arm64ec-Release
+            build_type: arm64ec-Release-Win10
             arch: amd64_arm64
 
     steps:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -287,12 +287,12 @@
     { "name": "x64-Fuzzing"  , "description": "MSVC for x64 (Release) with ASan", "inherits": [ "base", "x64", "Release", "MSVC", "Win10", "Fuzzing" ] }
   ],
   "testPresets": [
-    { "name": "x64-Debug"    , "configurePreset": "x64-Debug" },
-    { "name": "x64-Release"  , "configurePreset": "x64-Release" },
-    { "name": "x86-Debug"    , "configurePreset": "x86-Debug" },
-    { "name": "x86-Release"  , "configurePreset": "x86-Release" },
-    { "name": "arm64-Debug"  , "configurePreset": "arm64-Debug-Win10" },
-    { "name": "arm64-Release", "configurePreset": "arm64-Release-Win10" },
+    { "name": "x64-Debug"      , "configurePreset": "x64-Debug" },
+    { "name": "x64-Release"    , "configurePreset": "x64-Release" },
+    { "name": "x86-Debug"      , "configurePreset": "x86-Debug" },
+    { "name": "x86-Release"    , "configurePreset": "x86-Release" },
+    { "name": "arm64-Debug"    , "configurePreset": "arm64-Debug-Win10" },
+    { "name": "arm64-Release"  , "configurePreset": "arm64-Release-Win10" },
     { "name": "arm64ec-Debug"  , "configurePreset": "arm64ec-Debug-Win10" },
     { "name": "arm64ec-Release", "configurePreset": "arm64ec-Release-Win10" },
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -293,6 +293,8 @@
     { "name": "x86-Release"  , "configurePreset": "x86-Release" },
     { "name": "arm64-Debug"  , "configurePreset": "arm64-Debug-Win10" },
     { "name": "arm64-Release", "configurePreset": "arm64-Release-Win10" },
+    { "name": "arm64ec-Debug"  , "configurePreset": "arm64ec-Debug-Win10" },
+    { "name": "arm64ec-Release", "configurePreset": "arm64ec-Release-Win10" },
 
     { "name": "x64-Debug-Win7"    , "configurePreset": "x64-Debug-Win7" },
     { "name": "x64-Release-Win7"  , "configurePreset": "x64-Release-Win7" },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -287,14 +287,14 @@
     { "name": "x64-Fuzzing"  , "description": "MSVC for x64 (Release) with ASan", "inherits": [ "base", "x64", "Release", "MSVC", "Win10", "Fuzzing" ] }
   ],
   "testPresets": [
-    { "name": "x64-Debug"      , "configurePreset": "x64-Debug" },
-    { "name": "x64-Release"    , "configurePreset": "x64-Release" },
-    { "name": "x86-Debug"      , "configurePreset": "x86-Debug" },
-    { "name": "x86-Release"    , "configurePreset": "x86-Release" },
-    { "name": "arm64-Debug"    , "configurePreset": "arm64-Debug-Win10" },
-    { "name": "arm64-Release"  , "configurePreset": "arm64-Release-Win10" },
-    { "name": "arm64ec-Debug"  , "configurePreset": "arm64ec-Debug-Win10" },
-    { "name": "arm64ec-Release", "configurePreset": "arm64ec-Release-Win10" },
+    { "name": "x64-Debug"            , "configurePreset": "x64-Debug" },
+    { "name": "x64-Release"          , "configurePreset": "x64-Release" },
+    { "name": "x86-Debug"            , "configurePreset": "x86-Debug" },
+    { "name": "x86-Release"          , "configurePreset": "x86-Release" },
+    { "name": "arm64-Debug-Win10"    , "configurePreset": "arm64-Debug-Win10" },
+    { "name": "arm64-Release-Win10"  , "configurePreset": "arm64-Release-Win10" },
+    { "name": "arm64ec-Debug-Win10"  , "configurePreset": "arm64ec-Debug-Win10" },
+    { "name": "arm64ec-Release-Win10", "configurePreset": "arm64ec-Release-Win10" },
 
     { "name": "x64-Debug-Win7"    , "configurePreset": "x64-Debug-Win7" },
     { "name": "x64-Release-Win7"  , "configurePreset": "x64-Release-Win7" },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -212,14 +212,15 @@
     { "name": "x86-Debug"    , "description": "MSVC for x86 (Debug) for Windows 8", "inherits": [ "base", "x86", "Debug", "MSVC" ] },
     { "name": "x86-Release"  , "description": "MSVC for x86 (Release) for Windows 8", "inherits": [ "base", "x86", "Release", "MSVC" ] },
 
-    { "name": "x64-Debug-Win10"    , "description": "MSVC for x64 (Debug) for Windows 10", "inherits": [ "base", "x64", "Debug", "MSVC", "Win10" ] },
-    { "name": "x64-Release-Win10"  , "description": "MSVC for x64 (Release) for Windows 10", "inherits": [ "base", "x64", "Release", "MSVC", "Win10" ] },
-    { "name": "x86-Debug-Win10"    , "description": "MSVC for x86 (Debug) for Windows 10", "inherits": [ "base", "x86", "Debug", "MSVC", "Win10" ] },
-    { "name": "x86-Release-Win10"  , "description": "MSVC for x86 (Release) for Windows 10", "inherits": [ "base", "x86", "Release", "MSVC", "Win10" ] },
-    { "name": "arm64-Debug-Win10"  , "description": "MSVC for ARM64 (Debug) for Windows 10", "inherits": [ "base", "ARM64", "Debug", "MSVC", "Win10" ] },
-    { "name": "arm64-Release-Win10", "description": "MSVC for ARM64 (Release) for Windows 10", "inherits": [ "base", "ARM64", "Release", "MSVC", "Win10" ] },
-    { "name": "arm64ec-Debug-Win10"  , "description": "MSVC for ARM64EC (Debug) for Windows 10", "inherits": [ "base", "ARM64EC", "Debug", "MSVC", "Win10" ], "environment": { "CXXFLAGS": "/arm64EC" } },
-    { "name": "arm64ec-Release-Win10", "description": "MSVC for ARM64EC (Release) for Windows 10", "inherits": [ "base", "ARM64EC", "Release", "MSVC", "Win10" ], "environment": { "CXXFLAGS": "/arm64EC" } },
+    { "name": "x64-Debug-Win10"   , "description": "MSVC for x64 (Debug) for Windows 10", "inherits": [ "base", "x64", "Debug", "MSVC", "Win10" ] },
+    { "name": "x64-Release-Win10" , "description": "MSVC for x64 (Release) for Windows 10", "inherits": [ "base", "x64", "Release", "MSVC", "Win10" ] },
+    { "name": "x86-Debug-Win10"   , "description": "MSVC for x86 (Debug) for Windows 10", "inherits": [ "base", "x86", "Debug", "MSVC", "Win10" ] },
+    { "name": "x86-Release-Win10" , "description": "MSVC for x86 (Release) for Windows 10", "inherits": [ "base", "x86", "Release", "MSVC", "Win10" ] },
+
+    { "name": "arm64-Debug"     , "description": "MSVC for ARM64 (Debug) for Windows 10", "inherits": [ "base", "ARM64", "Debug", "MSVC", "Win10" ] },
+    { "name": "arm64-Release"   , "description": "MSVC for ARM64 (Release) for Windows 10", "inherits": [ "base", "ARM64", "Release", "MSVC", "Win10" ] },
+    { "name": "arm64ec-Debug"   , "description": "MSVC for ARM64EC (Debug) for Windows 10", "inherits": [ "base", "ARM64EC", "Debug", "MSVC", "Win10" ], "environment": { "CXXFLAGS": "/arm64EC" } },
+    { "name": "arm64ec-Release" , "description": "MSVC for ARM64EC (Release) for Windows 10", "inherits": [ "base", "ARM64EC", "Release", "MSVC", "Win10" ], "environment": { "CXXFLAGS": "/arm64EC" } },
 
     { "name": "x64-Debug-UWP"    , "description": "MSVC for x64 (Debug) for UWP", "inherits": [ "base", "x64", "Debug", "MSVC", "UWP" ] },
     { "name": "x64-Release-UWP"  , "description": "MSVC for x64 (Release) for UWP", "inherits": [ "base", "x64", "Release", "MSVC", "UWP" ] },
@@ -243,8 +244,11 @@
     { "name": "x64-Release-VCPKG"  , "description": "MSVC for x64 (Release)", "inherits": [ "base", "x64", "Release", "MSVC", "VCPKG" ] },
     { "name": "x86-Debug-VCPKG"    , "description": "MSVC for x86 (Debug)", "inherits": [ "base", "x86", "Debug", "MSVC", "VCPKG" ] },
     { "name": "x86-Release-VCPKG"  , "description": "MSVC for x86 (Release)", "inherits": [ "base", "x86", "Release", "MSVC", "VCPKG" ] },
-    { "name": "arm64-Debug-VCPKG"  , "description": "MSVC for ARM64 (Debug)", "inherits": [ "base", "ARM64", "Debug", "MSVC", "VCPKG" ] },
-    { "name": "arm64-Release-VCPKG", "description": "MSVC for ARM64 (Release)", "inherits": [ "base", "ARM64", "Release", "MSVC", "VCPKG" ] },
+
+    { "name": "arm64-Debug-VCPKG"    , "description": "MSVC for ARM64 (Debug)", "inherits": [ "base", "ARM64", "Debug", "MSVC", "VCPKG", "Win10" ] },
+    { "name": "arm64-Release-VCPKG"  , "description": "MSVC for ARM64 (Release)", "inherits": [ "base", "ARM64", "Release", "MSVC", "VCPKG", "Win10" ] },
+    { "name": "arm64ec-Debug-VCPKG"  , "description": "MSVC for ARM64EC (Debug)", "inherits": [ "base", "ARM64EC", "Debug", "MSVC", "VCPKG", "Win10" ], "environment": { "CXXFLAGS": "/arm64EC" }, "cacheVariables": { "VCPKG_TARGET_TRIPLET": "arm64ec-windows" } },
+    { "name": "arm64ec-Release-VCPKG", "description": "MSVC for ARM64EC (Release)", "inherits": [ "base", "ARM64EC", "Release", "MSVC", "VCPKG", "Win10" ], "environment": { "CXXFLAGS": "/arm64EC" }, "cacheVariables": { "VCPKG_TARGET_TRIPLET": "arm64ec-windows" } },
 
     { "name": "x64-Debug-Clang"    , "description": "Clang/LLVM for x64 (Debug) for Windows 8", "inherits": [ "base", "x64", "Debug", "Clang" ] },
     { "name": "x64-Release-Clang"  , "description": "Clang/LLVM for x64 (Release) for Windows 8", "inherits": [ "base", "x64", "Release", "Clang" ] },
@@ -255,8 +259,9 @@
     { "name": "x64-Release-Win10-Clang"  , "description": "Clang/LLVM for x64 (Release) for Windows 10", "inherits": [ "base", "x64", "Release", "Clang", "Win10" ] },
     { "name": "x86-Debug-Win10-Clang"    , "description": "Clang/LLVM for x86 (Debug) for Windows 10", "inherits": [ "base", "x86", "Debug", "Clang", "Win10" ], "environment": { "CXXFLAGS": "-m32" } },
     { "name": "x86-Release-Win10-Clang"  , "description": "Clang/LLVM for x86 (Release) for Windows 10", "inherits": [ "base", "x86", "Release", "Clang", "Win10" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "arm64-Debug-Win10-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) for Windows 10", "inherits": [ "base", "ARM64", "Debug", "Clang", "Win10" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
-    { "name": "arm64-Release-Win10-Clang", "description": "Clang/LLVM for AArch64 (Release) for Windows 10", "inherits": [ "base", "ARM64", "Release", "Clang", "Win10" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+
+    { "name": "arm64-Debug-Clang"   , "description": "Clang/LLVM for AArch64 (Debug) for Windows 10", "inherits": [ "base", "ARM64", "Debug", "Clang", "Win10" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+    { "name": "arm64-Release-Clang" , "description": "Clang/LLVM for AArch64 (Release) for Windows 10", "inherits": [ "base", "ARM64", "Release", "Clang", "Win10" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
 
     { "name": "x64-Debug-UWP-Clang"    , "description": "Clang/LLVM for x64 (Debug) for UWP", "inherits": [ "base", "x64", "Debug", "Clang", "UWP" ] },
     { "name": "x64-Release-UWP-Clang"  , "description": "Clang/LLVM for x64 (Release) for UWP", "inherits": [ "base", "x64", "Release", "Clang", "UWP" ] },
@@ -287,14 +292,15 @@
     { "name": "x64-Fuzzing"  , "description": "MSVC for x64 (Release) with ASan", "inherits": [ "base", "x64", "Release", "MSVC", "Win10", "Fuzzing" ] }
   ],
   "testPresets": [
-    { "name": "x64-Debug"            , "configurePreset": "x64-Debug" },
-    { "name": "x64-Release"          , "configurePreset": "x64-Release" },
-    { "name": "x86-Debug"            , "configurePreset": "x86-Debug" },
-    { "name": "x86-Release"          , "configurePreset": "x86-Release" },
-    { "name": "arm64-Debug-Win10"    , "configurePreset": "arm64-Debug-Win10" },
-    { "name": "arm64-Release-Win10"  , "configurePreset": "arm64-Release-Win10" },
-    { "name": "arm64ec-Debug-Win10"  , "configurePreset": "arm64ec-Debug-Win10" },
-    { "name": "arm64ec-Release-Win10", "configurePreset": "arm64ec-Release-Win10" },
+    { "name": "x64-Debug"      , "configurePreset": "x64-Debug" },
+    { "name": "x64-Release"    , "configurePreset": "x64-Release" },
+    { "name": "x86-Debug"      , "configurePreset": "x86-Debug" },
+    { "name": "x86-Release"    , "configurePreset": "x86-Release" },
+
+    { "name": "arm64-Debug"    , "configurePreset": "arm64-Debug" },
+    { "name": "arm64-Release"  , "configurePreset": "arm64-Release" },
+    { "name": "arm64ec-Debug"  , "configurePreset": "arm64ec-Debug" },
+    { "name": "arm64ec-Release", "configurePreset": "arm64ec-Release" },
 
     { "name": "x64-Debug-Win7"    , "configurePreset": "x64-Debug-Win7" },
     { "name": "x64-Release-Win7"  , "configurePreset": "x64-Release-Win7" },
@@ -305,8 +311,8 @@
     { "name": "x64-Release-Clang"  , "configurePreset": "x64-Release-Clang" },
     { "name": "x86-Debug-Clang"    , "configurePreset": "x86-Debug-Clang" },
     { "name": "x86-Release-Clang"  , "configurePreset": "x86-Release-Clang" },
-    { "name": "arm64-Debug-Clang"  , "configurePreset": "arm64-Debug-Win10-Clang" },
-    { "name": "arm64-Release-Clang", "configurePreset": "arm64-Release-Win10-Clang" },
+    { "name": "arm64-Debug-Clang"  , "configurePreset": "arm64-Debug-Clang" },
+    { "name": "arm64-Release-Clang", "configurePreset": "arm64-Release-Clang" },
 
     { "name": "x64-Debug-MinGW"    , "configurePreset": "x64-Debug-MinGW" },
     { "name": "x64-Release-MinGW"  , "configurePreset": "x64-Release-MinGW" },

--- a/build/DirectXTK-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTK-GitHub-CMake-Dev17.yml
@@ -20,6 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -35,6 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/build/DirectXTK-GitHub-CMake-Dev17.yml
+++ b/build/DirectXTK-GitHub-CMake-Dev17.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkId=248929
 
-# Builds the library using CMake.
+# Builds the library using CMake with VS Generator (GitHub Actions covers Ninja).
 
 schedules:
 - cron: "0 4 * * *"

--- a/build/DirectXTK-GitHub-CMake.yml
+++ b/build/DirectXTK-GitHub-CMake.yml
@@ -20,6 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -35,6 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/build/DirectXTK-GitHub-CMake.yml
+++ b/build/DirectXTK-GitHub-CMake.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkId=248929
 
-# Builds the library using CMake.
+# Builds the library using CMake with VS Generator (GitHub Actions covers Ninja).
 
 schedules:
 - cron: "0 4 * * *"

--- a/build/DirectXTK-GitHub-Dev17.yml
+++ b/build/DirectXTK-GitHub-Dev17.yml
@@ -12,44 +12,15 @@ schedules:
     include:
     - main
 
-trigger:
-  branches:
-    include:
-    - main
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-
+# GitHub Actions handles MSBuild for CI/PR
+trigger: none
 pr:
   branches:
     include:
     - main
   paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-  drafts: false
+    include:
+    - build/DirectXTK-GitHub-Dev17.yml
 
 resources:
   repositories:

--- a/build/DirectXTK-GitHub-Dev17.yml
+++ b/build/DirectXTK-GitHub-Dev17.yml
@@ -21,6 +21,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd
@@ -39,6 +40,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd

--- a/build/DirectXTK-GitHub-GDK.yml
+++ b/build/DirectXTK-GitHub-GDK.yml
@@ -23,6 +23,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd
@@ -39,6 +40,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd

--- a/build/DirectXTK-GitHub-MinGW.yml
+++ b/build/DirectXTK-GitHub-MinGW.yml
@@ -20,6 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -35,6 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/build/DirectXTK-GitHub-Test-Dev17.yml
+++ b/build/DirectXTK-GitHub-Test-Dev17.yml
@@ -12,8 +12,8 @@ schedules:
     include:
     - main
 
+# GitHub Actions handles test suite for CI/PR
 trigger: none
-
 pr:
   branches:
     include:

--- a/build/DirectXTK-GitHub-Test-Dev17.yml
+++ b/build/DirectXTK-GitHub-Test-Dev17.yml
@@ -362,12 +362,12 @@ jobs:
     displayName: CMake (MSVC; arm64-Debug) Config
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --preset=arm64-Debug-Win10
+      cmakeArgs: --preset=arm64-Debug
   - task: CMake@1
     displayName: CMake (MSVC; arm64-Debug) Build
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out/build/arm64-Debug-Win10 -v
+      cmakeArgs: --build out/build/arm64-Debug -v
   - task: DeleteFiles@1
     inputs:
       Contents: 'out'
@@ -375,12 +375,12 @@ jobs:
     displayName: CMake (MSVC; arm64-Release) Config
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --preset=arm64-Release-Win10
+      cmakeArgs: --preset=arm64-Release
   - task: CMake@1
     displayName: CMake (MSVC; arm64-Release) Build
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out/build/arm64-Release-Win10 -v
+      cmakeArgs: --build out/build/arm64-Release -v
   - task: DeleteFiles@1
     inputs:
       Contents: 'out'
@@ -388,12 +388,12 @@ jobs:
     displayName: CMake (clang/LLVM; arm64-Debug) Config
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --preset=arm64-Debug-Win10-Clang
+      cmakeArgs: --preset=arm64-Debug-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Debug) Build
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out/build/arm64-Debug-Win10-Clang -v
+      cmakeArgs: --build out/build/arm64-Debug-Clang -v
   - task: DeleteFiles@1
     inputs:
       Contents: 'out'
@@ -401,12 +401,12 @@ jobs:
     displayName: CMake (clang/LLVM; arm64-Release) Config
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --preset=arm64-Release-Win10-Clang
+      cmakeArgs: --preset=arm64-Release-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Release) Build
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out/build/arm64-Release-Win10-Clang -v
+      cmakeArgs: --build out/build/arm64-Release-Clang -v
   - task: DeleteFiles@1
     inputs:
       Contents: 'out'
@@ -414,12 +414,12 @@ jobs:
     displayName: CMake (MSVC; arm64ec-Debug) Config
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --preset=arm64ec-Debug-Win10
+      cmakeArgs: --preset=arm64ec-Debug
   - task: CMake@1
     displayName: CMake (MSVC; arm64ec-Debug) Build
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out/build/arm64ec-Debug-Win10 -v
+      cmakeArgs: --build out/build/arm64ec-Debug -v
   - task: DeleteFiles@1
     inputs:
       Contents: 'out'
@@ -427,9 +427,9 @@ jobs:
     displayName: CMake (MSVC; arm64ec-Release) Config
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --preset=arm64ec-Release-Win10
+      cmakeArgs: --preset=arm64ec-Release
   - task: CMake@1
     displayName: CMake (MSVC; arm64ec-Release) Build
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out/build/arm64ec-Release-Win10 -v
+      cmakeArgs: --build out/build/arm64ec-Release -v

--- a/build/DirectXTK-GitHub-Test.yml
+++ b/build/DirectXTK-GitHub-Test.yml
@@ -12,44 +12,15 @@ schedules:
     include:
     - main
 
-trigger:
-  branches:
-    include:
-    - main
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-
+# GitHub Actions handles test suite for CI/PR
+trigger: none
 pr:
   branches:
     include:
     - main
   paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-  drafts: false
+    include:
+    - build/DirectXTK-GitHub-Test.yml
 
 resources:
   repositories:

--- a/build/DirectXTK-GitHub-Test.yml
+++ b/build/DirectXTK-GitHub-Test.yml
@@ -21,6 +21,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd
@@ -39,6 +40,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd

--- a/build/DirectXTK-GitHub.yml
+++ b/build/DirectXTK-GitHub.yml
@@ -12,44 +12,15 @@ schedules:
     include:
     - main
 
-trigger:
-  branches:
-    include:
-    - main
-  paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-
+# GitHub Actions handles MSBuild for CI/PR
+trigger: none
 pr:
   branches:
     include:
     - main
   paths:
-    exclude:
-    - '*.md'
-    - LICENSE
-    - CMake*
-    - '.github/*'
-    - '.nuget/*'
-    - build/*.cmake
-    - build/*.cmd
-    - build/*.in
-    - build/*.json
-    - build/*.props
-    - build/*.ps1
-    - build/*.targets
-  drafts: false
+    include:
+    - build/DirectXTK-GitHub.yml
 
 resources:
   repositories:

--- a/build/DirectXTK-GitHub.yml
+++ b/build/DirectXTK-GitHub.yml
@@ -21,6 +21,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd
@@ -39,6 +40,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
+    - '.github/*'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd

--- a/build/DirectXTK-SDL.yml
+++ b/build/DirectXTK-SDL.yml
@@ -12,8 +12,8 @@ schedules:
     include:
     - main
 
+# GitHub Actions handles CodeQL and PREFAST for CI/PR
 trigger: none
-
 pr:
   branches:
     include:


### PR DESCRIPTION
While most pipelines are hosted on ADO, this adds GitHub build actions that are available to everyone who forks the repo. This also uses GitHub actions to validate PRs where possible rather than ADO for security reasons.

Also enables the GitHub Action based CodeQL and PREfast analysis.