### PR TITLE
CoPilot instruction improvements

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -261,10 +261,10 @@ When creating documentation:
 
 - The code targets Win32 desktop applications for Windows 8.1 or later, legacy Xbox One XDK, and Universal Windows Platform (UWP) apps for Windows 10 and Windows 11.
 - Portability and conformance of the code is validated by building with Visual C++, clang/LLVM for Windows, and MinGW.
-- For PC development using the Microsoft GDK, the project provides MSBuild solution `DirectXTK_GDKW_2022.sln` for the x64 or ARM64 architectures.
-- The MSBuild solution `DirectXTK_GDK_2022.sln` is for Microsoft GDK development for desktop using the legacy Gaming.Desktop.x64 custom platform.
+- For PC development using the *Microsoft GDK*, the project provides MSBuild solution `DirectXTK_GDKW_2022.sln` for the x64 or ARM64 architectures.
+- The MSBuild solution `DirectXTK_GDK_2022.sln` is for *Microsoft GDK with Xbox Extensions* development for PC using the legacy Gaming.Desktop.x64 custom platform. There is no support for the Gaming.Xbox.*.x64 custom platforms since they do not support DirectX 11.
 - The project ships MSBuild projects for Visual Studio 2022 (`.sln` / `.vcxproj`) and Visual Studio 2026 (`.slnx` / `.vcxproj`). VS 2019 projects have been retired.
