### PR TITLE
Keep asserts on in fuzz-testing builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '7516a02de04e8f8ff4e4beb8f5bac0565f9bf9da'
+        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         runVcpkgInstall: true
         vcpkgJsonGlob: '**/build/vcpkg.json'
-        vcpkgGitCommitId: '3508985146f1b1d248c67ead13f8f54be5b4f5da'
+        vcpkgGitCommitId: '${{ vars.VCPKG_COMMIT_ID }}'
 
     - name: 'Configure CMake'
       working-directory: ${{ github.workspace }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,13 +458,16 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
       target_compile_options(${t} PRIVATE ${WarningsEXE})
     endforeach()
 
-    if(BUILD_FUZZING
-        AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.32)
-        AND (NOT WINDOWS_STORE))
-          foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
-            target_compile_options(${t} PRIVATE ${ASAN_SWITCHES})
-            target_link_libraries(${t} PRIVATE ${ASAN_LIBS})
-          endforeach()
+    if(BUILD_FUZZING AND (NOT WINDOWS_STORE))
+      string(REPLACE "/DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+      string(REPLACE "/DNDEBUG" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+
+      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.32)
+        foreach(t IN LISTS TOOL_EXES ITEMS ${PROJECT_NAME})
+          target_compile_options(${t} PRIVATE ${ASAN_SWITCHES})
+          target_link_libraries(${t} PRIVATE ${ASAN_LIBS})
+        endforeach()
+      endif()
     endif()
 endif()
 

--- a/build/DirectXTK-GitHub-GDK.yml
+++ b/build/DirectXTK-GitHub-GDK.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248929
+# https://go.microsoft.com/fwlink/?LinkId=248929
 
 # Builds the library and test suite using the Microsoft GDK.
 
@@ -54,6 +54,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtktest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -65,7 +70,6 @@ variables:
   EXTRACTED_FOLDER: $(ExtractedFolder)
   GDK_EDITION: $(GDKEditionNumber)
   GDKEnableBWOI: true
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   URL_FEED: $(ADOFeedURL)
   skipNugetSecurityAnalysis: true # We explicitly call this task so we don't need it to be auto-injected
 
@@ -78,6 +82,7 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
+    fetchDepth: 1
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: PowerShell@2
@@ -147,12 +152,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: PowerShell@2

--- a/build/DirectXTK-GitHub-MinGW.yml
+++ b/build/DirectXTK-GitHub-MinGW.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248929
+# https://go.microsoft.com/fwlink/?LinkId=248929
 
 # Builds the library and test suite using the MinGW compiler.
 
