### PR TITLE
GHA and ADO pipeline updates

### DIFF
--- a/.azuredevops/pipelines/DirectXTK-GitHub-CMake.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-CMake.yml
@@ -55,12 +55,12 @@ name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 variables:
   Codeql.Enabled: false
-  VS_GENERATOR: 'Visual Studio 16 2019'
+  VS_GENERATOR: 'Visual Studio 17 2022'
   WIN10_SDK: '10.0.19041.0'
   WIN11_SDK: '10.0.22000.0'
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-2022
 
 jobs:
   - job: CMAKE_BUILD
@@ -74,7 +74,7 @@ jobs:
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -B out
+            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out
             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
             -DBUILD_XAUDIO_WIN8=ON -DBUILD_TOOLS=ON
       - task: CMake@1
@@ -92,7 +92,7 @@ jobs:
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A Win32 -B out2
+            -G "$(VS_GENERATOR)" -T v142 -A Win32 -B out2
             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
             -DBUILD_XAUDIO_WIN8=ON -DBUILD_TOOLS=ON
       - task: CMake@1
@@ -110,7 +110,7 @@ jobs:
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -B out3
+            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out3
             -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=10.0
       - task: CMake@1
         displayName: 'CMake (UWP): Build x64'
@@ -118,29 +118,11 @@ jobs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: --build out3 -v
       - task: CMake@1
-        displayName: 'CMake (ClangCl): Config x64'
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -T clangcl -B out4
-            -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
-            -DBUILD_XAUDIO_WIN8=ON -DBUILD_TOOLS=ON
-      - task: CMake@1
-        displayName: 'CMake (ClangCl): Build x64 Debug'
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out4 -v --config Debug
-      - task: CMake@1
-        displayName: 'CMake (ClangCl): Build x64 Release'
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out4 -v --config RelWithDebInfo
-      - task: CMake@1
         displayName: 'CMake (Win10): Config'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -B out5
+            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out4
             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
             -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
             -DBUILD_XAUDIO_WIN10=ON -DBUILD_TOOLS=OFF
@@ -148,45 +130,26 @@ jobs:
         displayName: 'CMake (Win10): Build'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out5 -v
-      - task: CMake@1
-        displayName: 'CMake (MSVC Spectre): Config x64'
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -B out6
-            -DENABLE_SPECTRE_MITIGATION=ON -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
-            -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
-            -DBUILD_XAUDIO_WIN8=ON -DBUILD_TOOLS=ON
-      - task: CMake@1
-        displayName: 'CMake (MSVC Spectre): Build x64 Debug'
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out6 -v --config Debug
-      - task: CMake@1
-        displayName: 'CMake (MSVC Spectre): Build x64 Release'
-        inputs:
-          cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out6 -v --config RelWithDebInfo
+          cmakeArgs: --build out4 -v
       - task: CMake@1
         displayName: 'CMake (NO_WCHAR_T): Config'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -B out7
+            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out5
             -DNO_WCHAR_T=ON
             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN11_SDK)'
       - task: CMake@1
         displayName: 'CMake (NO_WCHAR_T): Build'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out7 -v --config Debug
+          cmakeArgs: --build out5 -v --config Debug
       - task: CMake@1
         displayName: 'CMake (DLL): Config x64'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
           cmakeArgs: >
-            -G "$(VS_GENERATOR)" -A x64 -B out8
+            -G "$(VS_GENERATOR)" -T v142 -A x64 -B out6
             -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_SYSTEM_VERSION=$(WIN10_SDK)
             -DBUILD_XAUDIO_WIN8=ON -DBUILD_TOOLS=ON
             -DBUILD_SHARED_LIBS=ON
@@ -194,9 +157,9 @@ jobs:
         displayName: 'CMake (DLL): Build x64 Debug'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out8 -v --config Debug
+          cmakeArgs: --build out6 -v --config Debug
       - task: CMake@1
         displayName: 'CMake (DLL): Build x64 Release'
         inputs:
           cwd: '$(Build.SourcesDirectory)'
-          cmakeArgs: --build out8 -v --config RelWithDebInfo
+          cmakeArgs: --build out6 -v --config RelWithDebInfo

--- a/.azuredevops/pipelines/DirectXTK-GitHub-GDK-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-GDK-Dev17.yml
@@ -58,6 +58,8 @@ variables:
 jobs:
   - job: BUILD_GDK
     displayName: 'Microsoft Game Development Kit (GDK)'
+    workspace:
+      clean: all
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 1
     steps:
@@ -132,6 +134,8 @@ jobs:
 
   - job: BUILD_GDK_CMAKE
     displayName: 'Microsoft Game Development Kit (GDK) using CMake'
+    workspace:
+      clean: all
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 1
     steps:

--- a/.azuredevops/pipelines/DirectXTK-GitHub-GDK-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-GDK-Dev17.yml
@@ -44,6 +44,8 @@ variables:
     value: false
   - name: EXTRACTED_FOLDER
     value: '$(ExtractedFolder)'
+  - name: GDK_EDITION
+    value: $(GDKEditionNumber)
   - name: GDKEnableBWOI
     value: true
   - name: URL_FEED
@@ -90,11 +92,13 @@ jobs:
         displayName: 'Secure Supply Chain Analysis'
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Auth'
-      - task: NuGetCommand@2
-        displayName: NuGet install PGDK
+      - task: PowerShell@2
+        displayName: 'NuGet Install GDK'
         inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.PC.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
+          targetType: filePath
+          filePath: ./build/RestoreGDK.ps1
+          arguments: -GDKEditionNumber $(GDK_EDITION) -OutputDirectory $(EXTRACTED_FOLDER)
+          failOnStderr: true
       - task: CopyFiles@2
         displayName: Set up Directory.Build.props
         inputs:
@@ -164,11 +168,13 @@ jobs:
         displayName: 'Secure Supply Chain Analysis'
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Auth'
-      - task: NuGetCommand@2
-        displayName: NuGet install PGDK
+      - task: PowerShell@2
+        displayName: 'NuGet Install GDK'
         inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.PC.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
+          targetType: filePath
+          filePath: ./build/RestoreGDK.ps1
+          arguments: -GDKEditionNumber $(GDK_EDITION) -OutputDirectory $(EXTRACTED_FOLDER)
+          failOnStderr: true
       - task: CmdLine@2
         displayName: Setup BWOI for GDK command-line
         inputs:

--- a/.azuredevops/pipelines/DirectXTK-GitHub-GDK-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-GDK-Dev17.yml
@@ -109,7 +109,6 @@ jobs:
         displayName: Setup BWOI VCTargets
         inputs:
           solution: build/SetupBWOI.targets
-          msbuildVersion: 17.0
           msbuildArchitecture: x64
           msbuildArguments: /p:GDKEditionNumber=$(GDK_EDITION)
       - task: VSBuild@1
@@ -117,7 +116,6 @@ jobs:
         continueOnError: true
         inputs:
           solution: DirectXTK_GDK_2022.sln
-          vsVersion: 17.0
           platform: Gaming.Desktop.x64
           configuration: Debug
           msbuildArchitecture: x64
@@ -127,7 +125,6 @@ jobs:
         continueOnError: true
         inputs:
           solution: DirectXTK_GDK_2022.sln
-          vsVersion: 17.0
           platform: Gaming.Desktop.x64
           configuration: Release
           msbuildArchitecture: x64

--- a/.azuredevops/pipelines/DirectXTK-GitHub-GDK.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-GDK.yml
@@ -83,6 +83,8 @@ variables:
 jobs:
   - job: BUILD_GDK
     displayName: 'Microsoft Game Development Kit (GDK)'
+    workspace:
+      clean: all
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 1
     steps:
@@ -157,6 +159,8 @@ jobs:
 
   - job: BUILD_TESTS_GDK
     displayName: 'Test Suite for Microsoft Game Development Kit (GDK)'
+    workspace:
+      clean: all
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 1
     steps:

--- a/.azuredevops/pipelines/DirectXTK-GitHub-GDK.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-GDK.yml
@@ -63,7 +63,7 @@ resources:
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-2022
 
 variables:
   - group: dxtk-shared-variables
@@ -134,7 +134,6 @@ jobs:
         displayName: Setup BWOI VCTargets
         inputs:
           solution: build/SetupBWOI.targets
-          msbuildVersion: 16.0
           msbuildArchitecture: x64
           msbuildArguments: /p:GDKEditionNumber=$(GDK_EDITION)
       - task: VSBuild@1
@@ -142,7 +141,6 @@ jobs:
         continueOnError: true
         inputs:
           solution: DirectXTK_GDK_2019.sln
-          vsVersion: 16.0
           platform: Gaming.Desktop.x64
           configuration: Debug
           msbuildArchitecture: x64
@@ -152,7 +150,6 @@ jobs:
         continueOnError: true
         inputs:
           solution: DirectXTK_GDK_2019.sln
-          vsVersion: 16.0
           platform: Gaming.Desktop.x64
           configuration: Release
           msbuildArchitecture: x64
@@ -217,14 +214,12 @@ jobs:
         displayName: Setup BWOI VCTargets
         inputs:
           solution: build/SetupBWOI.targets
-          msbuildVersion: 16.0
           msbuildArchitecture: x64
           msbuildArguments: /p:GDKEditionNumber=$(GDK_EDITION)
       - task: VSBuild@1
         displayName: Build Tests pcdbg
         inputs:
           solution: '**\*GDK_2019*.sln'
-          vsVersion: 16.0
           platform: Gaming.Desktop.x64
           configuration: Debug
           msbuildArchitecture: x64
@@ -233,7 +228,6 @@ jobs:
         displayName: Build Tests pcrel
         inputs:
           solution: '**\*GDK_2019*.sln'
-          vsVersion: 16.0
           platform: Gaming.Desktop.x64
           configuration: Release
           msbuildArchitecture: x64

--- a/.azuredevops/pipelines/DirectXTK-GitHub-GDK.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-GDK.yml
@@ -71,6 +71,8 @@ variables:
     value: false
   - name: EXTRACTED_FOLDER
     value: '$(ExtractedFolder)'
+  - name: GDK_EDITION
+    value: $(GDKEditionNumber)
   - name: GDKEnableBWOI
     value: true
   - name: URL_FEED
@@ -115,11 +117,13 @@ jobs:
         displayName: 'Secure Supply Chain Analysis'
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Auth'
-      - task: NuGetCommand@2
-        displayName: NuGet install PGDK
+      - task: PowerShell@2
+        displayName: 'NuGet Install GDK'
         inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.PC.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
+          targetType: filePath
+          filePath: ./build/RestoreGDK.ps1
+          arguments: -GDKEditionNumber $(GDK_EDITION) -OutputDirectory $(EXTRACTED_FOLDER)
+          failOnStderr: true
       - task: CopyFiles@2
         displayName: Set up Directory.Build.props
         inputs:
@@ -196,11 +200,13 @@ jobs:
         displayName: 'Secure Supply Chain Analysis'
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Auth'
-      - task: NuGetCommand@2
-        displayName: NuGet install PGDK
+      - task: PowerShell@2
+        displayName: 'NuGet Install GDK'
         inputs:
-          command: custom
-          arguments: install -prerelease Microsoft.GDK.PC.$(GDK_EDITION) -ExcludeVersion -OutputDirectory $(EXTRACTED_FOLDER)
+          targetType: filePath
+          filePath: ./build/RestoreGDK.ps1
+          arguments: -GDKEditionNumber $(GDK_EDITION) -OutputDirectory $(EXTRACTED_FOLDER)
+          failOnStderr: true
       - task: CopyFiles@2
         displayName: Set up Directory.Build.props
         inputs:

--- a/.azuredevops/pipelines/DirectXTK-GitHub-Test-Dev17.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-Test-Dev17.yml
@@ -27,7 +27,6 @@ resources:
     - repository: self
       type: git
       ref: refs/heads/main
-      trigger: none
     - repository: testRepo
       name: walbourn/directxtktest
       type: github
@@ -92,7 +91,6 @@ jobs:
         displayName: Build solution DirectXTK_Tests_Desktop_2022.sln
         inputs:
           solution: Tests/DirectXTK_Tests_Desktop_2022.sln
-          vsVersion: 17.0
           msbuildArgs: /p:PreferredToolArchitecture=x64
           platform: '$(BuildPlatform)'
           configuration: '$(BuildConfiguration)'
@@ -102,7 +100,6 @@ jobs:
         displayName: Build solution DirectXTK_Tests_Desktop_2022_Win10.sln
         inputs:
           solution: Tests/DirectXTK_Tests_Desktop_2022_Win10.sln
-          vsVersion: 17.0
           msbuildArgs: /p:PreferredToolArchitecture=x64
           platform: '$(BuildPlatform)'
           configuration: '$(BuildConfiguration)'
@@ -149,7 +146,6 @@ jobs:
         displayName: Build solution DirectXTK_Tests_Windows10.sln
         inputs:
           solution: Tests/DirectXTK_Tests_Windows10.sln
-          vsVersion: 17.0
           msbuildArgs: /p:PreferredToolArchitecture=x64 /p:AppxBundle=Never
           platform: '$(BuildPlatform)'
           configuration: '$(BuildConfiguration)'

--- a/.azuredevops/pipelines/DirectXTK-GitHub-Test.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub-Test.yml
@@ -36,14 +36,12 @@ resources:
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-2022
 
 variables:
   - group: dxtk-shared-variables
   - name: Codeql.Enabled
     value: false
-  - name: VC_PATH
-    value: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC'
   - name: GUID_FEED
     value: $(ADOFeedGUID)
 
@@ -85,7 +83,6 @@ jobs:
         displayName: Build solution DirectXTK_Tests_Desktop_2019.sln
         inputs:
           solution: Tests/DirectXTK_Tests_Desktop_2019.sln
-          vsVersion: 16.0
           msbuildArgs: /p:PreferredToolArchitecture=x64
           platform: '$(BuildPlatform)'
           configuration: '$(BuildConfiguration)'
@@ -93,63 +90,6 @@ jobs:
         displayName: Build solution DirectXTK_Tests_Desktop_2019_Win10.sln
         inputs:
           solution: Tests/DirectXTK_Tests_Desktop_2019_Win10.sln
-          vsVersion: 16.0
           msbuildArgs: /p:PreferredToolArchitecture=x64
           platform: '$(BuildPlatform)'
           configuration: '$(BuildConfiguration)'
-
-  - job: CMAKE_BUILD_X64
-    displayName: 'CMake for X64 BUILD_TESTING=ON'
-    timeoutInMinutes: 60
-    workspace:
-      clean: all
-    steps:
-      - checkout: self
-        clean: true
-        fetchTags: false
-        fetchDepth: 1
-        path: 's'
-      - checkout: testRepo
-        displayName: Fetch Tests
-        clean: true
-        fetchTags: false
-        fetchDepth: 1
-        path: 's/Tests'
-      - task: CmdLine@2
-        displayName: Setup environment for CMake to use VS
-        inputs:
-          script: |
-            call "$(VC_PATH)\Auxiliary\Build\vcvars64.bat"
-            echo ##vso[task.setvariable variable=WindowsSdkVerBinPath;]%WindowsSdkVerBinPath%
-            echo ##vso[task.prependpath]%VSINSTALLDIR%Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja
-            echo ##vso[task.prependpath]%VCINSTALLDIR%Tools\Llvm\x64\bin
-            echo ##vso[task.prependpath]%WindowsSdkBinPath%x64
-            echo ##vso[task.prependpath]%WindowsSdkVerBinPath%x64
-            echo ##vso[task.prependpath]%VCToolsInstallDir%bin\Hostx64\x64
-            echo ##vso[task.setvariable variable=EXTERNAL_INCLUDE;]%EXTERNAL_INCLUDE%
-            echo ##vso[task.setvariable variable=INCLUDE;]%INCLUDE%
-            echo ##vso[task.setvariable variable=LIB;]%LIB%
-
-      - task: CMake@1
-        displayName: CMake (MSVC; x64-Debug) Config
-        inputs:
-          cwd: $(Build.SourcesDirectory)
-          cmakeArgs: --preset=x64-Debug
-      - task: CMake@1
-        displayName: CMake (MSVC; x64-Debug) Build
-        inputs:
-          cwd: $(Build.SourcesDirectory)
-          cmakeArgs: --build out/build/x64-Debug -v
-      - task: DeleteFiles@1
-        inputs:
-          Contents: 'out'
-      - task: CMake@1
-        displayName: CMake (MSVC; x64-Release) Config
-        inputs:
-          cwd: $(Build.SourcesDirectory)
-          cmakeArgs: --preset=x64-Release
-      - task: CMake@1
-        displayName: CMake (MSVC; x64-Release) Build
-        inputs:
-          cwd: $(Build.SourcesDirectory)
-          cmakeArgs: --build out/build/x64-Release -v

