### PR TITLE
SimpleMath fixes for binary operator* with scalar

### DIFF
--- a/Inc/SimpleMath.h
+++ b/Inc/SimpleMath.h
@@ -235,9 +235,10 @@ namespace DirectX
         DIRECTX_TOOLKIT_API inline Vector2 operator- (const Vector2& V1, const Vector2& V2) noexcept { return Vector2(V1.x - V2.x, V1.y - V2.y); }
         DIRECTX_TOOLKIT_API inline Vector2 operator* (const Vector2& V1, const Vector2& V2) noexcept { return Vector2(V1.x * V2.x, V1.y * V2.y); }
         DIRECTX_TOOLKIT_API inline Vector2 operator* (const Vector2& V, float S) noexcept { return Vector2(V.x * S, V.y * S); }
+        DIRECTX_TOOLKIT_API inline Vector2 operator* (float S, const Vector2& V) noexcept { return Vector2(S * V.x, S * V.y); }
         DIRECTX_TOOLKIT_API inline Vector2 operator/ (const Vector2& V1, const Vector2& V2) noexcept { return Vector2(V1.x / V2.x, V1.y / V2.y); }
         DIRECTX_TOOLKIT_API inline Vector2 operator/ (const Vector2& V, float S) noexcept { return Vector2(V.x / S, V.y / S); }
-        DIRECTX_TOOLKIT_API inline Vector2 operator* (float S, const Vector2& V) noexcept { return Vector2(S / V.x, S / V.y); };
+        DIRECTX_TOOLKIT_API inline Vector2 operator/ (float S, const Vector2& V) noexcept { return Vector2(S / V.x, S / V.y); };
 
         //------------------------------------------------------------------------------
         // 3D vector
@@ -355,9 +356,10 @@ namespace DirectX
         DIRECTX_TOOLKIT_API inline Vector3 operator- (const Vector3& V1, const Vector3& V2) noexcept { return Vector3(V1.x - V2.x, V1.y - V2.y, V1.z - V2.z); }
         DIRECTX_TOOLKIT_API inline Vector3 operator* (const Vector3& V1, const Vector3& V2) noexcept { return Vector3(V1.x * V2.x, V1.y * V2.y, V1.z * V2.z); }
         DIRECTX_TOOLKIT_API inline Vector3 operator* (const Vector3& V, float S) noexcept  { return Vector3(V.x * S, V.y * S, V.z * S); }
+        DIRECTX_TOOLKIT_API inline Vector3 operator* (float S, const Vector3& V) noexcept  { return Vector3(S * V.x, S * V.y, S * V.z); }
         DIRECTX_TOOLKIT_API inline Vector3 operator/ (const Vector3& V1, const Vector3& V2) noexcept { return Vector3(V1.x / V2.x, V1.y / V2.y, V1.z / V2.z); }
         DIRECTX_TOOLKIT_API inline Vector3 operator/ (const Vector3& V, float S) noexcept { return Vector3(V.x / S, V.y / S, V.z / S); }
-        DIRECTX_TOOLKIT_API inline Vector3 operator* (float S, const Vector3& V) noexcept { return Vector3(S / V.x, S / V.y, S / V.z); }
+        DIRECTX_TOOLKIT_API inline Vector3 operator/ (float S, const Vector3& V) noexcept { return Vector3(S / V.x, S / V.y, S / V.z); }
 
         //------------------------------------------------------------------------------
         // 4D vector
@@ -469,9 +471,10 @@ namespace DirectX
         DIRECTX_TOOLKIT_API Vector4 operator- (const Vector4& V1, const Vector4& V2) noexcept;
         DIRECTX_TOOLKIT_API Vector4 operator* (const Vector4& V1, const Vector4& V2) noexcept;
         DIRECTX_TOOLKIT_API Vector4 operator* (const Vector4& V, float S) noexcept;
+        DIRECTX_TOOLKIT_API Vector4 operator* (float S, const Vector4& V) noexcept;
         DIRECTX_TOOLKIT_API Vector4 operator/ (const Vector4& V1, const Vector4& V2) noexcept;
         DIRECTX_TOOLKIT_API Vector4 operator/ (const Vector4& V, float S) noexcept;
-        DIRECTX_TOOLKIT_API Vector4 operator* (float S, const Vector4& V) noexcept;
+        DIRECTX_TOOLKIT_API Vector4 operator/ (float S, const Vector4& V) noexcept;
 
         //------------------------------------------------------------------------------
         // 4x4 Matrix (assumes right-handed cooordinates)