@@ -23,7 +23,7 @@ trigger:
     - '.github/*'
     - '.nuget/*'
     - build/*.cmd
-    - build/*.json
+    - build/OneFuzz*.json
     - build/*.props
     - build/*.ps1
     - build/*.targets
@@ -39,7 +39,7 @@ pr:
     - '.github/*'
     - '.nuget/*'
     - build/*.cmd
-    - build/*.json
+    - build/OneFuzz*.json
     - build/*.props
     - build/*.ps1
     - build/*.targets
@@ -50,6 +50,16 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: vcpkgRepo
+    name: Microsoft/vcpkg
+    type: github
+    endpoint: microsoft
+    ref: refs/tags/$(VCPKG_TAG)
+  - repository: testRepo
+    name: walbourn/directxtktest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -58,28 +68,29 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  VCPKG_CMAKE_DIR: '$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
+  VCPKG_ROOT: $(Build.SourcesDirectory)/vcpkg
+  VCPKG_CMAKE_DIR: $(Build.SourcesDirectory)/vcpkg/scripts/buildsystems/vcpkg.cmake
+  VCPKG_MANIFEST_DIR: $(Build.SourcesDirectory)/build
   WIN11_SDK: '10.0.22000.0'
   URL_MINGW32: https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-14.0.6-10.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-12.2.0-llvm-14.0.6-mingw-w64ucrt-10.0.0-r2.zip
   HASH_MINGW32: 'fcd1e11b896190da01c83d5b5fb0d37b7c61585e53446c2dab0009debc3915e757213882c35e35396329338de6f0222ba012e23a5af86932db45186a225d1272'
+  CompileShadersOutput: $(Build.BinariesDirectory)\Shaders
 
 jobs:
 - job: MINGW32_BUILD
-  displayName: 'Minimalist GNU for Windows (MinGW32) BUILD_TESTING=ON'
+  displayName: 'Minimalist GNU for Windows (MinGW32)'
   steps:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
-  - task: CmdLine@2
-    displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
     inputs:
@@ -90,7 +101,7 @@ jobs:
 
       workingDirectory: $(Build.SourcesDirectory)\vcpkg
   - task: PowerShell@2
-    displayName: Install MinGW32 and setup FXC for Shader Compilation
+    displayName: Install MinGW32 and setup for Windows 11 SDK
     inputs:
       targetType: inline
       script: |
@@ -110,9 +121,13 @@ jobs:
         Write-Host "Added to path: $env:BUILD_SOURCESDIRECTORY\gw32\mingw32\bin"
         Write-Host "##vso[task.prependpath]$env:BUILD_SOURCESDIRECTORY\gw32\mingw32\bin"
         $sdkroot = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots' | Select-Object -ExpandProperty KitsRoot10
-        $windows11sdk = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
-        if (Test-Path "$windows11sdk") {
-            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$windows11sdk"
+        $wsdkbin = "{0}bin\" -f $sdkroot
+        $wsdkverbin = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
+        $wsdkarchbin = "{0}bin\$(WIN11_SDK)\x86" -f $sdkroot
+        if (Test-Path "$wsdkarchbin") {
+            Write-Host "##vso[task.setvariable variable=WindowsSdkBinPath;]$wsdkbin"
+            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$wsdkverbin"
+            Write-Host "##vso[task.prependpath]$wsdkarchbin"
         }
         else {
             Write-Error -Message "##[error]Can't find Windows SDK ($(WIN11_SDK))" -ErrorAction Stop
@@ -130,32 +145,24 @@ jobs:
       workingFolder: $(Build.SourcesDirectory)\Src\Shaders
   - task: CmdLine@2
     # Test suite for DirectX Tool Kit for DX11 needs DX12 headers for the simplemath test.
-    displayName: VCPKG install headers
+  - task: CmdLine@2
+    displayName: VCPKG install packages
     inputs:
-      script: |
-        call vcpkg install directxmath
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-headers
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install xaudio2redist
-        @if ERRORLEVEL 1 goto error
-        :finish
-        @echo --- VCPKG COMPLETE ---
-        exit /b 0
-        :error
-        @echo --- ERROR: VCPKG FAILED ---
-        exit /b 1
-
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x86-mingw-static
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake (MinGW32)
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x86 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x86-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\Src\Shaders\Compiled -DBUILD_XAUDIO_WIN7=ON
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x86
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput) -DBUILD_XAUDIO_WIN7=ON
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out
 
 - job: MINGW64_BUILD
@@ -164,15 +171,20 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: vcpkgRepo
     displayName: Fetch VCPKG
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/vcpkg.git
-      workingDirectory: $(Build.SourcesDirectory)
-  - task: CmdLine@2
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/vcpkg'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: VCPKG Bootstrap
     inputs:
@@ -189,50 +201,43 @@ jobs:
       script: |
         $ProgressPreference = 'SilentlyContinue'
         $sdkroot = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots' | Select-Object -ExpandProperty KitsRoot10
-        $windows11sdk = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
-        $windows11x64sdk = "{0}bin\$(WIN11_SDK)\x64" -f $sdkroot
-        if (Test-Path "$windows11sdk") {
-            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$windows11sdk"
-            Write-Host "##vso[task.prependpath]$windows11x64sdk"
+        $wsdkbin = "{0}bin\" -f $sdkroot
+        $wsdkverbin = "{0}bin\$(WIN11_SDK)\" -f $sdkroot
+        $wsdkarchbin = "{0}bin\$(WIN11_SDK)\x64" -f $sdkroot
+        if (Test-Path "$wsdkarchbin") {
+            Write-Host "##vso[task.setvariable variable=WindowsSdkBinPath;]$wsdkbin"
+            Write-Host "##vso[task.setvariable variable=WindowsSdkVerBinPath;]$wsdkverbin"
+            Write-Host "##vso[task.prependpath]$wsdkarchbin"
         }
         else {
             Write-Error -Message "##[error]Can't find Windows SDK ($(WIN11_SDK))" -ErrorAction Stop
         }
 
+  - task: CmdLine@2
+    displayName: GCC version
+    inputs:
+      script: g++ --version
   - task: BatchScript@1
     displayName: CompileShaders
     inputs:
       filename: Src/Shaders/CompileShaders.cmd
       workingFolder: $(Build.SourcesDirectory)\Src\Shaders
   - task: CmdLine@2
-    displayName: GCC version
+    displayName: VCPKG install packages
     inputs:
-      script: g++ --version
-  - task: CmdLine@2
-    displayName: VCPKG install headers
-    inputs:
-      script: |
-        call vcpkg install directxmath
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install directx-headers
-        @if ERRORLEVEL 1 goto error
-        call vcpkg install xaudio2redist
-        @if ERRORLEVEL 1 goto error
-        :finish
-        @echo --- VCPKG COMPLETE ---
-        exit /b 0
-        :error
-        @echo --- ERROR: VCPKG FAILED ---
-        exit /b 1
-
-      workingDirectory: $(Build.SourcesDirectory)\vcpkg
+      script: call vcpkg install --x-manifest-root=$(VCPKG_MANIFEST_DIR) --triplet=x64-mingw-static
+      workingDirectory: $(VCPKG_ROOT)
   - task: CMake@1
     displayName: CMake (MinGW-W64)
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles" -DVCPKG_TARGET_TRIPLET=x64-mingw-static -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(Build.SourcesDirectory)\Src\Shaders\Compiled -DBUILD_XAUDIO_WIN7=ON
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: >
+        -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64
+        -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput) -DBUILD_XAUDIO_WIN7=ON
+        -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out

--- a/build/DirectXTK-GitHub-MinGW.yml
+++ b/build/DirectXTK-GitHub-MinGW.yml
@@ -143,7 +143,6 @@ jobs:
     inputs:
       filename: Src/Shaders/CompileShaders.cmd
       workingFolder: $(Build.SourcesDirectory)\Src\Shaders
-  - task: CmdLine@2
     # Test suite for DirectX Tool Kit for DX11 needs DX12 headers for the simplemath test.
   - task: CmdLine@2
     displayName: VCPKG install packages
@@ -155,9 +154,9 @@ jobs:
     inputs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
-        -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x86
+        -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x86 -DBUILD_XAUDIO_WIN7=ON
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
-        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput) -DBUILD_XAUDIO_WIN7=ON
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x86-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW32) Build
@@ -232,9 +231,9 @@ jobs:
     inputs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: >
-        -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64
+        -B out -DCMAKE_BUILD_TYPE="Debug" -DDIRECTX_ARCH=x64 -DBUILD_XAUDIO_WIN7=ON
         -DCMAKE_CXX_COMPILER="g++.exe" -G "MinGW Makefiles"
-        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput) -DBUILD_XAUDIO_WIN7=ON
+        -DUSE_PREBUILT_SHADERS=ON -DCOMPILED_SHADERS=$(CompileShadersOutput)
         -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_CMAKE_DIR)" -DVCPKG_MANIFEST_DIR="$(VCPKG_MANIFEST_DIR)" -DVCPKG_TARGET_TRIPLET=x64-mingw-static
   - task: CMake@1
     displayName: CMake (MinGW-W64) Build

--- a/build/DirectXTK-GitHub-Test-Dev17.yml
+++ b/build/DirectXTK-GitHub-Test-Dev17.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248929
+# https://go.microsoft.com/fwlink/?LinkId=248929
 
 # Builds the library and test suite.
 
@@ -28,6 +28,11 @@ resources:
     type: git
     ref: refs/heads/main
     trigger: none
+  - repository: testRepo
+    name: walbourn/directxtktest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -37,7 +42,6 @@ pool:
 variables:
   Codeql.Enabled: false
   VC_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   GUID_FEED: $(ADOFeedGUID)
 
 jobs:
@@ -51,19 +55,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: VSBuild@1
     displayName: Build solution DirectXTK_Tests_Desktop_2022.sln 32dbg
     inputs:
@@ -170,19 +169,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: NuGetAuthenticate@1
@@ -245,19 +239,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: Setup environment for CMake to use VS
     inputs:
@@ -276,12 +265,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; x64-Debug) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Debug
   - task: CMake@1
     displayName: CMake (MSVC; x64-Debug) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Debug -v
   - task: DeleteFiles@1
     inputs:
@@ -289,12 +278,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; x64-Release) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Release
   - task: CMake@1
     displayName: CMake (MSVC; x64-Release) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Release -v
   - task: DeleteFiles@1
     inputs:
@@ -302,12 +291,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Debug) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Debug-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Debug) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Debug-Clang -v
   - task: DeleteFiles@1
     inputs:
@@ -315,12 +304,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Release) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=x64-Release-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; x64-Release) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Release-Clang -v
 
 - job: CMAKE_BUILD_ARM64
@@ -332,19 +321,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CmdLine@2
     displayName: Setup environment for CMake to use VS
     inputs:
@@ -363,12 +347,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; arm64-Debug) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64-Debug
   - task: CMake@1
     displayName: CMake (MSVC; arm64-Debug) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64-Debug -v
   - task: DeleteFiles@1
     inputs:
@@ -376,12 +360,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; arm64-Release) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64-Release
   - task: CMake@1
     displayName: CMake (MSVC; arm64-Release) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64-Release -v
   - task: DeleteFiles@1
     inputs:
@@ -389,12 +373,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Debug) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64-Debug-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Debug) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64-Debug-Clang -v
   - task: DeleteFiles@1
     inputs:
@@ -402,12 +386,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Release) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64-Release-Clang
   - task: CMake@1
     displayName: CMake (clang/LLVM; arm64-Release) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64-Release-Clang -v
   - task: DeleteFiles@1
     inputs:
@@ -415,12 +399,12 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; arm64ec-Debug) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64ec-Debug
   - task: CMake@1
     displayName: CMake (MSVC; arm64ec-Debug) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64ec-Debug -v
   - task: DeleteFiles@1
     inputs:
@@ -428,10 +412,10 @@ jobs:
   - task: CMake@1
     displayName: CMake (MSVC; arm64ec-Release) Config
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --preset=arm64ec-Release
   - task: CMake@1
     displayName: CMake (MSVC; arm64ec-Release) Build
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/arm64ec-Release -v

--- a/build/DirectXTK-GitHub-Test.yml
+++ b/build/DirectXTK-GitHub-Test.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248929
+# https://go.microsoft.com/fwlink/?LinkId=248929
 
 # Builds the library and test suite.
 
@@ -27,6 +27,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtktest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -35,7 +40,6 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   GUID_FEED: $(ADOFeedGUID)
 
 jobs:
@@ -43,23 +47,20 @@ jobs:
   displayName: 'Win32 Desktop'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  workspace:
+    clean: all
   steps:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: VSBuild@1
     displayName: Build solution DirectXTK_Tests_Desktop_2019.sln 32dbg
     inputs:
@@ -154,19 +155,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet'
   - task: NuGetAuthenticate@1
@@ -224,19 +220,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: VSBuild@1
     displayName: Build solution DirectXTK_Tests_Windows10.sln 64dbg
     inputs:
@@ -261,19 +252,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: VSBuild@1
     displayName: Build solution DirectXTK_Tests_Windows10.sln 32dbg
     inputs:
@@ -298,19 +284,14 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: VSBuild@1
     displayName: Build solution DirectXTK_Tests_Windows10.sln arm64dbg
     inputs:

--- a/build/DirectXTK-GitHub-WSL-11.yml
+++ b/build/DirectXTK-GitHub-WSL-11.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248929
+# https://go.microsoft.com/fwlink/?LinkId=248929
 
 # Builds the SimpleMath module for Windows Subsystem for Linux (WSL)
 
@@ -31,6 +31,21 @@ resources:
     type: git
     ref: refs/heads/main
     trigger: none
+  - repository: dxHeadersRepo
+    name: Microsoft/DirectX-Headers
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+  - repository: dxMathRepo
+    name: Microsoft/DirectXMath
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtktest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -39,7 +54,6 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   LOCAL_PKG_DIR: '$(Agent.BuildDirectory)/install/'
 
 jobs:
@@ -51,10 +65,26 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
-    displayName: Fetch directx-headers
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectX-Headers.git directx-headers
+    fetchDepth: 1
+    path: 's'
+  - checkout: dxHeadersRepo
+    displayName: Fetch DirectX-Headers
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/directx-headers'
+  - checkout: dxMathRepo
+    displayName: Fetch DirectX-Math
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/directxmath'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CMake@1
     displayName: CMake DirectX-Headers
     inputs:
@@ -70,10 +100,6 @@ jobs:
     inputs:
       cwd: directx-headers
       cmakeArgs: --install .
-  - task: CmdLine@2
-    displayName: Fetch directxmath
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMath.git directxmath
   - task: CMake@1
     displayName: CMake DirectXMath
     inputs:
@@ -89,12 +115,6 @@ jobs:
     inputs:
       cwd: directxmath
       cmakeArgs: --install .
-  - task: CmdLine@2
-    displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
   - task: PowerShell@2
     displayName: Fetch SAL.H
     inputs:

--- a/build/DirectXTK-GitHub-WSL.yml
+++ b/build/DirectXTK-GitHub-WSL.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248929
+# https://go.microsoft.com/fwlink/?LinkId=248929
 
 # Builds the SimpleMath module for Windows Subsystem for Linux (WSL)
 
@@ -36,6 +36,22 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+    trigger: none
+  - repository: dxHeadersRepo
+    name: Microsoft/DirectX-Headers
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+  - repository: dxMathRepo
+    name: Microsoft/DirectXMath
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtktest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -44,7 +60,6 @@ pool:
 
 variables:
   Codeql.Enabled: false
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
   LOCAL_PKG_DIR: '$(Agent.BuildDirectory)/install/'
 
 jobs:
@@ -56,10 +71,26 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: CmdLine@2
-    displayName: Fetch directx-headers
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectX-Headers.git directx-headers
+    fetchDepth: 1
+    path: 's'
+  - checkout: dxHeadersRepo
+    displayName: Fetch DirectX-Headers
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/directx-headers'
+  - checkout: dxMathRepo
+    displayName: Fetch DirectX-Math
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/directxmath'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CMake@1
     displayName: CMake DirectX-Headers
     inputs:
@@ -75,10 +106,6 @@ jobs:
     inputs:
       cwd: directx-headers
       cmakeArgs: --install .
-  - task: CmdLine@2
-    displayName: Fetch directxmath
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/microsoft/DirectXMath.git directxmath
   - task: CMake@1
     displayName: CMake DirectXMath
     inputs:
@@ -94,12 +121,6 @@ jobs:
     inputs:
       cwd: directxmath
       cmakeArgs: --install .
-  - task: CmdLine@2
-    displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
   - task: PowerShell@2
     displayName: Fetch SAL.H
     inputs:

--- a/build/DirectXTK-OneFuzz-Coverage.yml
+++ b/build/DirectXTK-OneFuzz-Coverage.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248929
+# https://go.microsoft.com/fwlink/?LinkId=248929
 
 # OneFuzz code coverage pipeline
 
@@ -10,6 +10,17 @@ trigger: none
 
 pool:
   vmImage: windows-latest
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtktest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 parameters:
   - name: sasUrl
@@ -48,17 +59,17 @@ jobs:
   workspace:
     clean: all
   steps:
-  - task: CmdLine@2
-    displayName: 'Fetch source'
-    inputs:
-      script: |
-        git clone --quiet --no-tags https://%GITHUBPUBLICTOKEN%@github.com/microsoft/DirectXTK.git
-        cd DirectXTK
-        git checkout $(commit-ID)
-        git clone --quiet --no-tags https://%GITHUBPUBLICTOKEN%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
-
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - powershell: |
       Write-Host "Job ID: $(job-ID), Build Date: $(build-date), Branch: $(branch)"
       $SASUrl = [System.Uri]::new("$(sas-url)")

--- a/build/DirectXTK-OneFuzz.yml
+++ b/build/DirectXTK-OneFuzz.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# http://go.microsoft.com/fwlink/?LinkId=248929
+# https://go.microsoft.com/fwlink/?LinkId=248929
 
 # Builds the library using CMake and submit for file fuzzing
 
@@ -21,6 +21,11 @@ resources:
   - repository: self
     type: git
     ref: refs/heads/main
+  - repository: testRepo
+    name: walbourn/directxtktest
+    type: github
+    endpoint: microsoft
+    ref: refs/heads/main
 
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
@@ -28,7 +33,6 @@ variables:
   Codeql.Enabled: false
   VS_GENERATOR: 'Visual Studio 17 2022'
   WIN11_SDK: '10.0.22000.0'
-  GITHUB_PAT: $(GITHUBPUBLICTOKEN)
 
 pool:
   vmImage: windows-2022
@@ -40,28 +44,23 @@ jobs:
   - checkout: self
     clean: true
     fetchTags: false
-  - task: DeleteFiles@1
-    displayName: Delete files from Tests
-    inputs:
-      SourceFolder: Tests
-      Contents: '**'
-      RemoveSourceFolder: true
-      RemoveDotFiles: true
-  - task: CmdLine@2
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
     displayName: Fetch Tests
-    inputs:
-      script: git clone --quiet --no-tags https://%GITHUB_PAT%@github.com/walbourn/directxtktest.git Tests
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: true
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
   - task: CMake@1
     displayName: 'CMake (MSVC): Config with ASan'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_TOOLS=OFF -DBUILD_XAUDIO_WIN10=ON -DBUILD_FUZZING=ON -DBUILD_TESTING=OFF'
   - task: CMake@1
     displayName: 'CMake (MSVC): Build with ASan'
     inputs:
-      cwd: '$(Build.SourcesDirectory)'
+      cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out -v --config RelWithDebInfo
   - task: CopyFiles@2
     displayName: Copy fuzzer

--- a/build/DirectXTK-SDL.yml
+++ b/build/DirectXTK-SDL.yml
@@ -11,6 +11,7 @@ schedules:
   branches:
     include:
     - main
+  always: true
 
 # GitHub Actions handles CodeQL and PREFAST for CI/PR
 trigger: none

--- a/build/vcpkg.json
+++ b/build/vcpkg.json
@@ -6,6 +6,7 @@
         "name": "directx-dxc",
         "host": true
       },
+      "directx-headers",
       {
         "name": "xaudio2redist",
         "platform": "windows & !arm"


### PR DESCRIPTION
This PR makes sure ``assert`` macros in the library built for fuzz-testing remain in place even in release builds.

> Includes ADO YAML code review to clean up use of PATs, and to convert all use of vcpkg in the pipelines to 'manifest mode'.

> Also sets the dependabot to not spam quite so often for GHA.