--- a/.azuredevops/pipelines/DirectXTK-GitHub.yml
+++ b/.azuredevops/pipelines/DirectXTK-GitHub.yml
@@ -32,7 +32,7 @@ resources:
 name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-2022
 
 variables:
   - group: dxtk-shared-variables

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,8 +12,9 @@ These instructions define how GitHub Copilot should assist with this project. Th
 ## Getting Started
 
 - See the tutorial at [Getting Started](https://github.com/microsoft/DirectXTK/wiki/Getting-Started).
-- The recommended way to integrate DirectX Tool Kit for DirectX 11 into your project is by using VCPKG. See [d3d11game_vcpkg](https://github.com/walbourn/directx-vs-templates/tree/main/d3d11game_vcpkg) which includes a template and details in the `README.md` file for integrating this library.
+- The recommended way to integrate *DirectX Tool Kit for DirectX 11* into your project is by using the *vcpkg* Package Manager. See [d3d11game_vcpkg](https://github.com/walbourn/directx-vs-templates/tree/main/d3d11game_vcpkg) for a template which uses VCPKG.
 - You can make use of the nuget.org packages **directxtk_desktop_2019**, **directxtk_desktop_win10**, or **directxtk_uwp**.
+- You can also use the library source code directly in your project or as a git submodule.
 
 ## General Guidelines
 
@@ -29,21 +30,17 @@ These instructions define how GitHub Copilot should assist with this project. Th
 ## File Structure
 
 ```txt
-.azuredevops/
-.github/
-build/
-Audio/
-Inc/
-Src/
-  Shaders/
-MakeSpriteFont/
-XWBTool/
-Tests/
+.azuredevops/   # Azure DevOps pipeline configuration and policy files.
+.github/        # GitHub Actions workflow files and linter configuration files.
+build/          # Miscellaneous build files and scripts.
+Audio/          # DirectX Tool Kit for Audio implementation files.
+Inc/            # Public header files.
+Src/            # Implementation header and source files.
+  Shaders/      # HLSL shader files.
+MakeSpriteFont/ # CLI tool for capturing sprite fonts.
+XWBTool/        # CLI tool for creating XACT-style wave banks.
+Tests/          # Tests are designed to be cloned from a separate repository at this location.
 ```
-
-The `Inc` folder is for public header files, while the `Src` folder contains the implementation header and source files. The `Audio` folder contains DirectX Tool Kit for Audio implementation files.
-
-``MakeSpriteFont`` is a CLI tool for capturing sprite fonts. ``XWBTool`` is a CLI tool for creating XACT-style wave banks.
 
 ## Patterns
 
@@ -80,3 +77,31 @@ The `Inc` folder is for public header files, while the `Src` folder contains the
 - [Games for Windows and the DirectX SDK blog - September 2021](https://walbourn.github.io/latest-news-on-directx-tool-kit/)
 - [Games for Windows and the DirectX SDK blog - October 2021](https://walbourn.github.io/directx-tool-kit-vertex-skinning-update/)
 - [Games for Windows and the DirectX SDK blog - May 2020](https://walbourn.github.io/directx-tool-kit-for-audio-updates-and-a-direct3d-9-footnote/)
+
+## No speculation
+
+When creating documentation:
+
+### Document Only What Exists
+
+* Only document features, patterns, and decisions that are explicitly present in the source code.
+* Only include configurations and requirements that are clearly specified.
+* Do not make assumptions about implementation details.
+
+### Handle Missing Information
+
+* Ask the user questions to gather missing information.
+* Document gaps in current implementation or specifications.
+* List open questions that need to be addressed.
+
+### Source Material
+
+* Always cite the specific source file and line numbers for documented features.
+* Link directly to relevant source code when possible.
+* Indicate when information comes from requirements vs. implementation.
+
+### Verification Process
+
+* Review each documented item against source code whenever related to the task.
+* Remove any speculative content.
+* Ensure all documentation is verifiable against the current state of the codebase.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,82 @@
+# GitHub Copilot Instructions
+
+These instructions define how GitHub Copilot should assist with this project. The goal is to ensure consistent, high-quality code generation aligned with our conventions, stack, and best practices.
+
+## Context
+
+- **Project Type**: Graphics Library / DirectX / Direct3D 11 / Game Audio
+- **Language**: C++
+- **Framework / Libraries**: STL / CMake / CTest
+- **Architecture**: Modular / RAII / OOP
+
+## Getting Started
+
+- See the tutorial at [Getting Started](https://github.com/microsoft/DirectXTK/wiki/Getting-Started).
+- The recommended way to integrate DirectX Tool Kit for DirectX 11 into your project is by using VCPKG. See [d3d11game_vcpkg](https://github.com/walbourn/directx-vs-templates/tree/main/d3d11game_vcpkg) which includes a template and details in the `README.md` file for integrating this library.
+- You can make use of the nuget.org packages **directxtk_desktop_2019**, **directxtk_desktop_win10**, or **directxtk_uwp**.
+
+## General Guidelines
+
+- **Code Style**: The project uses an .editorconfig file to enforce coding standards. Follow the rules defined in `.editorconfig` for indentation, line endings, and other formatting. Additional information can be found on the wiki at [Implementation](https://github.com/microsoft/DirectXTK/wiki/Implementation). The code requires C++11/C++14 features.
+- **Documentation**: The project provides documentation in the form of wiki pages available at [Documentation](https://github.com/microsoft/DirectXTK/wiki/).
+- **Error Handling**: Use C++ exceptions for error handling and uses RAII smart pointers to ensure resources are properly managed. For some functions that return HRESULT error codes, they are marked `noexcept`, use `std::nothrow` for memory allocation, and should not throw exceptions.
+- **Testing**: Unit tests for this project are implemented in this repository [Test Suite](https://github.com/walbourn/directxtktest/) and can be run using CTest per the instructions at [Test Documentation](https://github.com/walbourn/directxtktest/wiki).
+- **Security**: This project uses secure coding practices from the Microsoft Secure Coding Guidelines, and is subject to the `SECURITY.md` file in the root of the repository. Functions that read input from image file, geomeotry files, and audio files are subject to OneFuzz testing to ensure they are secure against malformed files.
+- **Dependencies**: The project uses CMake and VCPKG for managing dependencies, making optional use of DirectXMath, GameInput, and XAudio2Redist. The project can be built without these dependencies, relying on the Windows SDK for core functionality.
+- **Continuous Integration**: This project implements GitHub Actions for continuous integration, ensuring that all code changes are tested and validated before merging. This includes building the project for a number of configurations and toolsets, running a subset of unit tests, and static code analysis including GitHub super-linter, CodeQL, and MSVC Code Analysis.
+- **Code of Conduct**: The project adheres to the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). All contributors are expected to follow this code of conduct in all interactions related to the project.
+
+## File Structure
+
+```txt
+.azuredevops/
+.github/
+build/
+Audio/
+Inc/
+Src/
+  Shaders/
+MakeSpriteFont/
+XWBTool/
+Tests/
+```
+
+The `Inc` folder is for public header files, while the `Src` folder contains the implementation header and source files. The `Audio` folder contains DirectX Tool Kit for Audio implementation files.
+
+``MakeSpriteFont`` is a CLI tool for capturing sprite fonts. ``XWBTool`` is a CLI tool for creating XACT-style wave banks.
+
+## Patterns
+
+### Patterns to Follow
+
+- Use RAII for all resource ownership (memory, file handles, etc.).
+- Many classes utilize the pImpl idiom to hide implementation details, and to enable optimized memory alignment in the implementation.
+- Use `std::unique_ptr` for exclusive ownership and `std::shared_ptr` for shared ownership.
+- Use `Microsoft::WRL::ComPtr` for COM object management.
+- Make use of anonymous namespaces to limit scope of functions and variables.
+- Make use of `assert` for debugging checks, but be sure to validate input parameters in release builds.
+- Make use of the `DebugTrace` helper to log diagnostic messages, particularly at the point of throwing an exception.
+
+### Patterns to Avoid
+
+- Don’t use raw pointers for ownership.
+- Avoid macros for constants—prefer `constexpr` or `inline` `const`.
+- Don’t put implementation logic in header files unless using templates, although the SimpleMath library does use an .inl file for performance.
+- Avoid using `using namespace` in header files to prevent polluting the global namespace.
+
+## References
+
+- [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)
+- [Microsoft Secure Coding Guidelines](https://learn.microsoft.com/en-us/security/develop/secure-coding-guidelines)
+- [CMake Documentation](https://cmake.org/documentation/)
+- [VCPK Documentation](https://learn.microsoft.com/vcpkg/)
+- [DirectX Tool Kit for DirectX 11 Wiki](https://github.com/microsoft/DirectXTK/wiki/)
+- [DirectX Tool Kit for Audio Wiki](https://github.com/Microsoft/DirectXTK/wiki/Audio)
+- [Games for Windows and the DirectX SDK blog - March 2012](https://walbourn.github.io/directxtk/)
+- [Games for Windows and the DirectX SDK blog - January 2013](https://walbourn.github.io/directxtk-update/)
+- [Games for Windows and the DirectX SDK blog - December 13](https://walbourn.github.io/directx-tool-kit-for-audio/)
+- [Games for Windows and the DirectX SDK blog - September 2014](https://walbourn.github.io/directx-tool-kit-now-with-gamepads/)
+- [Games for Windows and the DirectX SDK blog - August 2015](https://walbourn.github.io/directx-tool-kit-keyboard-and-mouse-support/)
+- [Games for Windows and the DirectX SDK blog - September 2021](https://walbourn.github.io/latest-news-on-directx-tool-kit/)
+- [Games for Windows and the DirectX SDK blog - October 2021](https://walbourn.github.io/directx-tool-kit-vertex-skinning-update/)
+- [Games for Windows and the DirectX SDK blog - May 2020](https://walbourn.github.io/directx-tool-kit-for-audio-updates-and-a-direct3d-9-footnote/)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,24 +85,24 @@ When creating documentation:
 
 ### Document Only What Exists
 
-* Only document features, patterns, and decisions that are explicitly present in the source code.
-* Only include configurations and requirements that are clearly specified.
-* Do not make assumptions about implementation details.
+- Only document features, patterns, and decisions that are explicitly present in the source code.
+- Only include configurations and requirements that are clearly specified.
+- Do not make assumptions about implementation details.
 
 ### Handle Missing Information
 
-* Ask the user questions to gather missing information.
-* Document gaps in current implementation or specifications.
-* List open questions that need to be addressed.
+- Ask the user questions to gather missing information.
+- Document gaps in current implementation or specifications.
+- List open questions that need to be addressed.
 
 ### Source Material
 
-* Always cite the specific source file and line numbers for documented features.
-* Link directly to relevant source code when possible.
-* Indicate when information comes from requirements vs. implementation.
+- Always cite the specific source file and line numbers for documented features.
+- Link directly to relevant source code when possible.
+- Indicate when information comes from requirements vs. implementation.
 
 ### Verification Process
 
-* Review each documented item against source code whenever related to the task.
-* Remove any speculative content.
-* Ensure all documentation is verifiable against the current state of the codebase.
+- Review each documented item against source code whenever related to the task.
+- Remove any speculative content.
+- Ensure all documentation is verifiable against the current state of the codebase.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,7 @@ These instructions define how GitHub Copilot should assist with this project. Th
 ## Context
 
 - **Project Type**: Graphics Library / DirectX / Direct3D 11 / Game Audio
+- **Project Name**: DirectX Tool Kit for DirectX 11
 - **Language**: C++
 - **Framework / Libraries**: STL / CMake / CTest
 - **Architecture**: Modular / RAII / OOP
@@ -22,7 +23,7 @@ These instructions define how GitHub Copilot should assist with this project. Th
 - **Documentation**: The project provides documentation in the form of wiki pages available at [Documentation](https://github.com/microsoft/DirectXTK/wiki/).
 - **Error Handling**: Use C++ exceptions for error handling and uses RAII smart pointers to ensure resources are properly managed. For some functions that return HRESULT error codes, they are marked `noexcept`, use `std::nothrow` for memory allocation, and should not throw exceptions.
 - **Testing**: Unit tests for this project are implemented in this repository [Test Suite](https://github.com/walbourn/directxtktest/) and can be run using CTest per the instructions at [Test Documentation](https://github.com/walbourn/directxtktest/wiki).
-- **Security**: This project uses secure coding practices from the Microsoft Secure Coding Guidelines, and is subject to the `SECURITY.md` file in the root of the repository. Functions that read input from image file, geomeotry files, and audio files are subject to OneFuzz testing to ensure they are secure against malformed files.
+- **Security**: This project uses secure coding practices from the Microsoft Secure Coding Guidelines, and is subject to the `SECURITY.md` file in the root of the repository. Functions that read input from image file, geometry files, and audio files are subject to OneFuzz testing to ensure they are secure against malformed files.
 - **Dependencies**: The project uses CMake and VCPKG for managing dependencies, making optional use of DirectXMath, GameInput, and XAudio2Redist. The project can be built without these dependencies, relying on the Windows SDK for core functionality.
 - **Continuous Integration**: This project implements GitHub Actions for continuous integration, ensuring that all code changes are tested and validated before merging. This includes building the project for a number of configurations and toolsets, running a subset of unit tests, and static code analysis including GitHub super-linter, CodeQL, and MSVC Code Analysis.
 - **Code of Conduct**: The project adheres to the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). All contributors are expected to follow this code of conduct in all interactions related to the project.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,7 @@ These instructions define how GitHub Copilot should assist with this project. Th
 ```txt
 .azuredevops/   # Azure DevOps pipeline configuration and policy files.
 .github/        # GitHub Actions workflow files and linter configuration files.
+.nuget/         # NuGet package configuration files.
 build/          # Miscellaneous build files and scripts.
 Audio/          # DirectX Tool Kit for Audio implementation files.
 Inc/            # Public header files.

--- a/.github/linters/actionlint.yml
+++ b/.github/linters/actionlint.yml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  # Workaround until linter is updated
+  labels:
+    - windows-11-arm

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkId=248929
 
-name: 'BVTs (x64)'
+name: 'CMake (Windows on ARM64)'
 
 on:
   push:
@@ -36,43 +36,40 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2022
-    timeout-minutes: 20
+    runs-on: windows-11-arm
 
     strategy:
       fail-fast: false
 
       matrix:
-        toolver: ['14.29', '14']
-        build_type: [x64-Release]
-        arch: [amd64]
+        build_type: [arm64-Debug, arm64-Release, arm64-Debug-UWP, arm64-Release-UWP]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Clone test repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: walbourn/directxtktest
-          path: Tests
-          ref: main
 
       - name: 'Install Ninja'
         run: choco install ninja
 
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
-          arch: ${{ matrix.arch }}
-          toolset: ${{ matrix.toolver }}
+          arch: arm64
 
       - name: 'Configure CMake'
         working-directory: ${{ github.workspace }}
-        run: cmake --preset=${{ matrix.build_type }} -DBUILD_TESTING=ON -DBUILD_TOOLS=OFF -DBUILD_BVT=ON
+        run: cmake --preset=${{ matrix.build_type }}
 
       - name: 'Build'
         working-directory: ${{ github.workspace }}
         run: cmake --build out\build\${{ matrix.build_type }}
 
-      - name: 'Run BVTs'
+      - name: 'Clean up'
         working-directory: ${{ github.workspace }}
-        run: ctest --preset=${{ matrix.build_type }} --output-on-failure
+        run: Remove-Item -Path out -Recurse -Force
+
+      - name: 'Configure CMake (DLL)'
+        working-directory: ${{ github.workspace }}
+        run: cmake --preset=${{ matrix.build_type }} -DBUILD_SHARED_LIBS=ON
+
+      - name: 'Build (DLL)'
+        working-directory: ${{ github.workspace }}
+        run: cmake --build out\build\${{ matrix.build_type }}

--- a/.github/workflows/arm64bvt.yml
+++ b/.github/workflows/arm64bvt.yml
@@ -3,7 +3,7 @@
 #
 # http://go.microsoft.com/fwlink/?LinkId=248929
 
-name: 'BVTs (x64)'
+name: 'BVTs (arm64)'
 
 on:
   push:
@@ -36,16 +36,14 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-11-arm
     timeout-minutes: 20
 
     strategy:
       fail-fast: false
 
       matrix:
-        toolver: ['14.29', '14']
-        build_type: [x64-Release]
-        arch: [amd64]
+        build_type: [arm64-Release]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -62,8 +60,7 @@ jobs:
 
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
-          arch: ${{ matrix.arch }}
-          toolset: ${{ matrix.toolver }}
+          arch: arm64
 
       - name: 'Configure CMake'
         working-directory: ${{ github.workspace }}

--- a/build/RestoreGDK.proj
+++ b/build/RestoreGDK.proj
@@ -1,0 +1,19 @@
+<!-- First update the GDKEditionNumber property in gdkedition.props -->
+
+<!-- nuget restore restoregdk.proj -packagesDirectory <outputdirectory> -->
+
+<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="gdkedition.props" />
+    <PropertyGroup>
+        <EditionYearMonth>$(GDKEditionNumber.Substring(0,2))$(GDKEditionNumber.Substring(2,2))</EditionYearMonth>
+        <EditionQFE>$(GDKEditionNumber.Substring(4,2).TrimStart('0'))</EditionQFE>
+        <EditionQFE Condition="'$(EditionQFE)'==''">0</EditionQFE>
+    </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net472</TargetFramework>
+        <Platforms>x64</Platforms>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.GDK.PC" Version="$(EditionYearMonth).$(EditionQFE).*" />
+    </ItemGroup>
+</Project>

--- a/build/RestoreGDK.ps1
+++ b/build/RestoreGDK.ps1
@@ -98,7 +98,6 @@ if (-Not (Test-Path $PGDK_DIR)) {
 
 # Reduce path depth removing version folder
 $PGDK_VER = Get-ChildItem $PGDK_DIR
-Write-Host $PGDK_VER
 if ($PGDK_VER.Count -ne 1) {
     Write-Error "##[error]Expected a single directory for the version!" -ErrorAction Stop
 }
@@ -107,15 +106,6 @@ $content = Get-ChildItem $PGDK_VER.Fullname
 ForEach-Object -InputObject $content { Move-Item $_.Fullname -Destination $PGDK_DIR }
 Remove-Item $PGDK_VER.Fullname
 
-$GDKX_VER = Get-ChildItem $GDKX_DIR
-if ($GDKX_VER.Count -ne 1) {
-    Write-Error "##[error]Expected a single directory for the version!" -ErrorAction Stop
-}
-
-$content = Get-ChildItem $GDKX_VER.Fullname
-ForEach-Object -InputObject $content { Move-Item $_.Fullname -Destination $GDKX_DIR }
-Remove-Item $GDKX_VER.Fullname
-
 Write-Host ("##[debug]PC Package ID: {0}  Version: {1}" -f $PGDK_ID, $PGDK_VER)
 
 
@@ -123,10 +113,6 @@ Write-Host ("##[debug]PC Package ID: {0}  Version: {1}" -f $PGDK_ID, $PGDK_VER)
 $PGDK_NUSPEC = New-Object xml
 $PGDK_NUSPEC.PreserveWhitespace = $true
 $PGDK_NUSPEC.Load([IO.Path]::Combine($PGDK_DIR, $PGDK_ID + ".nuspec"))
-
-$GDKX_NUSPEC = New-Object xml
-$GDKX_NUSPEC.PreserveWhitespace = $true
-$GDKX_NUSPEC.Load([IO.Path]::Combine($GDKX_DIR, $GDKX_ID + ".nuspec"))
 
 # Log results
 Write-Host "##[group]PC Nuget Package nuspec"

--- a/build/RestoreGDK.ps1
+++ b/build/RestoreGDK.ps1
@@ -1,0 +1,139 @@
+<#
+
+.SYNOPSIS
+Download and extract GDK NuGet based on edition number
+
+.DESCRIPTION
+This script determines the NuGet package id to use based on the provided GDK edition number. It makes use of MSBuild PackageReference floating version numbers to do the restore operation.
+
+.PARAMETER GDKEditionNumber
+The GDK edition number in the form of YYMMQQ.
+
+.PARAMETER OutputDirectory
+Directory to write the packages into. Path should not already contain the packages.
+
+#>
+
+param(
+    [Parameter(
+        Mandatory,
+        Position = 0
+    )]
+    [string]$GDKEditionNumber,
+    [Parameter(
+        Mandatory,
+        Position = 1
+    )]
+    [string]$OutputDirectory
+)
+
+# Validate output directory
+if ([string]::IsNullOrEmpty($OutputDirectory)) {
+    Write-Error "##[error]Output Directory is required" -ErrorAction Stop
+}
+
+# Parse edition number
+if (-not ($GDKEditionNumber -match '^([0-9][0-9])([0-9][0-9])([0-9][0-9])$')) {
+    Write-Error "##[error]This script requires a valid GDK edition number!" -ErrorAction Stop
+}
+
+$year = $Matches.1
+$month = [int]$Matches.2
+$qfe = [int]$Matches.3
+
+if ($year -lt 21)
+{
+    Write-Error "##[error]Edition year not supported: 20$year" -ErrorAction Stop
+}
+
+if (($month -lt 1) -or ($month -gt 12))
+{
+    Write-Error "##[error]Edition month not supported: $month" -ErrorAction Stop
+}
+
+if ($qfe -gt 0) {
+    Write-Host ("##[debug]GDKEditionNumber = $GDKEditionNumber ({0} 20{1} QFE {2})" -f (Get-Culture).DateTimeFormat.GetMonthName($month), $year, $qfe)
+}
+else {
+    Write-Host ("##[debug]GDKEditionNumber = $GDKEditionNumber ({0} 20{1})" -f (Get-Culture).DateTimeFormat.GetMonthName($month), $year)
+}
+
+# Verify NuGet tool is available
+$nuget = Get-Command nuget.exe -ErrorAction SilentlyContinue
+if (-Not $nuget) {
+    Write-Error "##[error]Missing required nuget.exe tool" -ErrorAction Stop
+}
+
+# Determine NuGet package ID
+if ($GDKEditionNumber -ge 241000) {
+    $PGDK_ID = "Microsoft.GDK.PC"
+}
+else {
+    Write-Error "##[error]Script supports October 2010 or later" -ErrorAction Stop
+}
+
+# Check that the package isn't already present
+$PGDK_DIR = [IO.Path]::Combine($OutputDirectory, $PGDK_ID)
+if (Test-Path $PGDK_DIR) {
+    Write-Error "##[error]PC Package ID already exists!" -ErrorAction Stop
+}
+
+# Restore Nuget packages using floating versions
+$propsfile = [IO.Path]::Combine( $PSScriptRoot , "gdkedition.props")
+$props = Get-Content -Path $propsfile
+$props = $props -replace '<GDKEditionNumber>.+</GDKEditionNumber>', ("<GDKEditionNumber>{0}</GDKEditionNumber>" -f $GDKEditionNumber)
+Set-Content -Path $propsfile -Value $props
+
+$nugetArgs = "restore RestoreGDK.proj -PackageSaveMode nuspec -packagesDirectory `"{0}`"" -f $OutputDirectory.TrimEnd('\')
+Write-Host "##[command]nuget $nugetArgs"
+$nugetrun = Start-Process -PassThru -Wait -FilePath $nuget.Path -WorkingDirectory $PSScriptRoot -ArgumentList $nugetArgs -NoNewWindow
+if ($nugetrun.ExitCode -gt 0) {
+    Write-Error "##[error]nuget restore failed" -ErrorAction Stop
+}
+
+# Verify expected output of restore
+if (-Not (Test-Path $PGDK_DIR)) {
+    Write-Error "##[error]Missing PC package after restore!" -ErrorAction Stop
+}
+
+# Reduce path depth removing version folder
+$PGDK_VER = Get-ChildItem $PGDK_DIR
+if ($PGDK_VER.Count -ne 1) {
+    Write-Error "##[error]Expected a single directory for the version!" -ErrorAction Stop
+}
+
+$content = Get-ChildItem $PGDK_VER.Fullname
+ForEach-Object -InputObject $content { Move-Item $_.Fullname -Destination $PGDK_DIR }
+Remove-Item $PGDK_VER.Fullname
+
+$GDKX_VER = Get-ChildItem $GDKX_DIR
+if ($GDKX_VER.Count -ne 1) {
+    Write-Error "##[error]Expected a single directory for the version!" -ErrorAction Stop
+}
+
+$content = Get-ChildItem $GDKX_VER.Fullname
+ForEach-Object -InputObject $content { Move-Item $_.Fullname -Destination $GDKX_DIR }
+Remove-Item $GDKX_VER.Fullname
+
+Write-Host ("##[debug]PC Package ID: {0}  Version: {1}" -f $PGDK_ID, $PGDK_VER)
+
+
+# Read the nuspec files
+$PGDK_NUSPEC = New-Object xml
+$PGDK_NUSPEC.PreserveWhitespace = $true
+$PGDK_NUSPEC.Load([IO.Path]::Combine($PGDK_DIR, $PGDK_ID + ".nuspec"))
+
+$GDKX_NUSPEC = New-Object xml
+$GDKX_NUSPEC.PreserveWhitespace = $true
+$GDKX_NUSPEC.Load([IO.Path]::Combine($GDKX_DIR, $GDKX_ID + ".nuspec"))
+
+# Log results
+Write-Host "##[group]PC Nuget Package nuspec"
+Write-host $PGDK_NUSPEC.outerxml
+Write-Host "##[endgroup]"
+
+$id = $PGDK_NUSPEC.package.metadata.id
+Write-Host "##vso[task.setvariable variable=PCNuGetPackage;]$id"
+
+$ver = $PGDK_NUSPEC.package.metadata.version
+Write-Host "##vso[task.setvariable variable=PCNuGetPackageVersion;]$ver"

--- a/build/RestoreGDK.ps1
+++ b/build/RestoreGDK.ps1
@@ -98,6 +98,7 @@ if (-Not (Test-Path $PGDK_DIR)) {
 
 # Reduce path depth removing version folder
 $PGDK_VER = Get-ChildItem $PGDK_DIR
+Write-Host $PGDK_VER
 if ($PGDK_VER.Count -ne 1) {
     Write-Error "##[error]Expected a single directory for the version!" -ErrorAction Stop
 }

--- a/build/RestoreGDK.ps1
+++ b/build/RestoreGDK.ps1
@@ -69,7 +69,7 @@ if ($GDKEditionNumber -ge 241000) {
     $PGDK_ID = "Microsoft.GDK.PC"
 }
 else {
-    Write-Error "##[error]Script supports October 2010 or later" -ErrorAction Stop
+    Write-Error "##[error]Script supports October 2024 or later" -ErrorAction Stop
 }
 
 # Check that the package isn't already present

--- a/build/SetupBWOI.cmd
+++ b/build/SetupBWOI.cmd
@@ -13,7 +13,7 @@ goto needconsole
 set GXDKEDITION=%2
 echo GXDKEDITION: %GXDKEDITION%
 
-set PCNUGET=%1\Microsoft.GDK.PC.%GXDKEDITION%\
+set PCNUGET=%1\Microsoft.GDK.PC\
 if NOT EXIST %PCNUGET% goto missingpcnuget
 
 set GRDKLatest=%PCNUGET%native\%GXDKEDITION%\GRDK\
@@ -21,7 +21,7 @@ echo GRDKLatest: %GRDKLatest%
 
 if %3.==PC. goto grdkonly
 
-set XBOXNUGET=%1\Microsoft.gdk.xbox.%GXDKEDITION%\
+set XBOXNUGET=%1\Microsoft.gdk.xbox\
 if NOT EXIST %XBOXNUGET% goto missingxboxnuget
 
 set GXDKLatest=%XBOXNUGET%native\%GXDKEDITION%\GXDK\
@@ -68,9 +68,9 @@ echo Usage: This script requires the target type of PC, Scarlett, or XboxOne in 
 exit /b 1
 
 :missingpcnuget
-echo ERROR - Cannot find Microsoft.GDK.PC.<edition> installed at '%1'
+echo ERROR - Cannot find Microsoft.GDK.PC installed at '%1'
 exit /b 1
 
 :missingxboxnuget
-echo ERROR - Cannot find Microsoft.GDK.Xbox.<edition> installed at '%1'
+echo ERROR - Cannot find Microsoft.GDK.Xbox installed at '%1'
 exit /b 1

--- a/build/gdkedition.props
+++ b/build/gdkedition.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <GDKEditionNumber>000000</GDKEditionNumber>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
* GitHub Actions using Windows on ARM64 native

* Updated Azure pipelines to stop using the windows-2019 image while still testing the v142 platform toolset.

* Some minor updates for the GDK pipelines for the package renaming as of October 2024.