### PR TITLE
Update ADO coverage for clang v12 

### DIFF
--- a/build/DirectXTK-GitHub-CMake.yml
+++ b/build/DirectXTK-GitHub-CMake.yml
@@ -100,103 +100,63 @@ jobs:
       cwd: '$(Build.SourcesDirectory)'
       cmakeArgs: --build out2 -v --config RelWithDebInfo
   - task: CMake@1
-    displayName: 'CMake (MSVC): Config ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -B out3 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_XAUDIO_WIN8=ON -DBUILD_TOOLS=ON'
-  - task: CMake@1
-    displayName: 'CMake (MSVC): Build ARM64 Debug'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out3 -v --config Debug
-  - task: CMake@1
-    displayName: 'CMake (MSVC): Build ARM64 Release'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out3 -v --config RelWithDebInfo
-  - task: CMake@1
     displayName: 'CMake (UWP): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out4 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out3 -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0'
   - task: CMake@1
     displayName: 'CMake (UWP): Build x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out4 -v
+      cmakeArgs: --build out3 -v
   - task: CMake@1
     displayName: 'CMake (ClangCl): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -T clangcl -B out6 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_XAUDIO_WIN8=ON -DBUILD_TOOLS=ON'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -T clangcl -B out4 -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_XAUDIO_WIN8=ON -DBUILD_TOOLS=ON'
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build x64 Debug'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out6 -v --config Debug
+      cmakeArgs: --build out4 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (ClangCl): Build x64 Release'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out6 -v --config RelWithDebInfo
-  - task: CMake@1
-    displayName: 'CMake (ClangCl): Config ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -T clangcl -B out7 -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK) -DBUILD_XAUDIO_WIN8=ON -DBUILD_TOOLS=ON'
-  - task: CMake@1
-    displayName: 'CMake (ClangCl): Build ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out7 -v --config Debug
+      cmakeArgs: --build out4 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (Win10): Config'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out8 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_XAUDIO_WIN10=ON -DBUILD_TOOLS=OFF'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out5 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_XAUDIO_WIN10=ON -DBUILD_TOOLS=OFF'
   - task: CMake@1
     displayName: 'CMake (Win10): Build'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out8 -v
+      cmakeArgs: --build out5 -v
   # removed out9 case
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Config x64'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out10 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_XAUDIO_WIN8=ON -DBUILD_TOOLS=ON'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out6 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_XAUDIO_WIN8=ON -DBUILD_TOOLS=ON'
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build x64 Debug'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out10 -v --config Debug
+      cmakeArgs: --build out6 -v --config Debug
   - task: CMake@1
     displayName: 'CMake (MSVC Spectre): Build x64 Release'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out10 -v --config RelWithDebInfo
-  - task: CMake@1
-    displayName: 'CMake (MSVC Spectre): Config ARM64'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A ARM64 -B out11 -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK) -DBUILD_XAUDIO_WIN8=ON -DBUILD_TOOLS=ON'
-  - task: CMake@1
-    displayName: 'CMake (MSVC Spectre): Build ARM64 Debug'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out11 -v --config Debug
-  - task: CMake@1
-    displayName: 'CMake (MSVC Spectre): Build ARM64 Release'
-    inputs:
-      cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out11 -v --config RelWithDebInfo
+      cmakeArgs: --build out6 -v --config RelWithDebInfo
   - task: CMake@1
     displayName: 'CMake (NO_WCHAR_T): Config'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out12 -DNO_WCHAR_T=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
+      cmakeArgs: '-G "$(VS_GENERATOR)" -A x64 -B out7 -DNO_WCHAR_T=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
   - task: CMake@1
     displayName: 'CMake (NO_WCHAR_T): Build'
     inputs:
       cwd: '$(Build.SourcesDirectory)'
-      cmakeArgs: --build out12 -v --config Debug
+      cmakeArgs: --build out7 -v --config Debug

--- a/build/DirectXTK-GitHub-Test-Dev17.yml
+++ b/build/DirectXTK-GitHub-Test-Dev17.yml
@@ -160,6 +160,103 @@ jobs:
       configuration: Release
       msbuildArchitecture: x64
 
