### PR TITLE
Fix for CMake using MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,13 +271,14 @@ endif()
 
 if(MINGW)
     find_package(directxmath CONFIG REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectXMath)
 else()
     find_package(directxmath CONFIG QUIET)
 endif()
 
 if(directxmath_FOUND)
     message(STATUS "Using DirectXMath package")
-    target_link_libraries(${PROJECT_NAME} PUBLIC Microsoft::DirectXMath)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Microsoft::DirectXMath)
 endif()
 
 if(BUILD_XAUDIO_WIN7


### PR DESCRIPTION
For Win32 scenarios, DirectXMath is optional for building. Even when using that package is used to build the library, the client code can still choose to use the SDK version of those headers which works fine.

For MinGW, however, clients must always use the packages since the platform toolset don't include these headers (or at least not the right versions of them).
