### PR TITLE
Fix -Wunused-member-function warning in xwbtool

### DIFF
--- a/XWBTool/xwbtool.cpp
+++ b/XWBTool/xwbtool.cpp
@@ -824,7 +824,6 @@ namespace
         WaveFile& operator= (WaveFile&) = delete;
 
         WaveFile(WaveFile&&) = default;
-        WaveFile& operator= (WaveFile&&) = default;
     };
 
     void FileNameToIdentifier(_Inout_updates_all_(count) wchar_t* str, size_t count)


### PR DESCRIPTION
Fixes warning when building with VS 2022 17.12 with clang v18.1.8