### PR TITLE
GameInput implementation updates for for GAMEINPUT_API_VERSION = 1

### DIFF
--- a/Inc/GamePad.h
+++ b/Inc/GamePad.h
@@ -325,7 +325,13 @@ namespace DirectX
         // Underlying device access
         _Success_(return)
         DIRECTX_TOOLKIT_API
-        bool __cdecl GetDevice(int player, _Outptr_ IGameInputDevice * *device) noexcept;
+        bool __cdecl GetDevice(int player,
+        #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+            _Outptr_ GameInput::v1::IGameInputDevice * *device
+        #else
+            _Outptr_ IGameInputDevice * *device
+        #endif
+            ) noexcept;
     #elif defined(USING_WINDOWS_GAMING_INPUT) || defined(_XBOX_ONE)
         DIRECTX_TOOLKIT_API void __cdecl RegisterEvents(void* ctrlChanged, void* userChanged) noexcept;
     #endif

--- a/Src/GamePad.cpp
+++ b/Src/GamePad.cpp
@@ -16,6 +16,10 @@
 using namespace DirectX;
 using Microsoft::WRL::ComPtr;
 
+#if defined(USING_GAMEINPUT) && defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+using namespace GameInput::v1;
+#endif
+
 
 namespace
 {
@@ -141,7 +145,11 @@ public:
         {
             if (mGameInput)
             {
+            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                if (!mGameInput->UnregisterCallback(mDeviceToken))
+            #else
                 if (!mGameInput->UnregisterCallback(mDeviceToken, UINT64_MAX))
+            #endif
                 {
                     DebugTrace("ERROR: GameInput::UnregisterCallback [gamepad] failed");
                 }
@@ -189,7 +197,11 @@ public:
             if (reading->GetGamepadState(&pad))
             {
                 state.connected = true;
+            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                state.packet = mGameInput->GetCurrentTimestamp();
+            #else
                 state.packet = reading->GetSequenceNumber(GameInputKindGamepad);
+            #endif
 
                 state.buttons.a = (pad.buttons & GameInputGamepadA) != 0;
                 state.buttons.b = (pad.buttons & GameInputGamepadB) != 0;
@@ -233,12 +245,20 @@ public:
             {
                 if (device->GetDeviceStatus() & GameInputDeviceConnected)
                 {
+                #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                    const GameInputDeviceInfo* deviceInfo = nullptr;
+                    device->GetDeviceInfo(&deviceInfo);
+                #else
                     auto deviceInfo = device->GetDeviceInfo();
+                #endif
                     caps.connected = true;
                     caps.gamepadType = Capabilities::GAMEPAD;
                     caps.id = deviceInfo->deviceId;
                     caps.vid = deviceInfo->vendorId;
                     caps.pid = deviceInfo->productId;
+                #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                    // TODO - How do I free deviceInfo?
+                #endif
                     return;
                 }
                 else

--- a/Src/Keyboard.cpp
+++ b/Src/Keyboard.cpp
@@ -53,6 +53,11 @@ namespace
 
 #include <GameInput.h>
 
+#if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+using namespace GameInput::v1;
+#endif
+
+
 //======================================================================================
 // GameInput
 //======================================================================================
@@ -111,7 +116,11 @@ public:
         {
             if (mGameInput)
             {
+            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                if (!mGameInput->UnregisterCallback(mDeviceToken))
+            #else
                 if (!mGameInput->UnregisterCallback(mDeviceToken, UINT64_MAX))
+            #endif
                 {
                     DebugTrace("ERROR: GameInput::UnregisterCallback [keyboard] failed");
                 }

--- a/Src/Mouse.cpp
+++ b/Src/Mouse.cpp
@@ -21,6 +21,10 @@ using Microsoft::WRL::ComPtr;
 
 #include <GameInput.h>
 
+#if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+using namespace GameInput::v1;
+#endif
+
 //======================================================================================
 // Win32 + GameInput implementation
 //======================================================================================
@@ -121,7 +125,11 @@ public:
         {
             if (mGameInput)
             {
+            #if defined(GAMEINPUT_API_VERSION) && (GAMEINPUT_API_VERSION == 1)
+                if (!mGameInput->UnregisterCallback(mDeviceToken))
+            #else
                 if (!mGameInput->UnregisterCallback(mDeviceToken, UINT64_MAX))
+            #endif
                 {
                     DebugTrace("ERROR: GameInput::UnregisterCallback [mouse] failed");
                 }


### PR DESCRIPTION
The original GameInput implementation that is used for the Microsoft GDK is 'verison 0'. Version 1 of the API was released today. This updates the implementation of GamePad, Keyboard, and Mouse to support both the old and new versions.
