### PR TITLE
Update CMO and vbo headers

### DIFF
--- a/Src/CMO.h
+++ b/Src/CMO.h
@@ -109,7 +109,7 @@ namespace VSD3DStarter
 
     // Vertex struct for Visual Studio Shader Designer (DGSL) holding position, normal,
     // tangent, color (RGBA), and texture mapping information
-    struct VertexPositionNormalTangentColorTexture
+    struct Vertex
     {
         DirectX::XMFLOAT3 position;
         DirectX::XMFLOAT3 normal;
@@ -173,7 +173,7 @@ namespace VSD3DStarter
 
 static_assert(sizeof(VSD3DStarter::Material) == 132, "CMO Mesh structure size incorrect");
 static_assert(sizeof(VSD3DStarter::SubMesh) == 20, "CMO Mesh structure size incorrect");
-static_assert(sizeof(VSD3DStarter::VertexPositionNormalTangentColorTexture) == 52, "CMO Mesh structure size incorrect");
+static_assert(sizeof(VSD3DStarter::Vertex) == 52, "CMO Mesh structure size incorrect");
 static_assert(sizeof(VSD3DStarter::SkinningVertex) == 32, "CMO Mesh structure size incorrect");
 static_assert(sizeof(VSD3DStarter::MeshExtents) == 40, "CMO Mesh structure size incorrect");
 static_assert(sizeof(VSD3DStarter::Bone) == 196, "CMO Mesh structure size incorrect");

--- a/Src/ModelLoadCMO.cpp
+++ b/Src/ModelLoadCMO.cpp
@@ -20,7 +20,7 @@ using Microsoft::WRL::ComPtr;
 
 #include "CMO.h"
 
-static_assert(sizeof(VertexPositionNormalTangentColorTexture) == sizeof(VSD3DStarter::VertexPositionNormalTangentColorTexture), "mismatch with CMO vertex type");
+static_assert(sizeof(VertexPositionNormalTangentColorTexture) == sizeof(VSD3DStarter::Vertex), "mismatch with CMO vertex type");
 
 
 namespace

--- a/Src/ModelLoadVBO.cpp
+++ b/Src/ModelLoadVBO.cpp
@@ -20,7 +20,7 @@
 using namespace DirectX;
 using Microsoft::WRL::ComPtr;
 
-static_assert(sizeof(VertexPositionNormalTexture) == 32, "VBO vertex size mismatch");
+static_assert(sizeof(VertexPositionNormalTexture) == sizeof(VBO::vertex_t), "VBO vertex size mismatch");
 
 namespace
 {

--- a/Src/vbo.h
+++ b/Src/vbo.h
@@ -28,8 +28,16 @@ namespace VBO
         uint32_t numIndices;
     };
 
+    struct vertex_t
+    {
+        DirectX::XMFLOAT3 position;
+        DirectX::XMFLOAT3 normal;
+        DirectX::XMFLOAT2 textureCoordinate;
+    };
+
 #pragma pack(pop)
 
 } // namespace
 
 static_assert(sizeof(VBO::header_t) == 8, "VBO header size mismatch");
+static_assert(sizeof(VBO::vertex_t) == 32, "VBO vertex size mismatch");


### PR DESCRIPTION
Minor updates to make CMO.h and VBO.h useful for DirectXMesh and UVAtlas.
