### PR TITLE
Add DDS_LOADER_IGNORE_MIPS flag to DDSTextureLoader

### DIFF
--- a/Inc/DDSTextureLoader.h
+++ b/Inc/DDSTextureLoader.h
@@ -47,6 +47,7 @@ namespace DirectX
             DDS_LOADER_DEFAULT = 0,
             DDS_LOADER_FORCE_SRGB = 0x1,
             DDS_LOADER_IGNORE_SRGB = 0x2,
+            DDS_LOADER_IGNORE_MIPS = 0x20,
         };
     }
 

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -164,6 +164,11 @@ namespace
             format = MakeLinear(format);
         }
 
+        if (loadFlags & DDS_LOADER_IGNORE_MIPS)
+        {
+            mipCount = 1;
+        }
+
         switch (resDim)
         {
         case D3D11_RESOURCE_DIMENSION_TEXTURE1D:

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -164,11 +164,6 @@ namespace
             format = MakeLinear(format);
         }
 
-        if (loadFlags & DDS_LOADER_IGNORE_MIPS)
-        {
-            mipCount = 1;
-        }
-
         switch (resDim)
         {
         case D3D11_RESOURCE_DIMENSION_TEXTURE1D:
@@ -408,7 +403,7 @@ namespace
         bool isCubeMap = false;
 
         size_t mipCount = header->mipMapCount;
-        if (0 == mipCount)
+        if ((0 == mipCount) || (loadFlags & DDS_LOADER_IGNORE_MIPS))
         {
             mipCount = 1;
         }


### PR DESCRIPTION
Adds a flag option to DDSTextureLoader for only loading the first mip of a DDS file.

> This was added to DirectXTex as `DDS_FLAGS_IGNORE_MIPS` in July. It is useful for more than just corrupted files.