### PR TITLE
Upgrade to CMake 3.21

### DIFF
--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -44,7 +44,7 @@ jobs:
 
       matrix:
         toolver: ['14.29', '14']
-        build_type: [x64-Release]
+        build_type: [x64-Release, x64-Release-Win10]
         arch: [amd64]
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-cmake_minimum_required (VERSION 3.20)
+cmake_minimum_required (VERSION 3.21)
 
 set(DIRECTXTK_VERSION 1.9.2)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": 2,
+  "version": 3,
   "configurePresets": [
     {
       "name": "base",
@@ -8,7 +8,7 @@
       "generator": "Ninja",
       "hidden": true,
       "binaryDir": "${sourceDir}/out/build/${presetName}",
-      "cacheVariables": { "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}" }
+      "installDir": "${sourceDir}/out/install/${presetName}"
     },
 
     {
@@ -164,12 +164,7 @@
     },
     {
       "name": "VCPKG",
-      "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": {
-          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-          "type": "FILEPATH"
-        }
-      },
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
       "hidden": true
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -342,6 +342,11 @@
     { "name": "x86-Debug"      , "configurePreset": "x86-Debug" },
     { "name": "x86-Release"    , "configurePreset": "x86-Release" },
 
+    { "name": "x64-Debug-Win10"  , "configurePreset": "x64-Debug-Win10" },
+    { "name": "x64-Release-Win10", "configurePreset": "x64-Release-Win10" },
+    { "name": "x86-Debug-Win10"  , "configurePreset": "x86-Debug-Win10" },
+    { "name": "x86-Release-Win10", "configurePreset": "x86-Release-Win10" },
+
     { "name": "arm64-Debug"    , "configurePreset": "arm64-Debug" },
     { "name": "arm64-Release"  , "configurePreset": "arm64-Release" },
     { "name": "arm64ec-Debug"  , "configurePreset": "arm64ec-Debug" },

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectXTK/sec
 
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/DirectXTK/blob/main/CHANGELOG.md).
 
+* The CMake projects require 3.21 or later. VS 2019 users will need to install a standalone version of CMake 3.21 or later and add it to their PATH.
+
 * Starting with the March 2025 release, Windows 7 and Windows 8.0 support has been retired. For _DirectX ToolKit for Audio_ this means that `DirectXTKAudio_Desktop_*_Win7` has been removed, and `DirectXTKAudio_Desktop_*_Win8` has been integrated into the `DirectXTK_Desktop_*` vcxproj which uses XAudio 2.8 for Windows 8.1 compatibility.
 
   * Remove any References to or use of `DirectXTKAudio_Desktop_*_Win8.vcxproj` or `DirectXTKAudio_Desktop_*_Win7`. If using `DirectXTK_Desktop_*.vcxproj` you will be using XAudio 2.8 as before. Client code will need to build with `_WIN32_WINNT=0x0603`.

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -16,6 +16,10 @@
 #include "DDSTextureLoader.h"
 #include "PlatformHelpers.h"
 
+#include <algorithm>
+#include <memory>
+#include <new>
+#include <tuple>
 
 namespace DirectX
 {

--- a/Src/LoaderHelpers.h
+++ b/Src/LoaderHelpers.h
@@ -17,6 +17,8 @@
 #include "PlatformHelpers.h"
 
 #include <algorithm>
+#include <cfloat>
+#include <cmath>
 #include <memory>
 #include <new>
 #include <tuple>

--- a/Src/PlatformHelpers.h
+++ b/Src/PlatformHelpers.h
@@ -14,6 +14,7 @@
 #pragma warning(disable : 4324)
 #endif
 
+#include <cstdio>
 #include <exception>
 #include <memory>
 


### PR DESCRIPTION
CMake 3.21 comes with VS 2022.

> VS 2019 users will need to install a standalone version of a CMake newer than the 3.20 that comes with it.