+- job: UWP_BUILD_X64
+  displayName: 'Universal Windows Platform (UWP) for x64'
+  timeoutInMinutes: 120
+  cancelTimeoutInMinutes: 1
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
+  - task: VSBuild@1
+    displayName: Build solution DirectXTK_Tests_Windows10.sln 64dbg
+    inputs:
+      solution: Tests/DirectXTK_Tests_Windows10.sln
+      vsVersion: 16.0
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
+      platform: x64
+      configuration: Debug
+  - task: VSBuild@1
+    displayName: Build solution DirectXTK_Tests_Windows10.sln 64rel
+    inputs:
+      solution: Tests/DirectXTK_Tests_Windows10.sln
+      vsVersion: 16.0
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
+      platform: x64
+      configuration: Release
+
+- job: UWP_BUILD_X86
+  displayName: 'Universal Windows Platform (UWP) for x86'
+  timeoutInMinutes: 120
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
+  - task: VSBuild@1
+    displayName: Build solution DirectXTK_Tests_Windows10.sln 32dbg
+    inputs:
+      solution: Tests/DirectXTK_Tests_Windows10.sln
+      vsVersion: 16.0
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
+      platform: x86
+      configuration: Debug
+  - task: VSBuild@1
+    displayName: Build solution DirectXTK_Tests_Windows10.sln 32rel
+    inputs:
+      solution: Tests/DirectXTK_Tests_Windows10.sln
+      vsVersion: 16.0
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
+      platform: x86
+      configuration: Release
+
+- job: UWP_BUILD_ARM64
+  displayName: 'Universal Windows Platform (UWP) for ARM64'
+  timeoutInMinutes: 120
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's'
+  - checkout: testRepo
+    displayName: Fetch Tests
+    clean: true
+    fetchTags: false
+    fetchDepth: 1
+    path: 's/Tests'
+  - task: VSBuild@1
+    displayName: Build solution DirectXTK_Tests_Windows10.sln arm64dbg
+    inputs:
+      solution: Tests/DirectXTK_Tests_Windows10.sln
+      vsVersion: 16.0
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
+      platform: ARM64
+      configuration: Debug
+  - task: VSBuild@1
+    displayName: Build solution DirectXTK_Tests_Windows10.sln arm64rel
+    inputs:
+      solution: Tests/DirectXTK_Tests_Windows10.sln
+      vsVersion: 16.0
+      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
+      platform: ARM64
+      configuration: Release
+
 - job: CMAKE_BUILD_X64
   displayName: 'CMake for X64 BUILD_TESTING=ON'
   timeoutInMinutes: 60

--- a/build/DirectXTK-GitHub-Test-Dev17.yml
+++ b/build/DirectXTK-GitHub-Test-Dev17.yml
@@ -180,7 +180,7 @@ jobs:
     displayName: Build solution DirectXTK_Tests_Windows10.sln 64dbg
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
+      vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
       platform: x64
       configuration: Debug
@@ -188,7 +188,7 @@ jobs:
     displayName: Build solution DirectXTK_Tests_Windows10.sln 64rel
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
+      vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
       platform: x64
       configuration: Release
@@ -212,7 +212,7 @@ jobs:
     displayName: Build solution DirectXTK_Tests_Windows10.sln 32dbg
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
+      vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
       platform: x86
       configuration: Debug
@@ -220,7 +220,7 @@ jobs:
     displayName: Build solution DirectXTK_Tests_Windows10.sln 32rel
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
+      vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
       platform: x86
       configuration: Release
@@ -244,7 +244,7 @@ jobs:
     displayName: Build solution DirectXTK_Tests_Windows10.sln arm64dbg
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
+      vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
       platform: ARM64
       configuration: Debug
@@ -252,7 +252,7 @@ jobs:
     displayName: Build solution DirectXTK_Tests_Windows10.sln arm64rel
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
+      vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
       platform: ARM64
       configuration: Release

--- a/build/DirectXTK-GitHub-Test.yml
+++ b/build/DirectXTK-GitHub-Test.yml
@@ -191,3 +191,26 @@ jobs:
   - task: DeleteFiles@1
     inputs:
       Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Debug) Config
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --preset=x64-Debug-Clang
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Debug) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out/build/x64-Debug-Clang -v
+  - task: DeleteFiles@1
+    inputs:
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Release) Config
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --preset=x64-Release-Clang
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Release) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out/build/x64-Release-Clang -v

--- a/build/DirectXTK-GitHub-Test.yml
+++ b/build/DirectXTK-GitHub-Test.yml
@@ -191,26 +191,3 @@ jobs:
   - task: DeleteFiles@1
     inputs:
       Contents: 'out'
-  - task: CMake@1
-    displayName: CMake (clang/LLVM; x64-Debug) Config
-    inputs:
-      cwd: $(Build.SourcesDirectory)
-      cmakeArgs: --preset=x64-Debug-Clang
-  - task: CMake@1
-    displayName: CMake (clang/LLVM; x64-Debug) Build
-    inputs:
-      cwd: $(Build.SourcesDirectory)
-      cmakeArgs: --build out/build/x64-Debug-Clang -v
-  - task: DeleteFiles@1
-    inputs:
-      Contents: 'out'
-  - task: CMake@1
-    displayName: CMake (clang/LLVM; x64-Release) Config
-    inputs:
-      cwd: $(Build.SourcesDirectory)
-      cmakeArgs: --preset=x64-Release-Clang
-  - task: CMake@1
-    displayName: CMake (clang/LLVM; x64-Release) Build
-    inputs:
-      cwd: $(Build.SourcesDirectory)
-      cmakeArgs: --build out/build/x64-Release-Clang -v