@@ -636,11 +639,11 @@ namespace DirectX
         DIRECTX_TOOLKIT_API Matrix operator- (const Matrix& M1, const Matrix& M2) noexcept;
         DIRECTX_TOOLKIT_API Matrix operator* (const Matrix& M1, const Matrix& M2) noexcept;
         DIRECTX_TOOLKIT_API Matrix operator* (const Matrix& M, float S) noexcept;
+        DIRECTX_TOOLKIT_API Matrix operator* (float S, const Matrix& M) noexcept;
         DIRECTX_TOOLKIT_API Matrix operator/ (const Matrix& M, float S) noexcept;
         DIRECTX_TOOLKIT_API Matrix operator/ (const Matrix& M1, const Matrix& M2) noexcept;
             // Element-wise divide
-            DIRECTX_TOOLKIT_API Matrix operator* (float S, const Matrix& M) noexcept;
-
+        DIRECTX_TOOLKIT_API Matrix operator/ (float S, const Matrix& M) noexcept;
 
         //-----------------------------------------------------------------------------
         // Plane
@@ -790,8 +793,8 @@ namespace DirectX
         DIRECTX_TOOLKIT_API Quaternion operator- (const Quaternion& Q1, const Quaternion& Q2) noexcept;
         DIRECTX_TOOLKIT_API Quaternion operator* (const Quaternion& Q1, const Quaternion& Q2) noexcept;
         DIRECTX_TOOLKIT_API Quaternion operator* (const Quaternion& Q, float S) noexcept;
-        DIRECTX_TOOLKIT_API Quaternion operator/ (const Quaternion& Q1, const Quaternion& Q2) noexcept;
         DIRECTX_TOOLKIT_API Quaternion operator* (float S, const Quaternion& Q) noexcept;
+        DIRECTX_TOOLKIT_API Quaternion operator/ (const Quaternion& Q1, const Quaternion& Q2) noexcept;
 
         //------------------------------------------------------------------------------
         // Color
@@ -888,8 +891,8 @@ namespace DirectX
         DIRECTX_TOOLKIT_API Color operator- (const Color& C1, const Color& C2) noexcept;
         DIRECTX_TOOLKIT_API Color operator* (const Color& C1, const Color& C2) noexcept;
         DIRECTX_TOOLKIT_API Color operator* (const Color& C, float S) noexcept;
-        DIRECTX_TOOLKIT_API Color operator/ (const Color& C1, const Color& C2) noexcept;
         DIRECTX_TOOLKIT_API Color operator* (float S, const Color& C) noexcept;
+        DIRECTX_TOOLKIT_API Color operator/ (const Color& C1, const Color& C2) noexcept;
 
         //------------------------------------------------------------------------------
         // Ray

--- a/Inc/SimpleMath.h
+++ b/Inc/SimpleMath.h
@@ -379,7 +379,7 @@ namespace DirectX
             Vector4(Vector4&&) = default;
             Vector4& operator=(Vector4&&) = default;
 
-            operator XMVECTOR() const  noexcept { return XMLoadFloat4(this); }
+            operator XMVECTOR() const noexcept { return XMLoadFloat4(this); }
 
             // Comparison operators
             bool operator == (const Vector4& V) const noexcept;
@@ -550,7 +550,7 @@ namespace DirectX
             Vector3 Up() const noexcept { return Vector3(_21, _22, _23); }
             void Up(const Vector3& v) noexcept { _21 = v.x; _22 = v.y; _23 = v.z; }
 
-            Vector3 Down() const  noexcept { return Vector3(-_21, -_22, -_23); }
+            Vector3 Down() const noexcept { return Vector3(-_21, -_22, -_23); }
             void Down(const Vector3& v) noexcept { _21 = -v.x; _22 = -v.y; _23 = -v.z; }
 
             Vector3 Right() const noexcept { return Vector3(_11, _12, _13); }
@@ -565,7 +565,7 @@ namespace DirectX
             Vector3 Backward() const noexcept { return Vector3(_31, _32, _33); }
             void Backward(const Vector3& v) noexcept { _31 = v.x; _32 = v.y; _33 = v.z; }
 
-            Vector3 Translation() const  noexcept { return Vector3(_41, _42, _43); }
+            Vector3 Translation() const noexcept { return Vector3(_41, _42, _43); }
             void Translation(const Vector3& v) noexcept { _41 = v.x; _42 = v.y; _43 = v.z; }
 
             // Matrix operations
@@ -733,7 +733,7 @@ namespace DirectX
             Quaternion& operator/= (const Quaternion& q) noexcept;
 
             // Unary operators
