### PR TITLE
Update MinGW GitHub action to cover more compiler versions

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -105,4 +105,4 @@ jobs:
 
       - name: 'Build'
         working-directory: ${{ github.workspace }}
-        run: cmake --build out\build\${{ matrix.build_type }}
+        run: cmake --build out/build/${{ matrix.build_type }}

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -37,8 +37,6 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2022
-
     strategy:
       fail-fast: false
 
@@ -46,6 +44,9 @@ jobs:
         build_type: [x64-Debug-MinGW, x64-Release-MinGW]
         shared: ['OFF', 'ON']
         gameinput: ['OFF', 'ON']
+        os: [windows-2022, windows-2025]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectXTK/sec
 
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/DirectXTK/blob/main/CHANGELOG.md).
 
+* The _directxtk_desktop_win10_ and _directxtk_uwp_ NuGet packages are deprecated. The best way to integrate the latest DirectX Tool Kit into your C++ project is using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/directxtk).
+
 * The CMake projects require 3.21 or later.
 
 * Starting with the March 2025 release, Windows 7 and Windows 8.0 support has been retired. For _DirectX ToolKit for Audio_ this means that `DirectXTKAudio_Desktop_*_Win7` has been removed, and `DirectXTKAudio_Desktop_*_Win8` has been integrated into the `DirectXTK_Desktop_*` vcxproj which uses XAudio 2.8 for Windows 8.1 compatibility.
@@ -166,6 +168,8 @@ Thanks to Roberto Sonnino for his help with the ``CMO``, DGSL rendering, and the
 
 Thanks to Pete Lewis and Justin Saunders for the normal-mapped and PBR shaders implementation.
 
-Thanks to Andrew Farrier and Scott Matloff for their on-going help with code reviews.
-
 Thanks to Imre Eilertsen for creating winget ports for the command-line tools.
+
+Thanks to Andrew Farrier, Jon Martin, and Scott Matloff for their help with code reviews.
+
+Thanks to Shawn Hargreaves and Nada Ouf for their continued support for this library.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Copyright (c) Microsoft Corporation.
 
 This package contains the "DirectX Tool Kit", a collection of helper classes for writing Direct3D 11 C++ code for Win32 desktop applications for Windows 8.1 or later, Xbox One, and Universal Windows Platform (UWP) apps for Windows 10 and Windows 11.
 
-This code is designed to build with Visual Studio 2022, Visual Studio 2026, clang for Windows v12 or later, or MinGW 12.2. Use of the Windows 10 May 2020 Update SDK ([19041](https://walbourn.github.io/windows-10-may-2020-update-sdk/)) or later is required for Visual Studio.
+This code is designed to build with Visual Studio 2022, Visual Studio 2026, clang for Windows v12 or later, or MinGW. Use of the Windows 10 May 2020 Update SDK ([19041](https://walbourn.github.io/windows-10-may-2020-update-sdk/)) or later is required for Visual Studio.
 
 These components are designed to work without requiring any content from the legacy DirectX SDK. For details, see [Where is the DirectX SDK?](https://aka.ms/dxsdk).
 


### PR DESCRIPTION
Added a second case to the MinGW GHA to test a different version of the compiler: current 14.2 and 15.2.

> Includes some readme edits as well.