### PR TITLE
Mouse::SetDpi was missing from DLL version

### DIFF
--- a/Inc/Mouse.h
+++ b/Inc/Mouse.h
@@ -154,21 +154,21 @@ namespace DirectX
     #ifdef USING_COREWINDOW
         DIRECTX_TOOLKIT_API void __cdecl SetWindow(ABI::Windows::UI::Core::ICoreWindow* window);
     #ifdef __cplusplus_winrt
-        DIRECTX_TOOLKIT_API void __cdecl SetWindow(Windows::UI::Core::CoreWindow^ window)
+        DIRECTX_TOOLKIT_API inline void __cdecl SetWindow(Windows::UI::Core::CoreWindow^ window)
         {
             // See https://msdn.microsoft.com/en-us/library/hh755802.aspx
             SetWindow(reinterpret_cast<ABI::Windows::UI::Core::ICoreWindow*>(window));
         }
     #endif
     #ifdef CPPWINRT_VERSION
-        DIRECTX_TOOLKIT_API void __cdecl SetWindow(winrt::Windows::UI::Core::CoreWindow window)
+        DIRECTX_TOOLKIT_API inline void __cdecl SetWindow(winrt::Windows::UI::Core::CoreWindow window)
         {
             // See https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/interop-winrt-abi
             SetWindow(reinterpret_cast<ABI::Windows::UI::Core::ICoreWindow*>(winrt::get_abi(window)));
         }
     #endif
 
-        static void __cdecl SetDpi(float dpi);
+        DIRECTX_TOOLKIT_API static void __cdecl SetDpi(float dpi);
     #elif defined(WM_USER)
         DIRECTX_TOOLKIT_API void __cdecl SetWindow(HWND window);
         DIRECTX_TOOLKIT_API static void __cdecl ProcessMessage(UINT message, WPARAM wParam, LPARAM lParam);

--- a/Inc/XboxDDSTextureLoader.h
+++ b/Inc/XboxDDSTextureLoader.h
@@ -1,4 +1,4 @@
-s//--------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------
 // File: XboxDDSTextureLoader.h
 //
 // Functions for loading a DDS texture using the XBOX extended header and creating a


### PR DESCRIPTION
Also fixed a stray typo in XboxDDSTextureLoader.h (only used for legacy Xbox One XDK)