-            Quaternion operator+ () const  noexcept { return *this; }
+            Quaternion operator+ () const noexcept { return *this; }
             Quaternion operator- () const noexcept { return Quaternion(-x, -y, -z, -w); }
 
             // Quaternion operations
@@ -860,8 +860,8 @@ namespace DirectX
             DirectX::PackedVector::XMCOLOR BGRA() const noexcept;
             DirectX::PackedVector::XMUBYTEN4 RGBA() const noexcept;
 
-            Vector3 ToVector3() const noexcept;
-            Vector4 ToVector4() const noexcept;
+            Vector3 ToVector3() const noexcept { return Vector3(x, y, z); }
+            Vector4 ToVector4() const noexcept { return Vector4(x, y, z, w); }
 
             void Negate() noexcept;
             void Negate(Color& result) const noexcept;

--- a/Inc/SimpleMath.inl
+++ b/Inc/SimpleMath.inl
@@ -3090,16 +3090,6 @@ inline DirectX::PackedVector::XMUBYTEN4 Color::RGBA() const noexcept
     return Packed;
 }
 
-inline Vector3 Color::ToVector3() const noexcept
-{
-    return Vector3(x, y, z);
-}
-
-inline Vector4 Color::ToVector4() const noexcept
-{
-    return Vector4(x, y, z, w);
-}
-
 inline void Color::Negate() noexcept
 {
     using namespace DirectX;

--- a/Inc/SimpleMath.inl
+++ b/Inc/SimpleMath.inl
@@ -960,8 +960,8 @@ inline Vector4& Vector4::operator*= (const Vector4& V) noexcept
 inline Vector4& Vector4::operator*= (float S) noexcept
 {
     using namespace DirectX;
-    const XMVECTOR v1 = XMLoadFloat4(this);
-    const XMVECTOR X = XMVectorScale(v1, S);
+    const XMVECTOR v = XMLoadFloat4(this);
+    const XMVECTOR X = XMVectorScale(v, S);
     XMStoreFloat4(this, X);
     return *this;
 }
@@ -970,8 +970,8 @@ inline Vector4& Vector4::operator/= (float S) noexcept
 {
     using namespace DirectX;
     assert(S != 0.0f);
-    const XMVECTOR v1 = XMLoadFloat4(this);
-    const XMVECTOR X = XMVectorScale(v1, 1.f / S);
+    const XMVECTOR v = XMLoadFloat4(this);
+    const XMVECTOR X = XMVectorScale(v, 1.f / S);
     XMStoreFloat4(this, X);
     return *this;
 }
@@ -1016,8 +1016,18 @@ inline Vector4 operator* (const Vector4& V1, const Vector4& V2) noexcept
 inline Vector4 operator* (const Vector4& V, float S) noexcept
 {
     using namespace DirectX;
-    const XMVECTOR v1 = XMLoadFloat4(&V);
-    const XMVECTOR X = XMVectorScale(v1, S);
+    const XMVECTOR v = XMLoadFloat4(&V);
+    const XMVECTOR X = XMVectorScale(v, S);
+    Vector4 R;
+    XMStoreFloat4(&R, X);
+    return R;
+}
+
+inline Vector4 operator* (float S, const Vector4& V) noexcept
+{
+    using namespace DirectX;
+    const XMVECTOR v = XMLoadFloat4(&V);
+    const XMVECTOR X = XMVectorScale(v, S);
     Vector4 R;
     XMStoreFloat4(&R, X);
     return R;
@@ -1037,21 +1047,23 @@ inline Vector4 operator/ (const Vector4& V1, const Vector4& V2) noexcept
 inline Vector4 operator/ (const Vector4& V, float S) noexcept
 {
     using namespace DirectX;
-    const XMVECTOR v1 = XMLoadFloat4(&V);
-    const XMVECTOR X = XMVectorScale(v1, 1.f / S);
+    const XMVECTOR v = XMLoadFloat4(&V);
+    const XMVECTOR X = XMVectorScale(v, 1.f / S);
     Vector4 R;
     XMStoreFloat4(&R, X);
     return R;
 }
 
-inline Vector4 operator* (float S, const Vector4& V) noexcept
+inline Vector4 operator/ (float S, const Vector4& V) noexcept
 {
     using namespace DirectX;
-    const XMVECTOR v1 = XMLoadFloat4(&V);
-    const XMVECTOR X = XMVectorScale(v1, S);
+    const XMVECTOR v1 = XMVectorReplicate(S);
+    const XMVECTOR v2 = XMLoadFloat4(&V);
+    const XMVECTOR X = XMVectorDivide(v1, v2);
     Vector4 R;
     XMStoreFloat4(&R, X);
     return R;
+
 }
 
 //------------------------------------------------------------------------------
@@ -1804,6 +1816,28 @@ inline Matrix operator* (const Matrix& M, float S) noexcept
     return R;
 }
 
+inline Matrix operator* (float S, const Matrix& M) noexcept
+{
+    using namespace DirectX;
+
+    XMVECTOR x1 = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(&M._11));
+    XMVECTOR x2 = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(&M._21));
+    XMVECTOR x3 = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(&M._31));
+    XMVECTOR x4 = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(&M._41));
+
+    x1 = XMVectorScale(x1, S);
+    x2 = XMVectorScale(x2, S);
+    x3 = XMVectorScale(x3, S);
+    x4 = XMVectorScale(x4, S);
+
+    Matrix R;
+    XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&R._11), x1);
+    XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&R._21), x2);
+    XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&R._31), x3);
+    XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&R._41), x4);
+    return R;
+}
+
 inline Matrix operator/ (const Matrix& M, float S) noexcept
 {
     using namespace DirectX;
@@ -1855,7 +1889,7 @@ inline Matrix operator/ (const Matrix& M1, const Matrix& M2) noexcept
     return R;
 }
 
