### PR TITLE
Add Spectre-mitigated libraries to the NuGet

### DIFF
--- a/.nuget/directxtk_desktop_2019.nuspec
+++ b/.nuget/directxtk_desktop_2019.nuspec
@@ -52,14 +52,26 @@ DirectX Tool Kit for Audio in this package uses XAudio 2.8 to support Windows 8.
         <file target="native\lib\x86\Debug" src="Bin\Desktop_2019\Win32\Debug\*.lib" />
         <file target="native\lib\x86\Debug" src="Bin\Desktop_2019\Win32\Debug\*.pdb" />
 
+        <file target="native\lib\x86\Debug" src="Bin\Desktop_2019\Win32\DebugSpectre\*.lib" />
+        <file target="native\lib\x86\Debug" src="Bin\Desktop_2019\Win32\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x86\Release" src="Bin\Desktop_2019\Win32\Release\*.lib" />
         <file target="native\lib\x86\Release" src="Bin\Desktop_2019\Win32\Release\*.pdb" />
+
+        <file target="native\lib\x86\Release" src="Bin\Desktop_2019\Win32\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x86\Release" src="Bin\Desktop_2019\Win32\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\x64\Debug" src="Bin\Desktop_2019\x64\Debug\*.lib" />
         <file target="native\lib\x64\Debug" src="Bin\Desktop_2019\x64\Debug\*.pdb" />
 
+        <file target="native\lib\x64\Debug" src="Bin\Desktop_2019\x64\DebugSpectre\*.lib" />
+        <file target="native\lib\x64\Debug" src="Bin\Desktop_2019\x64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x64\Release" src="Bin\Desktop_2019\x64\Release\*.lib" />
         <file target="native\lib\x64\Release" src="Bin\Desktop_2019\x64\Release\*.pdb" />
+
+        <file target="native\lib\x64\Release" src="Bin\Desktop_2019\x64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x64\Release" src="Bin\Desktop_2019\x64\ReleaseSpectre\*.pdb" />
 
         <file src=".nuget/directxtk_desktop_2019.targets" target="build\native" />
 

--- a/.nuget/directxtk_desktop_2019.targets
+++ b/.nuget/directxtk_desktop_2019.targets
@@ -16,12 +16,14 @@
 
   <PropertyGroup>
     <directxtk-LibPath>$(MSBuildThisFileDirectory)..\..\native\lib\$(PlatformTarget)\$(NuGetConfiguration)</directxtk-LibPath>
