### PR TITLE
Code review for const auto vs auto const

### DIFF
--- a/Audio/SoundCommon.cpp
+++ b/Audio/SoundCommon.cpp
@@ -478,7 +478,7 @@ bool DirectX::IsValid(_In_ const WAVEFORMATEX* wfx) noexcept
 
             if (wfex->dwChannelMask)
             {
-                auto const channelBits = ChannelsSpecifiedInMask(wfex->dwChannelMask);
+                const auto channelBits = ChannelsSpecifiedInMask(wfex->dwChannelMask);
                 if (channelBits != wfx->nChannels)
                 {
                     DebugTrace("ERROR: WAVEFORMATEXTENSIBLE: nChannels=%u but ChannelMask has %u bits set\n",

--- a/Audio/SoundStreamInstance.cpp
+++ b/Audio/SoundStreamInstance.cpp
@@ -524,7 +524,7 @@ HRESULT SoundStreamInstance::Impl::ReadBuffers() noexcept
         {
             if (mCurrentPosition < mLengthInBytes)
             {
-                auto const cbValid = static_cast<uint32_t>(std::min(mPacketSize, mLengthInBytes - mCurrentPosition));
+                const auto cbValid = static_cast<uint32_t>(std::min(mPacketSize, mLengthInBytes - mCurrentPosition));
 
                 mPackets[entry].valid = cbValid;
                 mPackets[entry].audioBytes = 0;

--- a/Src/AlphaTestEffect.cpp
+++ b/Src/AlphaTestEffect.cpp
@@ -202,7 +202,7 @@ void AlphaTestEffect::Impl::Apply(_In_ ID3D11DeviceContext* deviceContext)
     if (dirtyFlags & EffectDirtyFlags::AlphaTest)
     {
         // Convert reference alpha from 8 bit integer to 0-1 float format.
-        auto const reference = static_cast<float>(referenceAlpha) / 255.0f;
+        const auto reference = static_cast<float>(referenceAlpha) / 255.0f;
 
         // Comparison tolerance of half the 8 bit integer precision.
         constexpr float threshold = 0.5f / 255.0f;

--- a/Src/Geometry.cpp
+++ b/Src/Geometry.cpp
@@ -307,7 +307,7 @@ void DirectX::ComputeGeoSphere(VertexCollection& vertices, IndexCollection& indi
             uint16_t iv20; // index of v20
 
             // Function that, when given the index of two vertices, creates a new vertex at the midpoint of those vertices.
-            auto const divideEdge = [&](uint16_t i0, uint16_t i1, XMFLOAT3& outVertex, uint16_t& outIndex)
+            const auto divideEdge = [&](uint16_t i0, uint16_t i1, XMFLOAT3& outVertex, uint16_t& outIndex)
             {
                 const UndirectedEdge edge = makeUndirectedEdge(i0, i1);
 
@@ -372,8 +372,8 @@ void DirectX::ComputeGeoSphere(VertexCollection& vertices, IndexCollection& indi
     vertices.reserve(vertexPositions.size());
     for (const auto& it : vertexPositions)
     {
-        auto const normal = XMVector3Normalize(XMLoadFloat3(&it));
-        auto const pos = XMVectorScale(normal, radius);
+        const auto normal = XMVector3Normalize(XMLoadFloat3(&it));
+        const auto pos = XMVectorScale(normal, radius);
 
         XMFLOAT3 normalFloat3;
         XMStoreFloat3(&normalFloat3, normal);
@@ -385,7 +385,7 @@ void DirectX::ComputeGeoSphere(VertexCollection& vertices, IndexCollection& indi
         const float u = longitude / XM_2PI + 0.5f;
         const float v = latitude / XM_PI;
 
-        auto const texcoord = XMVectorSet(1.0f - u, v, 0.0f, 0.0f);
+        const auto texcoord = XMVectorSet(1.0f - u, v, 0.0f, 0.0f);
         vertices.push_back(VertexPositionNormalTexture(pos, normal, texcoord));
     }
 
@@ -468,7 +468,7 @@ void DirectX::ComputeGeoSphere(VertexCollection& vertices, IndexCollection& indi
     // onto a single point. In general there's no real way to do that right. But to match the behavior of non-geodesic
     // spheres, we need to duplicate the pole vertex for every triangle that uses it. This will introduce seams near the
     // poles, but reduce stretching.
-    auto const fixPole = [&](size_t poleIndex)
+    const auto fixPole = [&](size_t poleIndex)
     {
         const auto& poleVertex = vertices[poleIndex];
         bool overwrittenPoleVertex = false; // overwriting the original pole vertex saves us one vertex

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -340,7 +340,7 @@ namespace DirectX
             }
 
             // DDS files always start with the same magic number ("DDS ")
-            auto const dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
+            const auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData);
             if (dwMagicNumber != DDS_MAGIC)
             {
                 return E_FAIL;
@@ -450,7 +450,7 @@ namespace DirectX
             }
 
             // DDS files always start with the same magic number ("DDS ")
-            auto const dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData.get());
+            const auto dwMagicNumber = *reinterpret_cast<const uint32_t*>(ddsData.get());
             if (dwMagicNumber != DDS_MAGIC)
             {
                 ddsData.reset();
@@ -963,7 +963,7 @@ namespace DirectX
                 if (MAKEFOURCC('D', 'X', '1', '0') == header->ddspf.fourCC)
                 {
                     auto d3d10ext = reinterpret_cast<const DDS_HEADER_DXT10*>(reinterpret_cast<const uint8_t*>(header) + sizeof(DDS_HEADER));
-                    auto const mode = static_cast<DDS_ALPHA_MODE>(d3d10ext->miscFlags2 & DDS_MISC_FLAGS2_ALPHA_MODE_MASK);
+                    const auto mode = static_cast<DDS_ALPHA_MODE>(d3d10ext->miscFlags2 & DDS_MISC_FLAGS2_ALPHA_MODE_MASK);
                     switch (mode)
                     {
                     case DDS_ALPHA_MODE_STRAIGHT:

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -297,7 +297,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromCMO(
                     throw std::runtime_error("IB too large for DirectX 11");
             }
 
-            auto const ibBytes = static_cast<size_t>(sizeInBytes);
+            const auto ibBytes = static_cast<size_t>(sizeInBytes);
 
             auto indexes = reinterpret_cast<const uint16_t*>(meshData + usedSize);
             usedSize += ibBytes;

--- a/Src/ModelLoadSDKMESH.cpp
+++ b/Src/ModelLoadSDKMESH.cpp
@@ -641,7 +641,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromSDKMESH(
         mesh->meshParts.reserve(mh.NumSubsets);
         for (size_t j = 0; j < mh.NumSubsets; ++j)
         {
-            auto const sIndex = subsets[j];
+            const auto sIndex = subsets[j];
             if (sIndex >= header->NumTotalSubsets)
                 throw std::out_of_range("Invalid mesh found");
 

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -77,7 +77,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
             throw std::runtime_error("VB too large for DirectX 11");
     }
 
-    auto const vertSize = static_cast<size_t>(sizeInBytes);
+    const auto vertSize = static_cast<size_t>(sizeInBytes);
 
     if (dataSize < (vertSize + sizeof(VBO::header_t)))
         throw std::runtime_error("End of file");
@@ -94,7 +94,7 @@ std::unique_ptr<Model> DirectX::Model::CreateFromVBO(
             throw std::runtime_error("IB too large for DirectX 11");
     }
 
-    auto const indexSize = static_cast<size_t>(sizeInBytes);
+    const auto indexSize = static_cast<size_t>(sizeInBytes);
 
     if (dataSize < (sizeof(VBO::header_t) + vertSize + indexSize))
         throw std::runtime_error("End of file");

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -1443,8 +1443,8 @@ void Mouse::ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam)
                     const int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
                     const int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 
-                    auto const x = static_cast<int>((float(raw.data.mouse.lLastX) / 65535.0f) * float(width));
-                    auto const y = static_cast<int>((float(raw.data.mouse.lLastY) / 65535.0f) * float(height));
+                    const auto x = static_cast<int>((float(raw.data.mouse.lLastX) / 65535.0f) * float(width));
+                    const auto y = static_cast<int>((float(raw.data.mouse.lLastY) / 65535.0f) * float(height));
 
                     if (pImpl->mRelativeX == INT32_MAX)
                     {

--- a/Src/SharedResourcePool.h
+++ b/Src/SharedResourcePool.h
@@ -93,7 +93,7 @@ namespace DirectX
             {
                 const std::lock_guard<std::mutex> lock(mResourceMap->mutex);
 
-                auto const pos = mResourceMap->find(mKey);
+                const auto pos = mResourceMap->find(mKey);
 
                 // Check for weak reference expiry before erasing, in case DemandCreate runs on
                 // a different thread at the same time as a previous instance is being destroyed.

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -795,8 +795,8 @@ void SpriteBatch::Impl::RenderBatch(ID3D11ShaderResourceView* texture, SpriteInf
     #endif
 
             // Ok lads, the time has come for us draw ourselves some sprites!
-        auto const startIndex = static_cast<UINT>(mContextResources->vertexBufferPosition * IndicesPerSprite);
-        auto const indexCount = static_cast<UINT>(batchSize * IndicesPerSprite);
+        const auto startIndex = static_cast<UINT>(mContextResources->vertexBufferPosition * IndicesPerSprite);
+        const auto indexCount = static_cast<UINT>(batchSize * IndicesPerSprite);
 
         deviceContext->DrawIndexed(indexCount, startIndex, 0);
 

--- a/Src/SpriteFont.cpp
+++ b/Src/SpriteFont.cpp
@@ -486,7 +486,7 @@ XMVECTOR XM_CALLCONV SpriteFont::MeasureString(_In_z_ wchar_t const* text, bool 
         {
             UNREFERENCED_PARAMETER(advance);
 
-            auto const w = static_cast<float>(glyph->Subrect.right - glyph->Subrect.left);
+            const auto w = static_cast<float>(glyph->Subrect.right - glyph->Subrect.left);
             auto h = static_cast<float>(glyph->Subrect.bottom - glyph->Subrect.top) + glyph->YOffset;
 
             h = iswspace(wchar_t(glyph->Character)) ?
@@ -506,9 +506,9 @@ RECT SpriteFont::MeasureDrawBounds(_In_z_ wchar_t const* text, XMFLOAT2 const& p
 
     pImpl->ForEachGlyph(text, [&](Glyph const* glyph, float x, float y, float advance) noexcept
         {
-            auto const isWhitespace = iswspace(wchar_t(glyph->Character));
-            auto const w = static_cast<float>(glyph->Subrect.right - glyph->Subrect.left);
-            auto const h = isWhitespace ?
+            const auto isWhitespace = iswspace(wchar_t(glyph->Character));
+            const auto w = static_cast<float>(glyph->Subrect.right - glyph->Subrect.left);
+            const auto h = isWhitespace ?
                 pImpl->lineSpacing :
                 static_cast<float>(glyph->Subrect.bottom - glyph->Subrect.top);
 

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -530,8 +530,8 @@ namespace
         if (rowBytes > UINT32_MAX || numBytes > UINT32_MAX)
             return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
 
-        auto const rowPitch = static_cast<size_t>(rowBytes);
-        auto const imageSize = static_cast<size_t>(numBytes);
+        const auto rowPitch = static_cast<size_t>(rowBytes);
+        const auto imageSize = static_cast<size_t>(numBytes);
 
         std::unique_ptr<uint8_t[]> temp(new (std::nothrow) uint8_t[imageSize]);
         if (!temp)

--- a/build/DirectXTK-GitHub-WSL-13.yml
+++ b/build/DirectXTK-GitHub-WSL-13.yml
@@ -23,7 +23,7 @@ pr:
     - CMake*
     - build/*.cmake
     - build/*.in
-    - build/DirectXTK-GitHub-WSL-11.yml
+    - build/DirectXTK-GitHub-WSL-13.yml
 
 resources:
   repositories:


### PR DESCRIPTION
Both ``const auto`` and ``auto const`` are equivalent in terms of the C++ compiler parser, but general coding guidelines suggest using ``const auto``. The primary reason for this PR is to be consistent since the codebase was using both.