--- a/build/DirectXTK-GitHub-Test.yml
+++ b/build/DirectXTK-GitHub-Test.yml
@@ -40,6 +40,7 @@ pool:
 
 variables:
   Codeql.Enabled: false
+  VC_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC'
   GUID_FEED: $(ADOFeedGUID)
 
 jobs:

--- a/build/DirectXTK-GitHub-Test.yml
+++ b/build/DirectXTK-GitHub-Test.yml
@@ -36,7 +36,7 @@ resources:
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 pool:
-  vmImage: windows-2022
+  vmImage: windows-2019
 
 variables:
   Codeql.Enabled: false
@@ -131,27 +131,12 @@ jobs:
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln arm64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln arm64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
 
-- job: UWP_BUILD_X64
-  displayName: 'Universal Windows Platform (UWP) for x64'
-  timeoutInMinutes: 120
-  cancelTimeoutInMinutes: 1
+- job: CMAKE_BUILD_X64
+  displayName: 'CMake for X64 BUILD_TESTING=ON'
+  timeoutInMinutes: 60
+  workspace:
+    clean: all
   steps:
   - checkout: self
     clean: true
@@ -164,83 +149,67 @@ jobs:
     fetchTags: false
     fetchDepth: 1
     path: 's/Tests'
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 64dbg
+  - task: CmdLine@2
+    displayName: Setup environment for CMake to use VS
     inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x64
-      configuration: Release
+      script: |
+        call "$(VC_PATH)\Auxiliary\Build\vcvars64.bat"
+        echo ##vso[task.setvariable variable=WindowsSdkVerBinPath;]%WindowsSdkVerBinPath%
+        echo ##vso[task.prependpath]%VSINSTALLDIR%Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja
+        echo ##vso[task.prependpath]%VCINSTALLDIR%Tools\Llvm\x64\bin
+        echo ##vso[task.prependpath]%WindowsSdkBinPath%x64
+        echo ##vso[task.prependpath]%WindowsSdkVerBinPath%x64
+        echo ##vso[task.prependpath]%VCToolsInstallDir%bin\Hostx64\x64
+        echo ##vso[task.setvariable variable=EXTERNAL_INCLUDE;]%EXTERNAL_INCLUDE%
+        echo ##vso[task.setvariable variable=INCLUDE;]%INCLUDE%
+        echo ##vso[task.setvariable variable=LIB;]%LIB%
 
-- job: UWP_BUILD_X86
-  displayName: 'Universal Windows Platform (UWP) for x86'
-  timeoutInMinutes: 120
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's'
-  - checkout: testRepo
-    displayName: Fetch Tests
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's/Tests'
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 32dbg
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Debug) Config
     inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 32rel
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --preset=x64-Debug
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Debug) Build
     inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x86
-      configuration: Release
-
-- job: UWP_BUILD_ARM64
-  displayName: 'Universal Windows Platform (UWP) for ARM64'
-  timeoutInMinutes: 120
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's'
-  - checkout: testRepo
-    displayName: Fetch Tests
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's/Tests'
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln arm64dbg
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out/build/x64-Debug -v
+  - task: DeleteFiles@1
     inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln arm64rel
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Release) Config
     inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: ARM64
-      configuration: Release
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --preset=x64-Release
+  - task: CMake@1
+    displayName: CMake (MSVC; x64-Release) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out/build/x64-Release -v
+  - task: DeleteFiles@1
+    inputs:
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Debug) Config
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --preset=x64-Debug-Clang
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Debug) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out/build/x64-Debug-Clang -v
+  - task: DeleteFiles@1
+    inputs:
+      Contents: 'out'
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Release) Config
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --preset=x64-Release-Clang
+  - task: CMake@1
+    displayName: CMake (clang/LLVM; x64-Release) Build
+    inputs:
+      cwd: $(Build.SourcesDirectory)
+      cmakeArgs: --build out/build/x64-Release-Clang -v

--- a/build/DirectXTK-GitHub.yml
+++ b/build/DirectXTK-GitHub.yml
@@ -123,17 +123,3 @@ jobs:
       msbuildArgs: /p:PreferredToolArchitecture=x64
       platform: x64
       configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln arm64rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release


### PR DESCRIPTION
Remove cases of building for ARM64 with VS 2019 due to changes to Windows SDK (26100).

Also cleans up the original #436 quick fix for UWP which should be building in the Dev17 pipeline.