-- The CMake build supports legacy Xbox One XDK via the `XBOX_CONSOLE_TARGET` variable (`durango`).
+- The CMake build supports legacy Xbox One XDK via the `XBOX_CONSOLE_TARGET` variable (`durango`). Xbox Series X|S (`scarlett`) and Xbox One (`xboxone`) via the *Microsoft GDK with Xbox Extensions* only supports DirectX 12, so this version of the library cannot support those platforms.
 
 ### Platform and Compiler `#ifdef` Guards
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,12 +20,12 @@ These instructions define how GitHub Copilot should assist with this project. Th
 ## General Guidelines
 
 - **Code Style**: The project uses an .editorconfig file to enforce coding standards. Follow the rules defined in `.editorconfig` for indentation, line endings, and other formatting. Additional information can be found on the wiki at [Implementation](https://github.com/microsoft/DirectXTK/wiki/Implementation). The library's public API requires C++11, and the project builds with C++17 (`CMAKE_CXX_STANDARD 17`). The command-line tools also use C++17, including `<filesystem>` for long file path support. This code is designed to build with Visual Studio 2022, Visual Studio 2026, clang for Windows v12 or later, or MinGW 12.2.
-> Notable `.editorconfig` rules: C/C++ files use 4-space indentation, `crlf` line endings, and `latin1` charset — avoid non-ASCII characters in source files. HLSL files have separate indent/spacing rules defined in `.editorconfig`.
+> Notable `.editorconfig` rules: C/C++ and HLSL files use 4-space indentation, `crlf` line endings, and `latin1` charset — avoid non-ASCII characters in source files. HLSL files have separate indent/spacing rules defined in `.editorconfig`.
 - **Documentation**: The project provides documentation in the form of wiki pages available at [Documentation](https://github.com/microsoft/DirectXTK/wiki/).
 - **Error Handling**: Use C++ exceptions for error handling and uses RAII smart pointers to ensure resources are properly managed. For some functions that return HRESULT error codes, they are marked `noexcept`, use `std::nothrow` for memory allocation, and should not throw exceptions.
-- **Testing**: Unit tests for this project are implemented in this repository [Test Suite](https://github.com/walbourn/directxtktest/) and can be run using CTest per the instructions at [Test Documentation](https://github.com/walbourn/directxtktest/wiki).
-- **Security**: This project uses secure coding practices from the Microsoft Secure Coding Guidelines, and is subject to the `SECURITY.md` file in the root of the repository. Functions that read input from image file, geometry files, and audio files are subject to OneFuzz fuzz testing to ensure they are secure against malformed files.
-- **Dependencies**: The project uses CMake and VCPKG for managing dependencies, making optional use of DirectXMath, GameInput, and XAudio2Redist. The project can be built without these dependencies, relying on the Windows SDK for core functionality.
+- **Testing**: Unit tests for this project are implemented in this repository [Test Suite](https://github.com/walbourn/directxtktest/) and can be run using CTest per the instructions at [Test Documentation](https://github.com/walbourn/directxtktest/wiki). See [test copilot instructions](https://github.com/walbourn/directxtktest/blob/main/.github/copilot-instructions.md) for additional information on the tests.
+- **Security**: This project uses secure coding practices from the Microsoft Secure Coding Guidelines, and is subject to the `SECURITY.md` file in the root of the repository. Functions that read input from image files, geometry files, and audio files are subject to OneFuzz fuzz testing to ensure they are secure against malformed files.
+- **Dependencies**: The project uses CMake and VCPKG for managing dependencies, making optional use of DirectXMath, GameInput, and XAudio2Redist. The project can be built without these dependencies, relying on the Windows SDK for core functionality. CMake build options include `BUILD_GAMEINPUT`, `BUILD_WGI`, and `BUILD_XINPUT` for alternative input backends.
 - **Continuous Integration**: This project implements GitHub Actions for continuous integration, ensuring that all code changes are tested and validated before merging. This includes building the project for a number of configurations and toolsets, running a subset of unit tests, and static code analysis including GitHub super-linter, CodeQL, and MSVC Code Analysis.
 - **Code of Conduct**: The project adheres to the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). All contributors are expected to follow this code of conduct in all interactions related to the project.
 
@@ -35,7 +35,7 @@ These instructions define how GitHub Copilot should assist with this project. Th
 .azuredevops/   # Azure DevOps pipeline configuration and policy files.
 .github/        # GitHub Actions workflow files and linter configuration files.
 .nuget/         # NuGet package configuration files.
-build/          # Miscellaneous build files and scripts, including OneFuzzConfig.json.
+build/          # Miscellaneous build files and scripts.
 Audio/          # DirectX Tool Kit for Audio implementation files.
 Inc/            # Public header files.
 Src/            # Implementation header and source files.
@@ -62,10 +62,11 @@ wiki/           # Local clone of the GitHub wiki documentation repository.
 - Use 16-byte alignment (`_aligned_malloc` / `_aligned_free`) to support SIMD operations in the implementation, but do not expose this requirement in public APIs.
 - All implementation `.cpp` files include `pch.h` as their first include (precompiled header). MinGW builds skip precompiled headers.
 - `Model` and related classes require RTTI (`/GR` on MSVC, `__GXX_RTTI` on GCC/Clang). The CMake build enables `/GR` automatically; do not disable RTTI when using `Model`.
-
-#### Inline Namespace
-
-All public headers that contain types shared with the DirectX 12 version of the *DirectX Tool Kit* use `inline namespace DX11` inside `namespace DirectX`. This provides link-unique names (e.g. `DirectX::DX11::SpriteBatch`) without requiring explicit `DX11` qualification in client code. When adding new public types that also exist in DirectXTK12, place them inside this inline namespace.
+- Many public headers use `inline namespace DX11` inside `namespace DirectX` to disambiguate from *DirectX Tool Kit for DirectX 12* types when both libraries are used together. This is usually indicated when parameters use `ID3D11Device` or `ID3D11DeviceContext` types. Follow this pattern for new headers that have Direct3D 11-specific types in the public API.
+- Use `static constexpr` for class-scope constants (e.g., `static constexpr int MaxDirectionalLights = 3;`, `static constexpr unsigned int InputElementCount = 1;`). SimpleMath types use `constexpr` constructors for compile-time initialization.
+- Functions that load data from memory (texture loaders, Model) provide both `const uint8_t*` and `const std::byte*` overloads. When adding new memory-buffer APIs, provide both overload variants. The `const std::byte *` overloads are guarded by `#ifdef __cpp_lib_byte` to maintain compatibility with older C++ standards.
+- Each public header wraps the `DIRECTX_TOOLKIT_API` macro definition in `#ifndef DIRECTX_TOOLKIT_API` so it is only defined once. Follow this guard pattern when adding new headers.
+- Headers use `#pragma comment(lib, ...)` under `_MSC_VER` to auto-link platform libraries (e.g., `gameinput.lib`, `xinput.lib`, `runtimeobject.lib`). Follow this pattern for new platform library dependencies.
 
 #### SAL Annotations
 
@@ -112,8 +113,11 @@ HRESULT DirectX::CreateStaticBuffer(
 
 #### Calling Convention and DLL Export
 
-- All public functions use `__cdecl` explicitly for ABI stability.
-- All public function declarations are prefixed with `DIRECTX_TOOLKIT_API`, which wraps `__declspec(dllexport)` / `__declspec(dllimport)` or the GCC `__attribute__` equivalent when using `BUILD_SHARED_LIBS` in CMake.
+- All public free functions use `__cdecl` explicitly for ABI stability.
+- Functions that take `XMVECTOR`, `FXMVECTOR`, or `XMMATRIX` parameters use `XM_CALLCONV` instead of `__cdecl` to enable efficient SIMD register passing. This is the DirectXMath calling convention and is used extensively in SpriteBatch, SpriteFont, Effects, Model, GeometricPrimitive, and VertexTypes.
+- All public function declarations are prefixed with `DIRECTX_TOOLKIT_API`, which wraps `__declspec(dllexport)` / `__declspec(dllimport)` or the GCC `__attribute__` equivalent when using `BUILD_SHARED_LIBS` in CMake. The underlying macros are `DIRECTX_TOOLKIT_EXPORT` (for building the library) and `DIRECTX_TOOLKIT_IMPORT` (for consuming it).
+- For free functions, `DIRECTX_TOOLKIT_API` appears on the line above the return type. For inner classes and interfaces, the macro is placed inline: `class DIRECTX_TOOLKIT_API ClassName`.
+- When importing DLL classes under MSVC, headers suppress warnings C4251 and C4275 via `#pragma warning(disable : 4251 4275)` inside a `#if defined(DIRECTX_TOOLKIT_IMPORT) && defined(_MSC_VER)` guard.
 
 #### `noexcept` Rules
 
@@ -123,7 +127,7 @@ HRESULT DirectX::CreateStaticBuffer(
 
 #### Enum Flags Pattern
 
-Flags enums follow this pattern — a `uint32_t`-based unscoped enum with a `_DEFAULT = 0x0` base case, followed by a call to `DEFINE_ENUM_FLAG_OPERATORS` to enable `|`, `&`, and `~` operators:
+Flags enums follow this pattern — a `uint32_t`-based unscoped enum with a `_DEFAULT = 0` base case, followed by a call to `DEFINE_ENUM_FLAG_OPERATORS` to enable `|`, `&`, and `~` operators:
 
 ```cpp
   enum DDS_LOADER_FLAGS : uint32_t
@@ -139,20 +143,39 @@ DEFINE_ENUM_FLAG_OPERATORS(DDS_LOADER_FLAGS);
 
 See [this blog post](https://walbourn.github.io/modern-c++-bitmask-types/) for more information on this pattern.
 
+#### Clang Diagnostic Pragmas
+
+Headers that trigger Clang warnings use paired `#pragma clang diagnostic push`/`pop` blocks under `#ifdef __clang__` to suppress specific diagnostics. Common suppressions include `-Wunsafe-buffer-usage`, `-Wfloat-equal`, and `-Wunknown-warning-option`. Follow this pattern when adding code that legitimately triggers Clang-specific warnings:
+
+```cpp
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#endif
+
+// ... code ...
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+```
+
 ### Patterns to Avoid
 
 - Don’t use raw pointers for ownership.
 - Avoid macros for constants—prefer `constexpr` or `inline` `const`.
 - Don’t put implementation logic in header files unless using templates, although the SimpleMath library does use an .inl file for performance.
 - Avoid using `using namespace` in header files to prevent polluting the global namespace.
+- Don't use `[[deprecated]]` or `__declspec(deprecated)` attributes. Feature retirement is communicated via `CHANGELOG.md` notes, not in-source deprecation markers.
 
 ## Naming Conventions
 
 | Element | Convention | Example |
 | --- | --- | --- |
 | Classes / structs | PascalCase | `VertexPosition` |
-| Public functions | PascalCase + `__cdecl` | `ComputeDisplayArea` |
+| Public functions | PascalCase + `__cdecl` or `XM_CALLCONV` | `ComputeDisplayArea` |
 | Private data members | `m_` prefix | `m_count` |
+| Static constexpr members | `c_` prefix (camelCase) or PascalCase | `c_MostRecent`, `MaxDirectionalLights` |
 | Enum type names | UPPER_SNAKE_CASE | `DDS_LOADER_FLAGS` |
 | Enum values | UPPER_SNAKE_CASE | `DDS_LOADER_DEFAULT` |
 | Files | PascalCase | `ScreenGrab.h`, `SpriteEffect.fx` |
@@ -162,7 +185,7 @@ See [this blog post](https://walbourn.github.io/modern-c++-bitmask-types/) for m
 Every source file (`.cpp`, `.h`, `.hlsl`, `.fx`, etc.) must begin with this block:
 
 ```cpp
-//-------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------
 // File: {FileName}
 //
 // {One-line description}
@@ -171,12 +194,12 @@ Every source file (`.cpp`, `.h`, `.hlsl`, `.fx`, etc.) must begin with this bloc
 // Licensed under the MIT License.
 //
 // https://go.microsoft.com/fwlink/?LinkId=248929
-//-------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------
 ```
 
 Section separators within files use:
-- Major sections: `//-------------------------------------------------------------------------------------`
-- Subsections:   `//---------------------------------------------------------------------------------`
+- Major sections: `//--------------------------------------------------------------------------------------`
+- Subsections:   `//--------------------------------------------------------------------------------------`
 
 The project does **not** use Doxygen. API documentation is maintained exclusively on the GitHub wiki.
 
@@ -191,18 +214,19 @@ Shaders in `Src/Shaders/` are compiled with **FXC**, producing embedded C++ head
 
 - [Source git repository on GitHub](https://github.com/microsoft/DirectXTK.git)
 - [DirectXTK documentation git repository on GitHub](https://github.com/microsoft/DirectXTK.wiki.git)
-- [DirectXTK test suite git repository on GitHub](https://github.com/walbourn/directxtktest.wiki.git).
+- [DirectXTK test suite git repository on GitHub](https://github.com/walbourn/directxtktest.git)
+- [DirectX Tool Kit for Audio Wiki](https://github.com/Microsoft/DirectXTK/wiki/Audio)
 - [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)
 - [Microsoft Secure Coding Guidelines](https://learn.microsoft.com/en-us/security/develop/secure-coding-guidelines)
 - [CMake Documentation](https://cmake.org/documentation/)
 - [VCPKG Documentation](https://learn.microsoft.com/vcpkg/)
 - [Games for Windows and the DirectX SDK blog - March 2012](https://walbourn.github.io/directxtk/)
 - [Games for Windows and the DirectX SDK blog - January 2013](https://walbourn.github.io/directxtk-update/)
-- [Games for Windows and the DirectX SDK blog - December 13](https://walbourn.github.io/directx-tool-kit-for-audio/)
+- [Games for Windows and the DirectX SDK blog - December 2013](https://walbourn.github.io/directx-tool-kit-for-audio/)
 - [Games for Windows and the DirectX SDK blog - September 2014](https://walbourn.github.io/directx-tool-kit-now-with-gamepads/)
 - [Games for Windows and the DirectX SDK blog - August 2015](https://walbourn.github.io/directx-tool-kit-keyboard-and-mouse-support/)
-- [Games for Windows and the DirectX SDK blog - September 2021](https://walbourn.github.io/latest-news-on-directx-tool-kit/)
 - [Games for Windows and the DirectX SDK blog - October 2021](https://walbourn.github.io/directx-tool-kit-vertex-skinning-update/)
+- [Games for Windows and the DirectX SDK blog - September 2021](https://walbourn.github.io/latest-news-on-directx-tool-kit/)
 - [Games for Windows and the DirectX SDK blog - May 2020](https://walbourn.github.io/directx-tool-kit-for-audio-updates-and-a-direct3d-9-footnote/)
 
 ## No speculation
@@ -235,10 +259,12 @@ When creating documentation:
 
 ## Cross-platform Support Notes
 
-- The code targets Win32 desktop applications for Windows 8.1 or later, Xbox One, Xbox Series X|S, and Universal Windows Platform (UWP) apps for Windows 10 and Windows 11.
+- The code targets Win32 desktop applications for Windows 8.1 or later, legacy Xbox One XDK, and Universal Windows Platform (UWP) apps for Windows 10 and Windows 11.
 - Portability and conformance of the code is validated by building with Visual C++, clang/LLVM for Windows, and MinGW.
-- For Xbox development, the project provides MSBuild solutions for GDK (`DirectXTK_GDK_2022.sln`) and GDK with Xbox Extensions (`DirectXTK_GDKW_2022.sln`). The CMake build supports Xbox via the `XBOX_CONSOLE_TARGET` variable (`scarlett` or `xboxone`).
+- For PC development using the Microsoft GDK, the project provides MSBuild solution `DirectXTK_GDKW_2022.sln` for the x64 or ARM64 architectures.
+- The MSBuild solution `DirectXTK_GDK_2022.sln` is for Microsoft GDK development for desktop using the legacy Gaming.Desktop.x64 custom platform.
 - The project ships MSBuild projects for Visual Studio 2022 (`.sln` / `.vcxproj`) and Visual Studio 2026 (`.slnx` / `.vcxproj`). VS 2019 projects have been retired.
+- The CMake build supports legacy Xbox One XDK via the `XBOX_CONSOLE_TARGET` variable (`durango`).
 
 ### Platform and Compiler `#ifdef` Guards
 
@@ -247,20 +273,23 @@ Use these established guards — do not invent new ones:
 | Guard | Purpose |
 | --- | --- |
 | `_WIN32` | Windows platform (desktop, UWP, Xbox) |
-| `_GAMING_XBOX` | Xbox platform (GDK — covers both Xbox One and Xbox Series X\|S) |
+| `_GAMING_XBOX` | Xbox platform (GDK - covers both Xbox One and Xbox Series X\|S) |
 | `_GAMING_XBOX_SCARLETT` | Xbox Series X\|S (GDK with Xbox Extensions) |
 | `_GAMING_XBOX_XBOXONE` | Xbox One (GDK with Xbox Extensions) |
-| `_XBOX_ONE && _TITLE` | Xbox One XDK (legacy) |
+| `_GAMING_DESKTOP` | Gaming desktop platform (GDK); used for GRDK edition version checks |
+| `_XBOX_ONE && _TITLE` | Legacy Xbox One XDK |
 | `_MSC_VER` | MSVC-specific (and MSVC-like clang-cl) pragmas and warning suppression |
 | `__clang__` | Clang/LLVM diagnostic suppressions |
+| `__MINGW32__` | MinGW compatibility headers |
 | `__GNUC__` | MinGW/GCC DLL attribute equivalents |
 | `_M_ARM64` / `_M_X64` / `_M_IX86` | Architecture-specific code paths for MSVC (`#ifdef`) |
 | `_M_ARM64EC` | ARM64EC ABI (ARM64 code with x64 interop) for MSVC |
 | `__aarch64__` / `__x86_64__` / `__i386__` | Additional architecture-specific symbols for MinGW/GNUC (`#if`) |
 | `USING_GAMEINPUT` | GameInput API for GamePad, Keyboard, Mouse |
 | `USING_WINDOWS_GAMING_INPUT` | Windows.Gaming.Input API for GamePad |
-| `USING_XINPUT` | XInput API for GamePad, Keyboard, Mouse |
+| `USING_XINPUT` | XInput API for GamePad |
 | `USING_COREWINDOW` | CoreWindow-based input (UWP) for Keyboard, Mouse |
+| `GAMEINPUT_API_VERSION` | GameInput SDK version detection for API-level feature checks |
 
 > `_M_ARM`/ `__arm__` is legacy 32-bit ARM which is deprecated.
 
@@ -274,7 +303,7 @@ When reviewing code, focus on the following aspects:
 - Correct error handling practices and C++ Exception safety.
 - Clarity and maintainability of the code.
 - Adequate comments where necessary.
-- Public interfaces are located in `Inc\*.h` should be clearly defined and documented on the GitHub wiki.
+- Public interfaces located in `Inc\*.h` should be clearly defined and documented on the GitHub wiki.
 - Compliance with the project's architecture and design patterns.
 - Ensure that all public functions and classes are covered by unit tests located on [GitHub](https://github.com/walbourn/directxtktest.git) where applicable. Report any gaps in test coverage.
 - Check for performance implications, especially in geometry processing algorithms.

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -12,6 +12,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json
@@ -24,6 +25,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/arm64bvt.yml
+++ b/.github/workflows/arm64bvt.yml
@@ -12,6 +12,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json
@@ -24,6 +25,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -12,6 +12,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json
@@ -24,6 +25,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/clangcl.yml
+++ b/.github/workflows/clangcl.yml
@@ -12,6 +12,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json
@@ -24,6 +25,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json
@@ -24,6 +25,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json
@@ -24,6 +25,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -12,6 +12,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*
   pull_request:
@@ -20,6 +21,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -12,6 +12,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json
@@ -24,6 +25,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json
@@ -24,6 +25,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/uwp.yml
+++ b/.github/workflows/uwp.yml
@@ -12,6 +12,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json
@@ -24,6 +25,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -12,6 +12,8 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
+      - '.nuget/*'
       - build/*.cmd
       - build/*.props
       - build/*.ps1
@@ -22,6 +24,8 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
+      - '.nuget/*'
       - build/*.cmd
       - build/*.props
       - build/*.ps1

--- a/.github/workflows/win10.yml
+++ b/.github/workflows/win10.yml
@@ -12,6 +12,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json
@@ -24,6 +25,7 @@ on:
       - '*.md'
       - LICENSE
       - '.azuredevops/**'
+      - '.github/*.md'
       - '.nuget/*'
       - build/*.cmd
       - build/*.json

--- a/README.md
+++ b/README.md
@@ -151,3 +151,5 @@ Thanks to Roberto Sonnino for his help with the ``CMO``, DGSL rendering, and the
 Thanks to Pete Lewis and Justin Saunders for the normal-mapped and PBR shaders implementation.
 
 Thanks to Andrew Farrier and Scott Matloff for their on-going help with code reviews.
+
+Thanks to Imre Eilertsen for creating winget ports for the command-line tools.


### PR DESCRIPTION
Updated GitHub Actions to ignore changes to CoPilot instructions except for SuperLinter, plus a minor readme update.