### PR TITLE
Support using C++17 std::byte for FromMemory functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,7 @@ endif()
 
 if(directxmath_FOUND)
     message(STATUS "Using DirectXMath package")
-    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectXMath)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Microsoft::DirectXMath)
 endif()
 
 if(BUILD_XAUDIO_WIN7

--- a/Inc/DDSTextureLoader.h
+++ b/Inc/DDSTextureLoader.h
@@ -167,6 +167,78 @@ namespace DirectX
         _Outptr_opt_ ID3D11ShaderResourceView** textureView,
         _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept;
 
+#ifdef __cpp_lib_byte
+    inline HRESULT __cdecl CreateDDSTextureFromMemory(
+        _In_ ID3D11Device* d3dDevice,
+        _In_reads_bytes_(ddsDataSize) const std::byte* ddsData,
+        _In_ size_t ddsDataSize,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _In_ size_t maxsize = 0,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept
+    {
+        return CreateDDSTextureFromMemory(d3dDevice, reinterpret_cast<const uint8_t*>(ddsData), ddsDataSize, texture, textureView, maxsize, alphaMode);
+    }
+
+    inline HRESULT __cdecl CreateDDSTextureFromMemory(
+    #if defined(_XBOX_ONE) && defined(_TITLE)
+        _In_ ID3D11DeviceX* d3dDevice,
+        _In_opt_ ID3D11DeviceContextX* d3dContext,
+    #else
+        _In_ ID3D11Device* d3dDevice,
+        _In_opt_ ID3D11DeviceContext* d3dContext,
+    #endif
+        _In_reads_bytes_(ddsDataSize) const std::byte* ddsData,
+        _In_ size_t ddsDataSize,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _In_ size_t maxsize = 0,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept
+    {
+        return CreateDDSTextureFromMemory(d3dDevice, d3dContext, reinterpret_cast<const uint8_t*>(ddsData), ddsDataSize, texture, textureView, maxsize, alphaMode);
+    }
+
+    inline HRESULT __cdecl CreateDDSTextureFromMemoryEx(
+        _In_ ID3D11Device* d3dDevice,
+        _In_reads_bytes_(ddsDataSize) const std::byte* ddsData,
+        _In_ size_t ddsDataSize,
+        _In_ size_t maxsize,
+        _In_ D3D11_USAGE usage,
+        _In_ unsigned int bindFlags,
+        _In_ unsigned int cpuAccessFlags,
+        _In_ unsigned int miscFlags,
+        _In_ DDS_LOADER_FLAGS loadFlags,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept
+    {
+        return CreateDDSTextureFromMemoryEx(d3dDevice, reinterpret_cast<const uint8_t*>(ddsData), ddsDataSize, maxsize, usage, bindFlags, cpuAccessFlags, miscFlags, loadFlags, texture, textureView, alphaMode);
+    }
+
+    inline HRESULT __cdecl CreateDDSTextureFromMemoryEx(
+    #if defined(_XBOX_ONE) && defined(_TITLE)
+        _In_ ID3D11DeviceX* d3dDevice,
+        _In_opt_ ID3D11DeviceContextX* d3dContext,
+    #else
+        _In_ ID3D11Device* d3dDevice,
+        _In_opt_ ID3D11DeviceContext* d3dContext,
+    #endif
+        _In_reads_bytes_(ddsDataSize) const std::byte* ddsData,
+        _In_ size_t ddsDataSize,
+        _In_ size_t maxsize,
+        _In_ D3D11_USAGE usage,
+        _In_ unsigned int bindFlags,
+        _In_ unsigned int cpuAccessFlags,
+        _In_ unsigned int miscFlags,
+        _In_ DDS_LOADER_FLAGS loadFlags,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr) noexcept
+    {
+        return CreateDDSTextureFromMemoryEx(d3dDevice, d3dContext, reinterpret_cast<const uint8_t*>(ddsData), ddsDataSize, maxsize, usage, bindFlags, cpuAccessFlags, miscFlags, loadFlags, texture, textureView, alphaMode);
+    }
+#endif // __cpp_lib_byte
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"

--- a/Inc/Model.h
+++ b/Inc/Model.h
@@ -327,6 +327,36 @@ namespace DirectX
                 _In_ std::shared_ptr<IEffect> ieffect = nullptr,
                 ModelLoaderFlags flags = ModelLoader_Clockwise);
 
+#ifdef __cpp_lib_byte
+            static std::unique_ptr<Model> __cdecl CreateFromCMO(
+                _In_ ID3D11Device* device,
+                _In_reads_bytes_(dataSize) const std::byte* meshData, size_t dataSize,
+                _In_ IEffectFactory& fxFactory,
+                ModelLoaderFlags flags = ModelLoader_CounterClockwise,
+                _Out_opt_ size_t* animsOffset = nullptr)
+            {
+                return CreateFromCMO(device, reinterpret_cast<const uint8_t*>(meshData), dataSize, fxFactory, flags, animsOffset);
+            }
+
+            static std::unique_ptr<Model> __cdecl CreateFromSDKMESH(
+                _In_ ID3D11Device* device,
+                _In_reads_bytes_(dataSize) const std::byte* meshData, _In_ size_t dataSize,
+                _In_ IEffectFactory& fxFactory,
+                ModelLoaderFlags flags = ModelLoader_Clockwise)
+            {
+                return CreateFromSDKMESH(device, reinterpret_cast<const uint8_t*>(meshData), dataSize, fxFactory, flags);
+            }
+
+            static std::unique_ptr<Model> __cdecl CreateFromVBO(
+                _In_ ID3D11Device* device,
+                _In_reads_bytes_(dataSize) const std::byte* meshData, _In_ size_t dataSize,
+                _In_ std::shared_ptr<IEffect> ieffect = nullptr,
+                ModelLoaderFlags flags = ModelLoader_Clockwise)
+            {
+                return CreateFromVBO(device, reinterpret_cast<const uint8_t*>(meshData), dataSize, ieffect, flags);
+            }
+#endif // __cpp_lib_byte
+
 #if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
             static std::unique_ptr<Model> __cdecl CreateFromCMO(
                 _In_ ID3D11Device* device,

--- a/Inc/WICTextureLoader.h
+++ b/Inc/WICTextureLoader.h
@@ -161,6 +161,74 @@ namespace DirectX
         _Outptr_opt_ ID3D11Resource** texture,
         _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept;
 
+#ifdef __cpp_lib_byte
+    inline HRESULT __cdecl CreateWICTextureFromMemory(
+        _In_ ID3D11Device* d3dDevice,
+        _In_reads_bytes_(wicDataSize) const std::byte* wicData,
+        _In_ size_t wicDataSize,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _In_ size_t maxsize = 0) noexcept
+    {
+        return CreateWICTextureFromMemory(d3dDevice, reinterpret_cast<const uint8_t*>(wicData), wicDataSize, texture, textureView, maxsize);
+    }
+
+    inline HRESULT __cdecl CreateWICTextureFromMemory(
+    #if defined(_XBOX_ONE) && defined(_TITLE)
+        _In_ ID3D11DeviceX* d3dDevice,
+        _In_opt_ ID3D11DeviceContextX* d3dContext,
+    #else
+        _In_ ID3D11Device* d3dDevice,
+        _In_opt_ ID3D11DeviceContext* d3dContext,
+    #endif
+        _In_reads_bytes_(wicDataSize) const std::byte* wicData,
+        _In_ size_t wicDataSize,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _In_ size_t maxsize = 0) noexcept
+    {
+        return CreateWICTextureFromMemory(d3dDevice, d3dContext, reinterpret_cast<const uint8_t*>(wicData), wicDataSize, texture, textureView, maxsize);
+    }
+
+    inline HRESULT __cdecl CreateWICTextureFromMemoryEx(
+        _In_ ID3D11Device* d3dDevice,
+        _In_reads_bytes_(wicDataSize) const std::byte* wicData,
+        _In_ size_t wicDataSize,
+        _In_ size_t maxsize,
+        _In_ D3D11_USAGE usage,
+        _In_ unsigned int bindFlags,
+        _In_ unsigned int cpuAccessFlags,
+        _In_ unsigned int miscFlags,
+        _In_ WIC_LOADER_FLAGS loadFlags,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept
+    {
+        return CreateWICTextureFromMemoryEx(d3dDevice, reinterpret_cast<const uint8_t*>(wicData), wicDataSize, maxsize, usage, bindFlags, cpuAccessFlags, miscFlags, loadFlags, texture, textureView);
+    }
+
+    inline HRESULT __cdecl CreateWICTextureFromMemoryEx(
+    #if defined(_XBOX_ONE) && defined(_TITLE)
+        _In_ ID3D11DeviceX* d3dDevice,
+        _In_opt_ ID3D11DeviceContextX* d3dContext,
+    #else
+        _In_ ID3D11Device* d3dDevice,
+        _In_opt_ ID3D11DeviceContext* d3dContext,
+    #endif
+        _In_reads_bytes_(wicDataSize) const std::byte* wicData,
+        _In_ size_t wicDataSize,
+        _In_ size_t maxsize,
+        _In_ D3D11_USAGE usage,
+        _In_ unsigned int bindFlags,
+        _In_ unsigned int cpuAccessFlags,
+        _In_ unsigned int miscFlags,
+        _In_ WIC_LOADER_FLAGS loadFlags,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView) noexcept
+    {
+        return CreateWICTextureFromMemoryEx(d3dDevice, d3dContext, reinterpret_cast<const uint8_t*>(wicData), wicDataSize, maxsize, usage, bindFlags, cpuAccessFlags, miscFlags, loadFlags, texture, textureView);
+    }
+#endif // __cpp_lib_byte
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"

--- a/Inc/XboxDDSTextureLoader.h
+++ b/Inc/XboxDDSTextureLoader.h
@@ -64,4 +64,19 @@ namespace Xbox
         _In_ bool forceSRGB = false) noexcept;
 
     void FreeDDSTextureMemory( _In_opt_ void* grfxMemory ) noexcept;
+
+#ifdef __cpp_lib_byte
+    HRESULT __cdecl CreateDDSTextureFromMemory(
+        _In_ ID3D11DeviceX* d3dDevice,
+        _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
+        _In_ size_t ddsDataSize,
+        _Outptr_opt_ ID3D11Resource** texture,
+        _Outptr_opt_ ID3D11ShaderResourceView** textureView,
+        _Outptr_ void** grfxMemory,
+        _Out_opt_ DDS_ALPHA_MODE* alphaMode = nullptr,
+        _In_ bool forceSRGB = false) noexcept
+    {
+        return CreateDDSTextureFromMemory(d3dDevice, reinterpret_cast<const uint8_t*>(ddsData), ddsDataSize, texture, textureView, grfxMemory, alphaMode, forceSRGB);
+    }
+#endif // __cpp_lib_byte
 }

--- a/Inc/XboxDDSTextureLoader.h
+++ b/Inc/XboxDDSTextureLoader.h
@@ -66,7 +66,7 @@ namespace Xbox
     void FreeDDSTextureMemory( _In_opt_ void* grfxMemory ) noexcept;
 
 #ifdef __cpp_lib_byte
-    HRESULT __cdecl CreateDDSTextureFromMemory(
+    inline HRESULT __cdecl CreateDDSTextureFromMemory(
         _In_ ID3D11DeviceX* d3dDevice,
         _In_reads_bytes_(ddsDataSize) const uint8_t* ddsData,
         _In_ size_t ddsDataSize,


### PR DESCRIPTION
When #497 was added to make the type of `FromMemory` operations use something other than `void*`, this turns out to result in code-breaks for clients using C++17's ``std::byte*``.

This PR adds compat inlines to avoid requiring the client code add casts.

> Minor tweak to CMake to avoid requiring all clients use the directxmath package externally.
