### PR TITLE
Minor update to enable 'white box' testing of some internal functions

### DIFF
--- a/Audio/SoundCommon.h
+++ b/Audio/SoundCommon.h
@@ -55,31 +55,31 @@ namespace DirectX
 
 
     // Helper for validating wave format structure
-    bool IsValid(_In_ const WAVEFORMATEX* wfx) noexcept;
+    bool __cdecl IsValid(_In_ const WAVEFORMATEX* wfx) noexcept;
 
 
     // Helper for getting a default channel mask from channels
-    uint32_t GetDefaultChannelMask(int channels) noexcept;
+    uint32_t __cdecl GetDefaultChannelMask(int channels) noexcept;
 
 
     // Helpers for creating various wave format structures
-    void CreateIntegerPCM(_Out_ WAVEFORMATEX* wfx,
+    void __cdecl CreateIntegerPCM(_Out_ WAVEFORMATEX* wfx,
         int sampleRate, int channels, int sampleBits) noexcept;
-    void CreateFloatPCM(_Out_ WAVEFORMATEX* wfx,
+    void __cdecl CreateFloatPCM(_Out_ WAVEFORMATEX* wfx,
         int sampleRate, int channels) noexcept;
-    void CreateADPCM(_Out_writes_bytes_(wfxSize) WAVEFORMATEX* wfx, size_t wfxSize,
+    void __cdecl CreateADPCM(_Out_writes_bytes_(wfxSize) WAVEFORMATEX* wfx, size_t wfxSize,
         int sampleRate, int channels, int samplesPerBlock) noexcept(false);
 #ifdef DIRECTX_ENABLE_XWMA
-    void CreateXWMA(_Out_ WAVEFORMATEX* wfx,
+    void __cdecl CreateXWMA(_Out_ WAVEFORMATEX* wfx,
         int sampleRate, int channels, int blockAlign, int avgBytes, bool wma3) noexcept;
 #endif
 #ifdef DIRECTX_ENABLE_XMA2
-    void CreateXMA2(_Out_writes_bytes_(wfxSize) WAVEFORMATEX* wfx, size_t wfxSize,
+    void __cdecl CreateXMA2(_Out_writes_bytes_(wfxSize) WAVEFORMATEX* wfx, size_t wfxSize,
         int sampleRate, int channels, int bytesPerBlock, int blockCount, int samplesEncoded) noexcept(false);
 #endif
 
     // Helper for computing pan volume matrix
-    bool ComputePan(float pan, unsigned int channels, _Out_writes_(16) float* matrix) noexcept;
+    bool __cdecl ComputePan(float pan, unsigned int channels, _Out_writes_(16) float* matrix) noexcept;
 
     // Helper class for implementing SoundEffectInstance
     class SoundEffectInstanceBase

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -523,6 +523,9 @@ namespace DirectX
             size_t bpe = 0;
             switch (fmt)
             {
+            case DXGI_FORMAT_UNKNOWN:
+                return E_INVALIDARG;
+
             case DXGI_FORMAT_BC1_TYPELESS:
             case DXGI_FORMAT_BC1_UNORM:
             case DXGI_FORMAT_BC1_UNORM_SRGB:


### PR DESCRIPTION
I added some 'whitebox' testing of internal functions and it was resulting in link failures in some cases due to inconsistent calling conventions for the internal linkage. This decorates the internal free-functions for DirectX Tool Kit for Audio to make this linking robust.

> Also includes a minor update to use E_INVALIDARG