### PR TITLE
disable release test for SimpleMath GNU v13

### DIFF
--- a/build/DirectXTK-GitHub-WSL-13.yml
+++ b/build/DirectXTK-GitHub-WSL-13.yml
@@ -155,7 +155,9 @@ jobs:
       script: ./out/bin/simplemathtest
       workingDirectory: Tests/SimpleMathTest
   - task: CmdLine@2
+    # This is disabled due to a failure in Vector3 reflect and Viewport unproject in release mode.
     displayName: Run tests rel
+    enabled: false
     inputs:
       script: ./out2/bin/simplemathtest
       workingDirectory: Tests/SimpleMathTest


### PR DESCRIPTION
The codegen bug with GCC v11 optimization of SimpleMath that resulted in disabling a test in #348 is still present in GCC 13.