### PR TITLE
Use fixed width integers for underlying enum types

### DIFF
--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -159,7 +159,7 @@ namespace DirectX
         SoundEffectInstance_UseRedirectLFE = 0x10000,
     };
 
-    enum AUDIO_ENGINE_REVERB : unsigned int
+    enum AUDIO_ENGINE_REVERB : uint32_t
     {
         Reverb_Off,
         Reverb_Default,
@@ -195,7 +195,7 @@ namespace DirectX
         Reverb_MAX
     };
 
-    enum SoundState
+    enum SoundState : uint32_t
     {
         STOPPED = 0,
         PLAYING,
@@ -823,8 +823,8 @@ namespace DirectX
 #pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
 #endif
 
-    DEFINE_ENUM_FLAG_OPERATORS(AUDIO_ENGINE_FLAGS);
-    DEFINE_ENUM_FLAG_OPERATORS(SOUND_EFFECT_INSTANCE_FLAGS);
+    DEFINE_ENUM_FLAG_OPERATORS(AUDIO_ENGINE_FLAGS)
+    DEFINE_ENUM_FLAG_OPERATORS(SOUND_EFFECT_INSTANCE_FLAGS)
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/Inc/DDSTextureLoader.h
+++ b/Inc/DDSTextureLoader.h
@@ -174,7 +174,7 @@ namespace DirectX
 
     inline namespace DX11
     {
-        DEFINE_ENUM_FLAG_OPERATORS(DDS_LOADER_FLAGS);
+        DEFINE_ENUM_FLAG_OPERATORS(DDS_LOADER_FLAGS)
     }
 
 #ifdef __clang__

--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -19,6 +19,7 @@
 #endif
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #include <DirectXMath.h>
@@ -324,7 +325,7 @@ namespace DirectX
         class EnvironmentMapEffect : public IEffect, public IEffectMatrices, public IEffectLights, public IEffectFog
         {
         public:
-            enum Mapping
+            enum Mapping : uint32_t
             {
                 Mapping_Cube = 0,       // Cubic environment map
                 Mapping_Sphere,         // Spherical environment map
@@ -790,7 +791,7 @@ namespace DirectX
         class DebugEffect : public IEffect, public IEffectMatrices
         {
         public:
-            enum Mode
+            enum Mode : uint32_t
             {
                 Mode_Default = 0,   // Hemispherical ambient lighting
                 Mode_Normals,       // RGB normals

--- a/Inc/GamePad.h
+++ b/Inc/GamePad.h
@@ -87,7 +87,7 @@ namespace DirectX
         static constexpr int c_MergedInput = -2;
     #endif
 
-        enum DeadZone
+        enum DeadZone : uint32_t
         {
             DEAD_ZONE_INDEPENDENT_AXES = 0,
             DEAD_ZONE_CIRCULAR,
@@ -187,7 +187,7 @@ namespace DirectX
 
         struct Capabilities
         {
-            enum Type
+            enum Type : uint32_t
             {
                 UNKNOWN = 0,
                 GAMEPAD,
@@ -222,7 +222,7 @@ namespace DirectX
         class ButtonStateTracker
         {
         public:
-            enum ButtonState
+            enum ButtonState : uint32_t
             {
                 UP = 0,         // Button is up
                 HELD = 1,       // Button is held down

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -363,7 +363,7 @@ namespace DirectX
     #pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
     #endif
 
-        DEFINE_ENUM_FLAG_OPERATORS(ModelLoaderFlags);
+        DEFINE_ENUM_FLAG_OPERATORS(ModelLoaderFlags)
 
     #ifdef __clang__
     #pragma clang diagnostic pop

--- a/Inc/Mouse.h
+++ b/Inc/Mouse.h
@@ -28,6 +28,7 @@
 #pragma comment(lib,"gameinput.lib")
 #endif
 
+#include <cstdint>
 #include <memory>
 
 #ifdef USING_COREWINDOW
@@ -55,7 +56,7 @@ namespace DirectX
 
         virtual ~Mouse();
 
-        enum Mode
+        enum Mode : uint32_t
         {
             MODE_ABSOLUTE = 0,
             MODE_RELATIVE,
@@ -77,7 +78,7 @@ namespace DirectX
         class ButtonStateTracker
         {
         public:
-            enum ButtonState
+            enum ButtonState : uint32_t
             {
                 UP = 0,         // Button is up
                 HELD = 1,       // Button is held down

--- a/Inc/PostProcess.h
+++ b/Inc/PostProcess.h
@@ -15,6 +15,7 @@
 #include <d3d11_1.h>
 #endif
 
+#include <cstdint>
 #include <memory>
 #include <functional>
 
@@ -50,7 +51,7 @@ namespace DirectX
         class BasicPostProcess : public IPostProcess
         {
         public:
-            enum Effect : unsigned int
+            enum Effect : uint32_t
             {
                 Copy,
                 Monochrome,
@@ -106,7 +107,7 @@ namespace DirectX
         class DualPostProcess : public IPostProcess
         {
         public:
-            enum Effect : unsigned int
+            enum Effect : uint32_t
             {
                 Merge,
                 BloomCombine,
@@ -154,7 +155,7 @@ namespace DirectX
         {
         public:
             // Tone-mapping operator
-            enum Operator : unsigned int
+            enum Operator : uint32_t
             {
                 None,               // Pass-through
                 Saturate,           // Clamp [0,1]
@@ -164,7 +165,7 @@ namespace DirectX
             };
 
             // Electro-Optical Transfer Function (EOTF)
-            enum TransferFunction : unsigned int
+            enum TransferFunction : uint32_t
             {
                 Linear,             // Pass-through
                 SRGB,               // sRGB (Rec.709 and approximate sRGB display curve)
@@ -173,7 +174,7 @@ namespace DirectX
             };
 
             // Color Rotation Transform for HDR10
-            enum ColorPrimaryRotation : unsigned int
+            enum ColorPrimaryRotation : uint32_t
             {
                 HDTV_to_UHDTV,       // Rec.709 to Rec.2020
                 DCI_P3_D65_to_UHDTV, // DCI-P3-D65 (a.k.a Display P3 or P3D65) to Rec.2020

--- a/Inc/SpriteBatch.h
+++ b/Inc/SpriteBatch.h
@@ -28,7 +28,7 @@ namespace DirectX
 {
     inline namespace DX11
     {
-        enum SpriteSortMode
+        enum SpriteSortMode : uint32_t
         {
             SpriteSortMode_Deferred,
             SpriteSortMode_Immediate,

--- a/Inc/WICTextureLoader.h
+++ b/Inc/WICTextureLoader.h
@@ -168,7 +168,7 @@ namespace DirectX
 
     inline namespace DX11
     {
-        DEFINE_ENUM_FLAG_OPERATORS(WIC_LOADER_FLAGS);
+        DEFINE_ENUM_FLAG_OPERATORS(WIC_LOADER_FLAGS)
     }
 
 #ifdef __clang__


### PR DESCRIPTION
Originally I used `DWORD` for flags. When I removed Windows-specific types, I changed it to `unsigned long` to keep the signature the same. The ask is to use `uint32_t` instead which is more consistent on Windows vs. Linux.

Also removed 'extra-semi' for macro.