+    <directxtk-LibName Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">DirectXTK_Spectre</directxtk-LibName>
+    <directxtk-LibName Condition="'$(directxtk-LibName)'==''">DirectXTK</directxtk-LibName>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
     <Link>
       <AdditionalLibraryDirectories>$(directxtk-LibPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>DirectXTK.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(directxtk-LibName).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/.nuget/directxtk_desktop_win10.nuspec
+++ b/.nuget/directxtk_desktop_win10.nuspec
@@ -52,20 +52,38 @@ DirectX Tool Kit for Audio in this package uses XAudio 2.9 which requires Window
         <file target="native\lib\x86\Debug" src="Bin\Desktop_2022_Win10\Win32\Debug\*.lib" />
         <file target="native\lib\x86\Debug" src="Bin\Desktop_2022_Win10\Win32\Debug\*.pdb" />
 
+        <file target="native\lib\x86\Debug" src="Bin\Desktop_2022_Win10\Win32\DebugSpectre\*.lib" />
+        <file target="native\lib\x86\Debug" src="Bin\Desktop_2022_Win10\Win32\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x86\Release" src="Bin\Desktop_2022_Win10\Win32\Release\*.lib" />
         <file target="native\lib\x86\Release" src="Bin\Desktop_2022_Win10\Win32\Release\*.pdb" />
+
+        <file target="native\lib\x86\Release" src="Bin\Desktop_2022_Win10\Win32\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x86\Release" src="Bin\Desktop_2022_Win10\Win32\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\x64\Debug" src="Bin\Desktop_2022_Win10\x64\Debug\*.lib" />
         <file target="native\lib\x64\Debug" src="Bin\Desktop_2022_Win10\x64\Debug\*.pdb" />
 
+        <file target="native\lib\x64\Debug" src="Bin\Desktop_2022_Win10\x64\DebugSpectre\*.lib" />
+        <file target="native\lib\x64\Debug" src="Bin\Desktop_2022_Win10\x64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\x64\Release" src="Bin\Desktop_2022_Win10\x64\Release\*.lib" />
         <file target="native\lib\x64\Release" src="Bin\Desktop_2022_Win10\x64\Release\*.pdb" />
+
+        <file target="native\lib\x64\Release" src="Bin\Desktop_2022_Win10\x64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\x64\Release" src="Bin\Desktop_2022_Win10\x64\ReleaseSpectre\*.pdb" />
 
         <file target="native\lib\ARM64\Debug" src="Bin\Desktop_2022_Win10\ARM64\Debug\*.lib" />
         <file target="native\lib\ARM64\Debug" src="Bin\Desktop_2022_Win10\ARM64\Debug\*.pdb" />
 
+        <file target="native\lib\ARM64\Debug" src="Bin\Desktop_2022_Win10\ARM64\DebugSpectre\*.lib" />
+        <file target="native\lib\ARM64\Debug" src="Bin\Desktop_2022_Win10\ARM64\DebugSpectre\*.pdb" />
+
         <file target="native\lib\ARM64\Release" src="Bin\Desktop_2022_Win10\ARM64\Release\*.lib" />
         <file target="native\lib\ARM64\Release" src="Bin\Desktop_2022_Win10\ARM64\Release\*.pdb" />
+
+        <file target="native\lib\ARM64\Release" src="Bin\Desktop_2022_Win10\ARM64\ReleaseSpectre\*.lib" />
+        <file target="native\lib\ARM64\Release" src="Bin\Desktop_2022_Win10\ARM64\ReleaseSpectre\*.pdb" />
 
         <file src=".nuget/directxtk_desktop_win10.targets" target="build\native" />
 

--- a/.nuget/directxtk_desktop_win10.targets
+++ b/.nuget/directxtk_desktop_win10.targets
@@ -16,12 +16,14 @@
 
   <PropertyGroup>
     <directxtk-LibPath>$(MSBuildThisFileDirectory)..\..\native\lib\$(PlatformTarget)\$(NuGetConfiguration)</directxtk-LibPath>
+    <directxtk-LibName Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">DirectXTK_Spectre</directxtk-LibName>
+    <directxtk-LibName Condition="'$(directxtk-LibName)'==''">DirectXTK</directxtk-LibName>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
     <Link>
       <AdditionalLibraryDirectories>$(directxtk-LibPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>DirectXTK.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(directxtk-LibName).lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/DirectXTK_Desktop_2019.vcxproj
+++ b/DirectXTK_Desktop_2019.vcxproj
@@ -248,6 +248,11 @@
     <IntDir>Bin\Desktop_2019\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXTK</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2019\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2019\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXTK_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/DirectXTK_Desktop_2019_Win10.vcxproj
+++ b/DirectXTK_Desktop_2019_Win10.vcxproj
@@ -286,6 +286,11 @@
     <IntDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXTK</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2019_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXTK_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/DirectXTK_Desktop_2022.vcxproj
+++ b/DirectXTK_Desktop_2022.vcxproj
@@ -248,6 +248,11 @@
     <IntDir>Bin\Desktop_2022\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXTK</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2022\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2022\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXTK_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/DirectXTK_Desktop_2022_Win10.vcxproj
+++ b/DirectXTK_Desktop_2022_Win10.vcxproj
@@ -286,6 +286,11 @@
     <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXTK</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXTK_Spectre</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>


### PR DESCRIPTION
Customers using the BinSkim Microsoft security tool will get flagged when using static C++ libraries not built using /Qspectre. This adds the alternative flavor of the libraries to the directxtex_desktop_2019 and directxtex_desktop_win10 versions of the NuGet package. The targets automatically selects the Spectre version when building with SpectreMitigations enabled.

> The new packages are 65 MB and 98 MB, compared to the current size of 31 MB and 47 MB.