-inline Matrix operator* (float S, const Matrix& M) noexcept
+inline Matrix operator/ (float S, const Matrix& M) noexcept
 {
     using namespace DirectX;
 
@@ -1864,10 +1898,12 @@ inline Matrix operator* (float S, const Matrix& M) noexcept
     XMVECTOR x3 = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(&M._31));
     XMVECTOR x4 = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(&M._41));
 
-    x1 = XMVectorScale(x1, S);
-    x2 = XMVectorScale(x2, S);
-    x3 = XMVectorScale(x3, S);
-    x4 = XMVectorScale(x4, S);
+    XMVECTOR vs = XMVectorReplicate(S);
+
+    x1 = XMVectorDivide(vs, x1);
+    x2 = XMVectorDivide(vs, x2);
+    x3 = XMVectorDivide(vs, x3);
+    x4 = XMVectorDivide(vs, x4);
 
     Matrix R;
     XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&R._11), x1);
@@ -2596,6 +2632,16 @@ inline Quaternion operator* (const Quaternion& Q, float S) noexcept
     return R;
 }
 
+inline Quaternion operator* (float S, const Quaternion& Q) noexcept
+{
+    using namespace DirectX;
+    const XMVECTOR q1 = XMLoadFloat4(&Q);
+
+    Quaternion R;
+    XMStoreFloat4(&R, XMVectorScale(q1, S));
+    return R;
+}
+
 inline Quaternion operator/ (const Quaternion& Q1, const Quaternion& Q2) noexcept
 {
     using namespace DirectX;
@@ -2605,16 +2651,6 @@ inline Quaternion operator/ (const Quaternion& Q1, const Quaternion& Q2) noexcep
 
     Quaternion R;
     XMStoreFloat4(&R, XMQuaternionMultiply(q1, q2));
-    return R;
-}
-
-inline Quaternion operator* (float S, const Quaternion& Q) noexcept
-{
-    using namespace DirectX;
-    const XMVECTOR q1 = XMLoadFloat4(&Q);
-
-    Quaternion R;
-    XMStoreFloat4(&R, XMVectorScale(q1, S));
     return R;
 }
 
@@ -3013,6 +3049,15 @@ inline Color operator* (const Color& C, float S) noexcept
     return R;
 }
 
+inline Color operator* (float S, const Color& C) noexcept
+{
+    using namespace DirectX;
+    const XMVECTOR c1 = XMLoadFloat4(&C);
+    Color R;
+    XMStoreFloat4(&R, XMVectorScale(c1, S));
+    return R;
+}
+
 inline Color operator/ (const Color& C1, const Color& C2) noexcept
 {
     using namespace DirectX;
@@ -3020,15 +3065,6 @@ inline Color operator/ (const Color& C1, const Color& C2) noexcept
     const XMVECTOR c2 = XMLoadFloat4(&C2);
     Color R;
     XMStoreFloat4(&R, XMVectorDivide(c1, c2));
-    return R;
-}
-
-inline Color operator* (float S, const Color& C) noexcept
-{
-    using namespace DirectX;
-    const XMVECTOR c1 = XMLoadFloat4(&C);
-    Color R;
-    XMStoreFloat4(&R, XMVectorScale(c1, S));
     return R;
 }
 


### PR DESCRIPTION
* Fixed regression in #539 with Vector2/Vector3 * operator with scalar float first.
* added `operator/(scalar, vector)` for Vector2, Vector3, Vector4
* added `operator/(scalar, matrix)` for Matrix
* some minor code review
