### PR TITLE
Convert xwbtool to use GNU-style long options

### DIFF
--- a/MakeSpriteFont/CommandLineParser.cs
+++ b/MakeSpriteFont/CommandLineParser.cs
@@ -89,7 +89,25 @@ namespace MakeSpriteFont
 
         bool ParseArgument(string arg)
         {
-            if (arg.StartsWith("/"))
+            if (arg.StartsWith("--"))
+            {
+                string name = arg.Substring(2).ToLowerInvariant();
+
+                if (name == "version")
+                {
+                    ShowVersion();
+                }
+                else if (name == "help")
+                {
+                    ShowUsage();
+                }
+                else
+                {
+                    ShowError("Unknown long option '{0}'", name);
+                }
+                return false;
+            }
+            else if (arg.StartsWith("/") || arg.StartsWith("-"))
             {
                 // Parse an optional argument.
                 char[] separators = { ':' };
@@ -202,10 +220,16 @@ namespace MakeSpriteFont
 
         void ShowError(string message, params object[] args)
         {
-            string name = Path.GetFileNameWithoutExtension(Process.GetCurrentProcess().ProcessName);
-
             Console.Error.WriteLine(message, args);
             Console.Error.WriteLine();
+            ShowUsage();
+        }
+
+
+        void ShowUsage()
+        {
+            string name = Path.GetFileNameWithoutExtension(Process.GetCurrentProcess().ProcessName);
+
             Console.Error.WriteLine("Usage: {0} {1}", name, string.Join(" ", requiredUsageHelp));
 
             if (optionalUsageHelp.Count > 0)
@@ -218,6 +242,15 @@ namespace MakeSpriteFont
                     Console.Error.WriteLine("    {0}", optional);
                 }
             }
+        }
+
+        void ShowVersion()
+        {
+            string name = Path.GetFileNameWithoutExtension(Process.GetCurrentProcess().ProcessName);
+
+            Version version = Assembly.GetEntryAssembly().GetName().Version;
+
+            Console.Error.WriteLine("{0} Version {1}", name, version);
         }
 
 


### PR DESCRIPTION
Embraces the `-so` vs. `--long-option` GNU-like pattern for the command-line tool.

 This also adds `-o=value` which is the GNU standard and the tool already supported `-o:value` or `-o value`.

> This is a hybrid of the Windows style and GNU-like pattern. For example, you can't combine single-characters together such as  `-yl` with this tool like you can with GNU-style argument syntax. Not all multi-character options use `--` which would be the GNU standard.

> The tool already supports the `-- ` escape so you can start filenames with `/` or `-`
