### PR TITLE
Improve control for X3DAudio calculate flags

### DIFF
--- a/Audio/AudioEngine.cpp
+++ b/Audio/AudioEngine.cpp
@@ -136,7 +136,7 @@ namespace
         XAUDIO2FX_I3DL2_PRESET_PLATE,               // Reverb_Plate
     };
 
-    constexpr uint32_t c_XAudio3DCalculateDefault = X3DAUDIO_CALCULATE_MATRIX | X3DAUDIO_CALCULATE_DOPPLER | X3DAUDIO_CALCULATE_LPF_DIRECT;
+    constexpr uint32_t c_XAudio3DCalculateDefault = X3DAUDIO_CALCULATE_MATRIX | X3DAUDIO_CALCULATE_LPF_DIRECT;
 
     inline unsigned int makeVoiceKey(_In_ const WAVEFORMATEX* wfx) noexcept
     {
@@ -606,6 +606,11 @@ HRESULT AudioEngine::Impl::Reset(const WAVEFORMATEX* wfx, const wchar_t* deviceI
     if (mEngineFlags & AudioEngine_ZeroCenter3D)
     {
         mX3DCalcFlags |= X3DAUDIO_CALCULATE_ZEROCENTER;
+    }
+
+    if (!(mEngineFlags & AudioEngine_DisableDopplerEffect))
+    {
+        mX3DCalcFlags |= X3DAUDIO_CALCULATE_DOPPLER;
     }
 
     //

--- a/Audio/SoundCommon.cpp
+++ b/Audio/SoundCommon.cpp
@@ -758,6 +758,7 @@ void SoundEffectInstanceBase::Apply3D(const X3DAUDIO_LISTENER& listener, const X
     float matrix[XAUDIO2_MAX_AUDIO_CHANNELS * 8] = {};
     assert(mDSPSettings.SrcChannelCount <= XAUDIO2_MAX_AUDIO_CHANNELS);
     assert(mDSPSettings.DstChannelCount <= 8);
+    mDSPSettings.DopplerFactor = 1.f;
     mDSPSettings.pMatrixCoefficients = matrix;
 
     assert(engine != nullptr);

--- a/Audio/SoundCommon.cpp
+++ b/Audio/SoundCommon.cpp
@@ -755,20 +755,6 @@ void SoundEffectInstanceBase::Apply3D(const X3DAUDIO_LISTENER& listener, const X
         throw std::runtime_error("Apply3D");
     }
 
-    DWORD dwCalcFlags = X3DAUDIO_CALCULATE_MATRIX | X3DAUDIO_CALCULATE_DOPPLER | X3DAUDIO_CALCULATE_LPF_DIRECT;
-
-    if (mFlags & SoundEffectInstance_UseRedirectLFE)
-    {
-        // On devices with an LFE channel, allow the mono source data to be routed to the LFE destination channel.
-        dwCalcFlags |= X3DAUDIO_CALCULATE_REDIRECT_TO_LFE;
-    }
-
-    auto reverb = mReverbVoice;
-    if (reverb)
-    {
-        dwCalcFlags |= X3DAUDIO_CALCULATE_LPF_REVERB | X3DAUDIO_CALCULATE_REVERB;
-    }
-
     float matrix[XAUDIO2_MAX_AUDIO_CHANNELS * 8] = {};
     assert(mDSPSettings.SrcChannelCount <= XAUDIO2_MAX_AUDIO_CHANNELS);
     assert(mDSPSettings.DstChannelCount <= 8);
@@ -791,11 +777,11 @@ void SoundEffectInstanceBase::Apply3D(const X3DAUDIO_LISTENER& listener, const X
         lhListener.Position.z = -listener.Position.z;
         lhListener.Velocity.z = -listener.Velocity.z;
 
-        X3DAudioCalculate(engine->Get3DHandle(), &lhListener, &lhEmitter, dwCalcFlags, &mDSPSettings);
+        X3DAudioCalculate(engine->Get3DHandle(), &lhListener, &lhEmitter, mX3DCalcFlags, &mDSPSettings);
     }
     else
     {
-        X3DAudioCalculate(engine->Get3DHandle(), &listener, &emitter, dwCalcFlags, &mDSPSettings);
+        X3DAudioCalculate(engine->Get3DHandle(), &listener, &emitter, mX3DCalcFlags, &mDSPSettings);
     }
 
     mDSPSettings.pMatrixCoefficients = nullptr;
@@ -806,6 +792,7 @@ void SoundEffectInstanceBase::Apply3D(const X3DAUDIO_LISTENER& listener, const X
     assert(direct != nullptr);
     std::ignore = voice->SetOutputMatrix(direct, mDSPSettings.SrcChannelCount, mDSPSettings.DstChannelCount, matrix);
 
+    auto reverb = mReverbVoice;
     if (reverb)
     {
         for (size_t j = 0; (j < mDSPSettings.SrcChannelCount) && (j < XAUDIO2_MAX_AUDIO_CHANNELS); ++j)

--- a/Audio/SoundCommon.h
+++ b/Audio/SoundCommon.h
@@ -105,6 +105,7 @@ namespace DirectX
             mFreqRatio(1.f),
             mPan(0.f),
             mFlags(SoundEffectInstance_Default),
+            mX3DCalcFlags(0),
             mDirectVoice(nullptr),
             mReverbVoice(nullptr),
             mDSPSettings{}
@@ -126,13 +127,12 @@ namespace DirectX
         {
             assert(eng != nullptr);
             engine = eng;
+            mFlags = flags;
+
+            UpdateCalculateFlags();
+
             mDirectVoice = eng->GetMasterVoice();
             mReverbVoice = eng->GetReverbVoice();
-
-            if (eng->GetChannelMask() & SPEAKER_LOW_FREQUENCY)
-                mFlags = flags | SoundEffectInstance_UseRedirectLFE;
-            else
-                mFlags = flags & ~SoundEffectInstance_UseRedirectLFE;
 
             memset(&mDSPSettings, 0, sizeof(X3DAUDIO_DSP_SETTINGS));
             assert(wfx != nullptr);
@@ -333,10 +333,7 @@ namespace DirectX
             mDirectVoice = engine->GetMasterVoice();
             mReverbVoice = engine->GetReverbVoice();
 
-            if (engine->GetChannelMask() & SPEAKER_LOW_FREQUENCY)
-                mFlags = mFlags | SoundEffectInstance_UseRedirectLFE;
-            else
-                mFlags = mFlags & ~SoundEffectInstance_UseRedirectLFE;
+            UpdateCalculateFlags();
 
             mDSPSettings.DstChannelCount = engine->GetOutputChannels();
         }
@@ -390,9 +387,25 @@ namespace DirectX
         float                       mFreqRatio;
         float                       mPan;
         SOUND_EFFECT_INSTANCE_FLAGS mFlags;
+        uint32_t                    mX3DCalcFlags;
         IXAudio2Voice*              mDirectVoice;
         IXAudio2Voice*              mReverbVoice;
         X3DAUDIO_DSP_SETTINGS       mDSPSettings;
+
+        void UpdateCalculateFlags()
+        {
+            assert(engine != nullptr);
+            mX3DCalcFlags = engine->Get3DCalculateFlags();
+            if ((engine->GetChannelMask() & SPEAKER_LOW_FREQUENCY) && (mFlags & SoundEffectInstance_UseRedirectLFE))
+            {
+                mX3DCalcFlags |= X3DAUDIO_CALCULATE_REDIRECT_TO_LFE;
+            }
+
+            if (mFlags & SoundEffectInstance_ZeroCenter3D)
+            {
+                mX3DCalcFlags |= X3DAUDIO_CALCULATE_ZEROCENTER;
+            }
+        }
     };
 
     struct WaveBankSeekData

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -165,9 +165,8 @@ namespace DirectX
         SoundEffectInstance_Use3D = 0x1,
         SoundEffectInstance_ReverbUseFilters = 0x2,
         SoundEffectInstance_NoSetPitch = 0x4,
-
-        SoundEffectInstance_UseRedirectLFE = 0x10000,
-        SoundEffectInstance_ZeroCenter3D = 0x20000,
+        SoundEffectInstance_UseRedirectLFE = 0x8,
+        SoundEffectInstance_ZeroCenter3D = 0x10,
     };
 
     enum AUDIO_ENGINE_REVERB : uint32_t

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -150,6 +150,8 @@ namespace DirectX
         AudioEngine_EnvironmentalReverb = 0x1,
         AudioEngine_ReverbUseFilters = 0x2,
         AudioEngine_UseMasteringLimiter = 0x4,
+        AudioEngine_DisableLFERedirect = 0x8,
+        AudioEngine_ZeroCenter3D = 0x10,
 
         AudioEngine_Debug = 0x10000,
         AudioEngine_ThrowOnNoAudioHW = 0x20000,
@@ -165,6 +167,7 @@ namespace DirectX
         SoundEffectInstance_NoSetPitch = 0x4,
 
         SoundEffectInstance_UseRedirectLFE = 0x10000,
+        SoundEffectInstance_ZeroCenter3D = 0x20000,
     };
 
     enum AUDIO_ENGINE_REVERB : uint32_t
@@ -301,7 +304,10 @@ namespace DirectX
         DIRECTX_TOOLKIT_API IXAudio2* __cdecl GetInterface() const noexcept;
         DIRECTX_TOOLKIT_API IXAudio2MasteringVoice* __cdecl GetMasterVoice() const noexcept;
         DIRECTX_TOOLKIT_API IXAudio2SubmixVoice* __cdecl GetReverbVoice() const noexcept;
+
+        // X3DAudio interface access
         DIRECTX_TOOLKIT_API X3DAUDIO_HANDLE& __cdecl Get3DHandle() const noexcept;
+        DIRECTX_TOOLKIT_API uint32_t __cdecl Get3DCalculateFlags() const noexcept;
 
         // Static functions
         struct RendererDetail

--- a/Inc/Audio.h
+++ b/Inc/Audio.h
@@ -151,7 +151,8 @@ namespace DirectX
         AudioEngine_ReverbUseFilters = 0x2,
         AudioEngine_UseMasteringLimiter = 0x4,
         AudioEngine_DisableLFERedirect = 0x8,
-        AudioEngine_ZeroCenter3D = 0x10,
+        AudioEngine_DisableDopplerEffect = 0x10,
+        AudioEngine_ZeroCenter3D = 0x20,
 
         AudioEngine_Debug = 0x10000,
         AudioEngine_ThrowOnNoAudioHW = 0x20000,


### PR DESCRIPTION
* Adds new audio engine flags
  * `AudioEngine_DisableLFERedirect` will disable the current default behavior of using `X3DAUDIO_CALCULATE_REDIRECT_TO_LFE` if there is a LFE channel in the output.
  * `AudioEngine_DisableDopplerEffect` will disable the current default use of  `X3DAUDIO_CALCULATE_DOPPLER` for all X3DAudio calculations.
  * `AudioEngine_ZeroCenter3D` will add `X3DAUDIO_CALCULATE_ZEROCENTER` to all X3DAudio calculations.
* Adds new sound instance flags
  * `SoundEffectInstance_UseRedirectLFE` internal flag now repurposed to force use of `X3DAUDIO_CALCULATE_REDIRECT_TO_LFE` per voice if not enabled globally and if there is a LFE channel in the output.
  * `SoundEffectInstance_ZeroCenter3D` flag forces the use of  `X3DAUDIO_CALCULATE_ZEROCENTER` per voice if not enabled globally.
  