### PR TITLE
Cleanup of ADO pipeline YAML files

### DIFF
--- a/.azuredevops/pipelines/DirectXTK-GitHub-CMake-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-CMake-Dev17.yml
@@ -20,7 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -36,7 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/.azuredevops/pipelines/DirectXTK-GitHub-CMake.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-CMake.yml
@@ -20,7 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json
@@ -36,7 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmd
     - build/*.json

--- a/.azuredevops/pipelines/DirectXTK-GitHub-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-Dev17.yml
@@ -85,6 +85,7 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
+    condition: ne(variables['BuildPlatform'], 'ARM64')
   - task: VSBuild@1
     displayName: Build solution DirectXTK_Desktop_2022_Win10.sln
     inputs:

--- a/.azuredevops/pipelines/DirectXTK-GitHub-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-Dev17.yml
@@ -67,10 +67,10 @@ jobs:
       Debug_x86:
         BuildPlatform: x86
         BuildConfiguration: Debug
-      Mixed_x86:
+      Release_Mixed:
         BuildPlatform: 'Mixed Platforms'
         BuildConfiguration: Release
-      Mixed_x86:
+      Debug_Mixed:
         BuildPlatform: 'Mixed Platforms'
         BuildConfiguration: Debug
   steps:

--- a/.azuredevops/pipelines/DirectXTK-GitHub-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-Dev17.yml
@@ -43,175 +43,91 @@ variables:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop'
+  displayName: 'Windows Desktop'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 3
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
+      Mixed_x86:
+        BuildPlatform: 'Mixed Platforms'
+        BuildConfiguration: Release
+      Mixed_x86:
+        BuildPlatform: 'Mixed Platforms'
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
     fetchTags: false
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022.sln 32dbg
+    displayName: Build solution DirectXTK_Desktop_2022.sln
     inputs:
       solution: DirectXTK_Desktop_2022.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022.sln 32rel
-    inputs:
-      solution: DirectXTK_Desktop_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022.sln 64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022.sln 64rel
-    inputs:
-      solution: DirectXTK_Desktop_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: CmdLine@2
-    displayName: 'Reclaim diskspace'
-    inputs:
-      script: del *.pch /s
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: false
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022.sln managed dbg
-    inputs:
-      solution: DirectXTK_Desktop_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: Mixed Platforms
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022.sln managed rel
-    inputs:
-      solution: DirectXTK_Desktop_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: Mixed Platforms
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln 32dbg
+    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln
     inputs:
       solution: DirectXTK_Desktop_2022_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln 32rel
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln 64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln 64rel
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64rel
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
 
 - job: UWP_BUILD
   displayName: 'Universal Windows Platform (UWP)'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 3
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
     fetchTags: false
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 32dbg
+    displayName: Build solution DirectXTK_Windows10_2022.sln
     inputs:
       solution: DirectXTK_Windows10_2022.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 32rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 64dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 64rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: CmdLine@2
-    displayName: 'Reclaim diskspace'
-    inputs:
-      script: del *.pch /s
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: false
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln arm64rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64

--- a/.azuredevops/pipelines/DirectXTK-GitHub-GDK.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-GDK.yml
@@ -23,7 +23,7 @@ trigger:
     - '*.md'
     - LICENSE
     - CMake*
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd
@@ -40,7 +40,7 @@ pr:
     - '*.md'
     - LICENSE
     - CMake*
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmake
     - build/*.cmd

--- a/.azuredevops/pipelines/DirectXTK-GitHub-MinGW.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-MinGW.yml
@@ -20,7 +20,7 @@ trigger:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmd
     - build/OneFuzz*.json
@@ -36,7 +36,7 @@ pr:
     exclude:
     - '*.md'
     - LICENSE
-    - '.github/*'
+    - '.github/**'
     - '.nuget/*'
     - build/*.cmd
     - build/OneFuzz*.json

--- a/.azuredevops/pipelines/DirectXTK-GitHub-SDK-prerelease.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-SDK-prerelease.yml
@@ -97,97 +97,7 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln 32dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln 32rel
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln 64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln 64rel
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  - task: CmdLine@2
-    displayName: 'Reclaim diskspace'
-    inputs:
-      script: del *.pch /s
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: false
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln managed dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: Mixed Platforms
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln managed rel
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: Mixed Platforms
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  # VS 2019 for Win32 on ARM64 is out of support.
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64rel
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+  - template: '/.azuredevops/templates/DirectXTK-build-win32.yml'
 
 - job: UWP_BUILD
   displayName: 'Universal Windows Platform (UWP)'
@@ -239,34 +149,7 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 32dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 32rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 64dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 64rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
+  - template: '/.azuredevops/templates/DirectXTK-build-uwp.yml'
 
 - job: UWP_BUILD_ARM64
   displayName: 'Universal Windows Platform (UWP) for ARM64'
@@ -312,17 +195,4 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln arm64rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+  - template: '/.azuredevops/templates/DirectXTK-build-uwp-arm64.yml'

--- a/.azuredevops/pipelines/DirectXTK-GitHub-SDK-release.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-SDK-release.yml
@@ -97,97 +97,7 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln 32dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln 32rel
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln 64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln 64rel
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  - task: CmdLine@2
-    displayName: 'Reclaim diskspace'
-    inputs:
-      script: del *.pch /s
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: false
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln managed dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: Mixed Platforms
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln managed rel
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: Mixed Platforms
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  # VS 2019 for Win32 on ARM64 is out of support.
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64rel
-    inputs:
-      solution: DirectXTK_Desktop_2022_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+  - template: '/.azuredevops/templates/DirectXTK-build-win32.yml'
 
 - job: UWP_BUILD
   displayName: 'Universal Windows Platform (UWP)'
@@ -239,34 +149,7 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 32dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 32rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 64dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln 64rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
+  - template: '/.azuredevops/templates/DirectXTK-build-uwp.yml'
 
 - job: UWP_BUILD_ARM64
   displayName: 'Universal Windows Platform (UWP) for ARM64'
@@ -312,17 +195,4 @@ jobs:
       SourceFolder: build
       Contents: 'Directory.Build.props'
       TargetFolder: $(Build.SourcesDirectory)
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln arm64dbg
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Windows10_2022.sln arm64rel
-    inputs:
-      solution: DirectXTK_Windows10_2022.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+  - template: '/.azuredevops/templates/DirectXTK-build-uwp-arm64.yml'

--- a/.azuredevops/pipelines/DirectXTK-GitHub-Test-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-Test-Dev17.yml
@@ -50,11 +50,32 @@ variables:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop'
+  displayName: 'Windows Desktop'
   timeoutInMinutes: 60
   cancelTimeoutInMinutes: 1
   workspace:
     clean: all
+  strategy:
+    maxParallel: 3
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
@@ -68,106 +89,50 @@ jobs:
     fetchDepth: 1
     path: 's/Tests'
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022.sln 32dbg
+    displayName: Build solution DirectXTK_Tests_Desktop_2022.sln
     inputs:
       solution: Tests/DirectXTK_Tests_Desktop_2022.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
+    condition: ne(variables['BuildPlatform'], 'ARM64')
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022.sln 32rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022.sln 64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022.sln 64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: CmdLine@2
-    displayName: 'Reclaim diskspace'
-    inputs:
-      script: del *.pch /s
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: false
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln 32dbg
+    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln
     inputs:
       solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln 32rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln 64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln 64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln arm64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Debug
-      msbuildArchitecture: x64
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln arm64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
       msbuildArchitecture: x64
 
-- job: UWP_BUILD_X64
-  displayName: 'Universal Windows Platform (UWP) for x64'
+- job: UWP_BUILD
+  displayName: 'Universal Windows Platform (UWP)'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 3
+    matrix:
+      Release_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Release
+      Debug_arm64:
+        BuildPlatform: ARM64
+        BuildConfiguration: Debug
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
@@ -181,85 +146,14 @@ jobs:
     fetchDepth: 1
     path: 's/Tests'
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 64dbg
+    displayName: Build solution DirectXTK_Tests_Windows10.sln
     inputs:
       solution: Tests/DirectXTK_Tests_Windows10.sln
       vsVersion: 17.0
       msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x64
-      configuration: Release
-
-- job: UWP_BUILD_X86
-  displayName: 'Universal Windows Platform (UWP) for x86'
-  timeoutInMinutes: 120
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's'
-  - checkout: testRepo
-    displayName: Fetch Tests
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's/Tests'
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 32dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln 32rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: x86
-      configuration: Release
-
-- job: UWP_BUILD_ARM64
-  displayName: 'Universal Windows Platform (UWP) for ARM64'
-  timeoutInMinutes: 120
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's'
-  - checkout: testRepo
-    displayName: Fetch Tests
-    clean: true
-    fetchTags: false
-    fetchDepth: 1
-    path: 's/Tests'
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln arm64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: ARM64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Windows10.sln arm64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Windows10.sln
-      vsVersion: 17.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
-      platform: ARM64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
+      msbuildArchitecture: x64
 
 - job: CMAKE_BUILD_X64
   displayName: 'CMake for X64 BUILD_TESTING=ON'

--- a/.azuredevops/pipelines/DirectXTK-GitHub-Test.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-Test.yml
@@ -49,11 +49,26 @@ variables:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop'
+  displayName: 'Windows Desktop'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
   workspace:
     clean: all
+  strategy:
+    maxParallel: 2
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
@@ -67,75 +82,21 @@ jobs:
     fetchDepth: 1
     path: 's/Tests'
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019.sln 32dbg
+    displayName: Build solution DirectXTK_Tests_Desktop_2019.sln
     inputs:
       solution: Tests/DirectXTK_Tests_Desktop_2019.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019.sln 32rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019.sln 64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019.sln 64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  - task: CmdLine@2
-    displayName: 'Reclaim diskspace'
-    inputs:
-      script: del *.pch /s
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: false
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln 32dbg
+    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln
     inputs:
       solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
       vsVersion: 16.0
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln 32rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln 64dbg
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln 64rel
-    inputs:
-      solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
-      vsVersion: 16.0
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
 
 - job: CMAKE_BUILD_X64
   displayName: 'CMake for X64 BUILD_TESTING=ON'
@@ -192,6 +153,3 @@ jobs:
     inputs:
       cwd: $(Build.SourcesDirectory)
       cmakeArgs: --build out/build/x64-Release -v
-  - task: DeleteFiles@1
-    inputs:
-      Contents: 'out'

--- a/.azuredevops/pipelines/DirectXTK-GitHub.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub.yml
@@ -61,10 +61,10 @@ jobs:
       Debug_x86:
         BuildPlatform: x86
         BuildConfiguration: Debug
-      Mixed_x86:
+      Release_Mixed:
         BuildPlatform: 'Mixed Platforms'
         BuildConfiguration: Release
-      Mixed_x86:
+      Debug_Mixed:
         BuildPlatform: 'Mixed Platforms'
         BuildConfiguration: Debug
   steps:

--- a/.azuredevops/pipelines/DirectXTK-GitHub.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkId=248929
 
-# Builds the library for Windows Desktop and UWP.
+# Builds the library for Windows Desktop.
 
 schedules:
 - cron: "0 2 * * *"
@@ -43,86 +43,45 @@ variables:
 
 jobs:
 - job: DESKTOP_BUILD
-  displayName: 'Win32 Desktop'
+  displayName: 'Windows Desktop'
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 1
+  strategy:
+    maxParallel: 2
+    matrix:
+      Release_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Release
+      Debug_x64:
+        BuildPlatform: x64
+        BuildConfiguration: Debug
+      Release_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Release
+      Debug_x86:
+        BuildPlatform: x86
+        BuildConfiguration: Debug
+      Mixed_x86:
+        BuildPlatform: 'Mixed Platforms'
+        BuildConfiguration: Release
+      Mixed_x86:
+        BuildPlatform: 'Mixed Platforms'
+        BuildConfiguration: Debug
   steps:
   - checkout: self
     clean: true
     fetchTags: false
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln 32dbg
+    displayName: Build solution DirectXTK_Desktop_2019.sln
     inputs:
       solution: DirectXTK_Desktop_2019.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'
   - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln 32rel
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln 64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln 64rel
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
-  - task: CmdLine@2
-    displayName: 'Reclaim diskspace'
-    inputs:
-      script: del *.pch /s
-      workingDirectory: $(Build.SourcesDirectory)
-      failOnStderr: false
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln managed dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: Mixed Platforms
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019.sln managed rel
-    inputs:
-      solution: DirectXTK_Desktop_2019.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: Mixed Platforms
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32dbg
+    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln
     inputs:
       solution: DirectXTK_Desktop_2019_Win10.sln
       msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x86
-      configuration: Release
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64dbg
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Debug
-  - task: VSBuild@1
-    displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64rel
-    inputs:
-      solution: DirectXTK_Desktop_2019_Win10.sln
-      msbuildArgs: /p:PreferredToolArchitecture=x64
-      platform: x64
-      configuration: Release
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'

--- a/.azuredevops/templates/DirectXTK-build-uwp-arm64.yml
+++ b/.azuredevops/templates/DirectXTK-build-uwp-arm64.yml
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248929
+
+# Template used by SDK-release and SDK-prerelease pipelines
+
+steps:
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Windows10_2022.sln arm64dbg
+  inputs:
+    solution: DirectXTK_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: ARM64
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Windows10_2022.sln arm64rel
+  inputs:
+    solution: DirectXTK_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: ARM64
+    configuration: Release

--- a/.azuredevops/templates/DirectXTK-build-uwp.yml
+++ b/.azuredevops/templates/DirectXTK-build-uwp.yml
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248929
+
+# Template used by SDK-release and SDK-prerelease pipelines
+
+steps:
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Windows10_2022.sln 32dbg
+  inputs:
+    solution: DirectXTK_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Windows10_2022.sln 32rel
+  inputs:
+    solution: DirectXTK_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Release
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Windows10_2022.sln 64dbg
+  inputs:
+    solution: DirectXTK_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Windows10_2022.sln 64rel
+  inputs:
+    solution: DirectXTK_Windows10_2022.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Release

--- a/.azuredevops/templates/DirectXTK-build-win32.yml
+++ b/.azuredevops/templates/DirectXTK-build-win32.yml
@@ -1,0 +1,99 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# http://go.microsoft.com/fwlink/?LinkId=248929
+
+# Template used by SDK-release and SDK-prerelease pipelines
+
+steps:
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019.sln 32dbg
+  inputs:
+    solution: DirectXTK_Desktop_2019.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019.sln 32rel
+  inputs:
+    solution: DirectXTK_Desktop_2019.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Release
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019.sln 64dbg
+  inputs:
+    solution: DirectXTK_Desktop_2019.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019.sln 64rel
+  inputs:
+    solution: DirectXTK_Desktop_2019.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Release
+- task: CmdLine@2
+  displayName: 'Reclaim diskspace'
+  inputs:
+    script: del *.pch /s
+    workingDirectory: $(Build.SourcesDirectory)
+    failOnStderr: false
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019.sln managed dbg
+  inputs:
+    solution: DirectXTK_Desktop_2019.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: Mixed Platforms
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019.sln managed rel
+  inputs:
+    solution: DirectXTK_Desktop_2019.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: Mixed Platforms
+    configuration: Release
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32dbg
+  inputs:
+    solution: DirectXTK_Desktop_2019_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 32rel
+  inputs:
+    solution: DirectXTK_Desktop_2019_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x86
+    configuration: Release
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64dbg
+  inputs:
+    solution: DirectXTK_Desktop_2019_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2019_Win10.sln 64rel
+  inputs:
+    solution: DirectXTK_Desktop_2019_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: x64
+    configuration: Release
+# VS 2019 for Win32 on ARM64 is out of support.
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64dbg
+  inputs:
+    solution: DirectXTK_Desktop_2022_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: ARM64
+    configuration: Debug
+- task: VSBuild@1
+  displayName: Build solution DirectXTK_Desktop_2022_Win10.sln arm64rel
+  inputs:
+    solution: DirectXTK_Desktop_2022_Win10.sln
+    msbuildArgs: /p:PreferredToolArchitecture=x64
+    platform: ARM64
+    configuration: Release

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,12 +8,22 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,22 @@ name: 'CMake (Windows 8.1)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -8,12 +8,18 @@ name: MSBuild
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -8,12 +8,22 @@ name: Microsoft C++ Code Analysis
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,22 @@ name: 'CTest (Windows)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -8,12 +8,22 @@ name: 'CMake (UWP)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -8,12 +8,20 @@ name: 'CMake (Windows using VCPKG)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - build/*.cmd
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - build/*.cmd
       - build/*.props
       - build/*.ps1

--- a/.github/workflows/win10.yml
+++ b/.github/workflows/win10.yml
@@ -8,12 +8,22 @@ name: 'CMake (Windows 10/Windows 11)'
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '*.md'
+      - LICENSE
+      - '.azuredevops/**'
+      - '.nuget/*'
+      - build/*.cmd
+      - build/*.json
+      - build/*.props
+      - build/*.ps1
+      - build/*.targets
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '*.md'
       - LICENSE
-      - '.azuredevops/*'
+      - '.azuredevops/**'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json


### PR DESCRIPTION
This PR adds the use of strategy and templates to the existing ADO pipelines.

* For the basic builds using Visual Studio MSBuild with minimal job setup, I made use of `strategy` `matrix` to simplify the pipelines for GitHub, GitHub-Dev17, GitHub-Test, and GitHub-Dev17.

* For the Windows SDK NuGet pipelines which have substantial package sizes as part of job setup, I made use of `template` for SDK-release and SDK-prerelease pipelines to share implementation.

> Also updated pipeline trigger path filters: GHA should ignore everything under ``.azuredevops``, and ADO should ignore everything under ``.github``.
