### PR TITLE
Retire support for Direct3D 9.x Feature Levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ For a full change history, see [CHANGELOG.md](https://github.com/microsoft/Direc
 
 * The CMake projects require 3.21 or later.
 
+* Starting with the July 2026 release, support for Direct3D Hardware Feature Level 9.x has been retired. All shaders are built using Shader Model 4, and therefore require `D3D_FEATURE_LEVEL_10_0` or greater.
+
 * Starting with the March 2025 release, Windows 7 and Windows 8.0 support has been retired. For _DirectX ToolKit for Audio_ this means that `DirectXTKAudio_Desktop_*_Win7` has been removed, and `DirectXTKAudio_Desktop_*_Win8` has been integrated into the `DirectXTK_Desktop_*` vcxproj which uses XAudio 2.8 for Windows 8.1 compatibility.
 
   * Remove any References to or use of `DirectXTKAudio_Desktop_*_Win8.vcxproj` or `DirectXTKAudio_Desktop_*_Win7`. If using `DirectXTK_Desktop_*.vcxproj` you will be using XAudio 2.8 as before. Client code will need to build with `_WIN32_WINNT=0x0603`.

--- a/Src/BasicPostProcess.cpp
+++ b/Src/BasicPostProcess.cpp
@@ -102,7 +102,17 @@ namespace
             mVertexShader{},
             mPixelShaders{},
             mMutex{}
-        {}
+        {
+            if (!device)
+            {
+                throw std::invalid_argument("Direct3D device is null");
+            }
+
+            if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
+            {
+                throw std::runtime_error("DirectX Tool Kit requires Feature Level 10.0 or later");
+            }
+        }
 
         DeviceResources(const DeviceResources&) = delete;
         DeviceResources& operator=(const DeviceResources&) = delete;
@@ -219,11 +229,6 @@ BasicPostProcess::Impl::Impl(_In_ ID3D11Device* device)
     mConstantBuffer(device),
     mDeviceResources(deviceResourcesPool.DemandCreate(device))
 {
-    if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
-    {
-        throw std::runtime_error("BasicPostProcess requires Feature Level 10.0 or later");
-    }
-
     SetDebugObjectName(mConstantBuffer.GetBuffer(), "BasicPostProcess");
 }
 

--- a/Src/DDSTextureLoader.cpp
+++ b/Src/DDSTextureLoader.cpp
@@ -839,28 +839,20 @@ namespace
                     {
                     case D3D_FEATURE_LEVEL_9_1:
                     case D3D_FEATURE_LEVEL_9_2:
-                        if (isCubeMap)
-                        {
-                            maxsize = 512u /*D3D_FL9_1_REQ_TEXTURECUBE_DIMENSION*/;
-                        }
-                        else
-                        {
-                            maxsize = (resDim == D3D11_RESOURCE_DIMENSION_TEXTURE3D)
-                                ? 256u /*D3D_FL9_1_REQ_TEXTURE3D_U_V_OR_W_DIMENSION*/
-                                : 2048u /*D3D_FL9_1_REQ_TEXTURE2D_U_OR_V_DIMENSION*/;
-                        }
-                        break;
-
                     case D3D_FEATURE_LEVEL_9_3:
-                        maxsize = (resDim == D3D11_RESOURCE_DIMENSION_TEXTURE3D)
-                            ? 256u /*D3D_FL9_1_REQ_TEXTURE3D_U_V_OR_W_DIMENSION*/
-                            : 4096u /*D3D_FL9_3_REQ_TEXTURE2D_U_OR_V_DIMENSION*/;
-                        break;
+                        return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
 
-                    default: // D3D_FEATURE_LEVEL_10_0 & D3D_FEATURE_LEVEL_10_1
+                    case D3D_FEATURE_LEVEL_10_0:
+                    case D3D_FEATURE_LEVEL_10_1:
                         maxsize = (resDim == D3D11_RESOURCE_DIMENSION_TEXTURE3D)
                             ? 2048u /*D3D10_REQ_TEXTURE3D_U_V_OR_W_DIMENSION*/
                             : 8192u /*D3D10_REQ_TEXTURE2D_U_OR_V_DIMENSION*/;
+                        break;
+
+                    default: // D3D_FEATURE_LEVEL_11_0
+                        maxsize = (resDim == D3D11_RESOURCE_DIMENSION_TEXTURE3D)
+                            ? D3D11_REQ_TEXTURE3D_U_V_OR_W_DIMENSION
+                            : D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION;
                         break;
                     }
 

--- a/Src/DGSLEffectFactory.cpp
+++ b/Src/DGSLEffectFactory.cpp
@@ -245,13 +245,6 @@ std::shared_ptr<IEffect> DGSLEffectFactory::Impl::CreateDGSLEffect(DGSLEffectFac
         {
             lighting = false;
         }
-        else if (mDevice->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
-        {
-            // DGSL shaders are not compatible with Feature Level 9.x, use fallback shader
-            wcscat_s(root, L".cso");
-
-            factory->CreatePixelShader(root, ps.GetAddressOf());
-        }
         else
         {
             // Create DGSL shader and use it for the effect

--- a/Src/DebugEffect.cpp
+++ b/Src/DebugEffect.cpp
@@ -230,11 +230,6 @@ DebugEffect::Impl::Impl(_In_ ID3D11Device* device)
     instancing(false),
     debugMode(DebugEffect::Mode_Default)
 {
-    if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
-    {
-        throw std::runtime_error("DebugEffect requires Feature Level 10.0 or later");
-    }
-
     static_assert(static_cast<int>(std::size(EffectBase<DebugEffectTraits>::VertexShaderIndices)) == DebugEffectTraits::ShaderPermutationCount, "array/max mismatch");
     static_assert(static_cast<int>(std::size(EffectBase<DebugEffectTraits>::VertexShaderBytecode)) == DebugEffectTraits::VertexShaderCount, "array/max mismatch");
     static_assert(static_cast<int>(std::size(EffectBase<DebugEffectTraits>::PixelShaderBytecode)) == DebugEffectTraits::PixelShaderCount, "array/max mismatch");

--- a/Src/DualPostProcess.cpp
+++ b/Src/DualPostProcess.cpp
@@ -79,7 +79,17 @@ namespace
             mVertexShader{},
             mPixelShaders{},
             mMutex{}
-        {}
+        {
+            if (!device)
+            {
+                throw std::invalid_argument("Direct3D device is null");
+            }
+
+            if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
+            {
+                throw std::runtime_error("DirectX Tool Kit requires Feature Level 10.0 or later");
+            }
+        }
 
         DeviceResources(const DeviceResources&) = delete;
         DeviceResources& operator=(const DeviceResources&) = delete;
@@ -187,11 +197,6 @@ DualPostProcess::Impl::Impl(_In_ ID3D11Device* device)
     mConstantBuffer(device),
     mDeviceResources(deviceResourcesPool.DemandCreate(device))
 {
-    if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
-    {
-        throw std::runtime_error("DualPostProcess requires Feature Level 10.0 or later");
-    }
-
     SetDebugObjectName(mConstantBuffer.GetBuffer(), "DualPostProcess");
 }
 

--- a/Src/EffectCommon.h
+++ b/Src/EffectCommon.h
@@ -156,9 +156,19 @@ namespace DirectX
     class EffectDeviceResources
     {
     public:
-        EffectDeviceResources(_In_ ID3D11Device* device) noexcept
+        EffectDeviceResources(_In_ ID3D11Device* device)
             : mDevice(device)
-        {}
+        {
+            if (!device)
+            {
+                throw std::invalid_argument("Direct3D device is null");
+            }
+
+            if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
+            {
+                throw std::runtime_error("DirectX Tool Kit requires Feature Level 10.0 or later");
+            }
+        }
 
         ID3D11VertexShader* DemandCreateVertexShader(_Inout_ Microsoft::WRL::ComPtr<ID3D11VertexShader>& vertexShader, ShaderBytecode const& bytecode);
         ID3D11PixelShader * DemandCreatePixelShader(_Inout_ Microsoft::WRL::ComPtr<ID3D11PixelShader> & pixelShader, ShaderBytecode const& bytecode);
@@ -286,7 +296,7 @@ namespace DirectX
         class DeviceResources : protected EffectDeviceResources
         {
         public:
-            DeviceResources(_In_ ID3D11Device* device) noexcept
+            DeviceResources(_In_ ID3D11Device* device)
                 : EffectDeviceResources(device),
                 mVertexShaders{},
                 mPixelShaders{}

--- a/Src/EffectFactory.cpp
+++ b/Src/EffectFactory.cpp
@@ -70,11 +70,6 @@ public:
     {
         if (!device)
             throw std::invalid_argument("Direct3D device is null");
-
-        if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
-        {
-            mUseNormalMapEffect = false;
-        }
     }
 
     Impl(const Impl&) = delete;

--- a/Src/EnvironmentMapEffect.cpp
+++ b/Src/EnvironmentMapEffect.cpp
@@ -123,14 +123,12 @@ namespace
 #include "EnvironmentMapEffect_VSEnvMapOneLight.inc"
 #include "EnvironmentMapEffect_VSEnvMapOneLightFresnel.inc"
 #include "EnvironmentMapEffect_VSEnvMapPixelLighting.inc"
-#include "EnvironmentMapEffect_VSEnvMapPixelLightingSM4.inc"
 
 #include "EnvironmentMapEffect_VSEnvMapBn.inc"
 #include "EnvironmentMapEffect_VSEnvMapFresnelBn.inc"
 #include "EnvironmentMapEffect_VSEnvMapOneLightBn.inc"
 #include "EnvironmentMapEffect_VSEnvMapOneLightFresnelBn.inc"
 #include "EnvironmentMapEffect_VSEnvMapPixelLightingBn.inc"
-#include "EnvironmentMapEffect_VSEnvMapPixelLightingBnSM4.inc"
 
 #include "EnvironmentMapEffect_PSEnvMap.inc"
 #include "EnvironmentMapEffect_PSEnvMapNoFog.inc"
@@ -168,14 +166,6 @@ const ShaderBytecode EffectBase<EnvironmentMapEffectTraits>::VertexShaderBytecod
     { EnvironmentMapEffect_VSEnvMapOneLightBn,         sizeof(EnvironmentMapEffect_VSEnvMapOneLightBn)         },
     { EnvironmentMapEffect_VSEnvMapOneLightFresnelBn,  sizeof(EnvironmentMapEffect_VSEnvMapOneLightFresnelBn)  },
     { EnvironmentMapEffect_VSEnvMapPixelLightingBn,    sizeof(EnvironmentMapEffect_VSEnvMapPixelLightingBn)    },
-
-#if defined(_XBOX_ONE) && defined(_TITLE)
-    { EnvironmentMapEffect_VSEnvMapPixelLighting,      sizeof(EnvironmentMapEffect_VSEnvMapPixelLighting)      },
-    { EnvironmentMapEffect_VSEnvMapPixelLightingBn,    sizeof(EnvironmentMapEffect_VSEnvMapPixelLightingBn)    },
-#else
-    { EnvironmentMapEffect_VSEnvMapPixelLightingSM4,   sizeof(EnvironmentMapEffect_VSEnvMapPixelLightingSM4)   },
-    { EnvironmentMapEffect_VSEnvMapPixelLightingBnSM4, sizeof(EnvironmentMapEffect_VSEnvMapPixelLightingBnSM4) },
-#endif
 };
 
 
@@ -238,15 +228,15 @@ const int EffectBase<EnvironmentMapEffectTraits>::VertexShaderIndices[] =
     9,      // spheremap pixel lighting (biased vertex normals), fresnel
     9,      // spheremap pixel lighting (biased vertex normals), fresnel, no fog
 
-    10,     // dual-parabola pixel lighting
-    10,     // dual-parabola pixel lighting, no fog
-    10,     // dual-parabola pixel lighting, fresnel
-    10,     // dual-parabola pixel lighting, fresnel, no fog
+    4,      // dual-parabola pixel lighting
+    4,      // dual-parabola pixel lighting, no fog
+    4,      // dual-parabola pixel lighting, fresnel
+    4,      // dual-parabola pixel lighting, fresnel, no fog
 
-    11,     // dual-parabola pixel lighting (biased vertex normals)
-    11,     // dual-parabola pixel lighting (biased vertex normals), no fog
-    11,     // dual-parabola pixel lighting (biased vertex normals), fresnel
-    11,     // dual-parabola pixel lighting (biased vertex normals), fresnel, no fog
+    9,      // dual-parabola pixel lighting (biased vertex normals)
+    9,      // dual-parabola pixel lighting (biased vertex normals), no fog
+    9,      // dual-parabola pixel lighting (biased vertex normals), fresnel
+    9,      // dual-parabola pixel lighting (biased vertex normals), fresnel, no fog
 };
 
 
@@ -670,14 +660,6 @@ void EnvironmentMapEffect::SetMode(EnvironmentMapEffect::Mapping mapping)
     if (static_cast<int>(mapping) < 0 || static_cast<int>(mapping) >= EnvironmentMapEffectTraits::MappingCount)
     {
         throw std::invalid_argument("Unsupported mapping");
-    }
-
-    if (mapping == Mapping_DualParabola)
-    {
-        if (pImpl->GetDeviceFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
-        {
-            throw std::runtime_error("Dual Parabola requires Feature Level 10.0 or later");
-        }
     }
 
     pImpl->mapping = mapping;

--- a/Src/GraphicsMemory.cpp
+++ b/Src/GraphicsMemory.cpp
@@ -250,7 +250,14 @@ public:
     void Initialize(_In_ ID3D11Device* device, unsigned int backBufferCount)
     {
         if (!device)
+        {
             throw std::invalid_argument("Direct3D device is null");
+        }
+
+        if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
+        {
+            throw std::runtime_error("DirectX Tool Kit requires Feature Level 10.0 or later");
+        }
 
         UNREFERENCED_PARAMETER(backBufferCount);
     }

--- a/Src/NormalMapEffect.cpp
+++ b/Src/NormalMapEffect.cpp
@@ -301,11 +301,6 @@ NormalMapEffect::Impl::Impl(_In_ ID3D11Device* device)
     weightsPerVertex(0),
     boneConstants{}
 {
-    if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
-    {
-        throw std::runtime_error("NormalMapEffect requires Feature Level 10.0 or later");
-    }
-
     static_assert(static_cast<int>(std::size(EffectBase<NormalMapEffectTraits>::VertexShaderIndices)) == NormalMapEffectTraits::ShaderPermutationCount, "array/max mismatch");
     static_assert(static_cast<int>(std::size(EffectBase<NormalMapEffectTraits>::VertexShaderBytecode)) == NormalMapEffectTraits::VertexShaderCount, "array/max mismatch");
     static_assert(static_cast<int>(std::size(EffectBase<NormalMapEffectTraits>::PixelShaderBytecode)) == NormalMapEffectTraits::PixelShaderCount, "array/max mismatch");

--- a/Src/PBREffect.cpp
+++ b/Src/PBREffect.cpp
@@ -262,11 +262,6 @@ PBREffect::Impl::Impl(_In_ ID3D11Device* device)
     lightColor{},
     boneConstants{}
 {
-    if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
-    {
-        throw std::runtime_error("PBREffect requires Feature Level 10.0 or later");
-    }
-
     static_assert(static_cast<int>(std::size(EffectBase<PBREffectTraits>::VertexShaderIndices)) == PBREffectTraits::ShaderPermutationCount, "array/max mismatch");
     static_assert(static_cast<int>(std::size(EffectBase<PBREffectTraits>::VertexShaderBytecode)) == PBREffectTraits::VertexShaderCount, "array/max mismatch");
     static_assert(static_cast<int>(std::size(EffectBase<PBREffectTraits>::PixelShaderBytecode)) == PBREffectTraits::PixelShaderCount, "array/max mismatch");

--- a/Src/Shaders/CompileShaders.cmd
+++ b/Src/Shaders/CompileShaders.cmd
@@ -131,8 +131,6 @@ call :CompileShader%1 EnvironmentMapEffect vs VSEnvMapOneLightFresnel
 call :CompileShader%1 EnvironmentMapEffect vs VSEnvMapOneLightFresnelBn
 call :CompileShader%1 EnvironmentMapEffect vs VSEnvMapPixelLighting
 call :CompileShader%1 EnvironmentMapEffect vs VSEnvMapPixelLightingBn
-call :CompileShaderSM4%1 EnvironmentMapEffect vs VSEnvMapPixelLightingSM4
-call :CompileShaderSM4%1 EnvironmentMapEffect vs VSEnvMapPixelLightingBnSM4
 
 call :CompileShader%1 EnvironmentMapEffect ps PSEnvMap
 call :CompileShader%1 EnvironmentMapEffect ps PSEnvMapNoFog
@@ -148,10 +146,10 @@ call :CompileShader%1 EnvironmentMapEffect ps PSEnvMapSpherePixelLightingNoFog
 call :CompileShader%1 EnvironmentMapEffect ps PSEnvMapSpherePixelLightingFresnel
 call :CompileShader%1 EnvironmentMapEffect ps PSEnvMapSpherePixelLightingFresnelNoFog
 
-call :CompileShaderSM4%1 EnvironmentMapEffect ps PSEnvMapDualParabolaPixelLighting
-call :CompileShaderSM4%1 EnvironmentMapEffect ps PSEnvMapDualParabolaPixelLightingNoFog
-call :CompileShaderSM4%1 EnvironmentMapEffect ps PSEnvMapDualParabolaPixelLightingFresnel
-call :CompileShaderSM4%1 EnvironmentMapEffect ps PSEnvMapDualParabolaPixelLightingFresnelNoFog
+call :CompileShader%1 EnvironmentMapEffect ps PSEnvMapDualParabolaPixelLighting
+call :CompileShader%1 EnvironmentMapEffect ps PSEnvMapDualParabolaPixelLightingNoFog
+call :CompileShader%1 EnvironmentMapEffect ps PSEnvMapDualParabolaPixelLightingFresnel
+call :CompileShader%1 EnvironmentMapEffect ps PSEnvMapDualParabolaPixelLightingFresnelNoFog
 
 call :CompileShader%1 SkinnedEffect vs VSSkinnedVertexLightingOneBone
 call :CompileShader%1 SkinnedEffect vs VSSkinnedVertexLightingOneBoneBn
@@ -178,53 +176,53 @@ call :CompileShader%1 SkinnedEffect ps PSSkinnedVertexLighting
 call :CompileShader%1 SkinnedEffect ps PSSkinnedVertexLightingNoFog
 call :CompileShader%1 SkinnedEffect ps PSSkinnedPixelLighting
 
-call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTx
-call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxBn
-call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxVc
-call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxVcBn
+call :CompileShader%1 NormalMapEffect vs VSNormalPixelLightingTx
+call :CompileShader%1 NormalMapEffect vs VSNormalPixelLightingTxBn
+call :CompileShader%1 NormalMapEffect vs VSNormalPixelLightingTxVc
+call :CompileShader%1 NormalMapEffect vs VSNormalPixelLightingTxVcBn
 
-call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxInst
-call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxBnInst
-call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxVcInst
-call :CompileShaderSM4%1 NormalMapEffect vs VSNormalPixelLightingTxVcBnInst
+call :CompileShader%1 NormalMapEffect vs VSNormalPixelLightingTxInst
+call :CompileShader%1 NormalMapEffect vs VSNormalPixelLightingTxBnInst
+call :CompileShader%1 NormalMapEffect vs VSNormalPixelLightingTxVcInst
+call :CompileShader%1 NormalMapEffect vs VSNormalPixelLightingTxVcBnInst
 
-call :CompileShaderSM4%1 NormalMapEffect vs VSSkinnedPixelLightingTx
-call :CompileShaderSM4%1 NormalMapEffect vs VSSkinnedPixelLightingTxBn
+call :CompileShader%1 NormalMapEffect vs VSSkinnedPixelLightingTx
+call :CompileShader%1 NormalMapEffect vs VSSkinnedPixelLightingTxBn
 
-call :CompileShaderSM4%1 NormalMapEffect ps PSNormalPixelLightingTx
-call :CompileShaderSM4%1 NormalMapEffect ps PSNormalPixelLightingTxNoFog
-call :CompileShaderSM4%1 NormalMapEffect ps PSNormalPixelLightingTxNoSpec
-call :CompileShaderSM4%1 NormalMapEffect ps PSNormalPixelLightingTxNoFogSpec
+call :CompileShader%1 NormalMapEffect ps PSNormalPixelLightingTx
+call :CompileShader%1 NormalMapEffect ps PSNormalPixelLightingTxNoFog
+call :CompileShader%1 NormalMapEffect ps PSNormalPixelLightingTxNoSpec
+call :CompileShader%1 NormalMapEffect ps PSNormalPixelLightingTxNoFogSpec
 
-call :CompileShaderSM4%1 PBREffect vs VSConstant
-call :CompileShaderSM4%1 PBREffect vs VSConstantInst
-call :CompileShaderSM4%1 PBREffect vs VSConstantVelocity
-call :CompileShaderSM4%1 PBREffect vs VSConstantBn
-call :CompileShaderSM4%1 PBREffect vs VSConstantBnInst
-call :CompileShaderSM4%1 PBREffect vs VSConstantVelocityBn
-call :CompileShaderSM4%1 PBREffect vs VSSkinned
-call :CompileShaderSM4%1 PBREffect vs VSSkinnedBn
+call :CompileShader%1 PBREffect vs VSConstant
+call :CompileShader%1 PBREffect vs VSConstantInst
+call :CompileShader%1 PBREffect vs VSConstantVelocity
+call :CompileShader%1 PBREffect vs VSConstantBn
+call :CompileShader%1 PBREffect vs VSConstantBnInst
+call :CompileShader%1 PBREffect vs VSConstantVelocityBn
+call :CompileShader%1 PBREffect vs VSSkinned
+call :CompileShader%1 PBREffect vs VSSkinnedBn
 
-call :CompileShaderSM4%1 PBREffect ps PSConstant
-call :CompileShaderSM4%1 PBREffect ps PSTextured
-call :CompileShaderSM4%1 PBREffect ps PSTexturedEmissive
-call :CompileShaderSM4%1 PBREffect ps PSTexturedVelocity
-call :CompileShaderSM4%1 PBREffect ps PSTexturedEmissiveVelocity
+call :CompileShader%1 PBREffect ps PSConstant
+call :CompileShader%1 PBREffect ps PSTextured
+call :CompileShader%1 PBREffect ps PSTexturedEmissive
+call :CompileShader%1 PBREffect ps PSTexturedVelocity
+call :CompileShader%1 PBREffect ps PSTexturedEmissiveVelocity
 
-call :CompileShaderSM4%1 DebugEffect vs VSDebug
-call :CompileShaderSM4%1 DebugEffect vs VSDebugBn
-call :CompileShaderSM4%1 DebugEffect vs VSDebugVc
-call :CompileShaderSM4%1 DebugEffect vs VSDebugVcBn
+call :CompileShader%1 DebugEffect vs VSDebug
+call :CompileShader%1 DebugEffect vs VSDebugBn
+call :CompileShader%1 DebugEffect vs VSDebugVc
+call :CompileShader%1 DebugEffect vs VSDebugVcBn
 
-call :CompileShaderSM4%1 DebugEffect vs VSDebugInst
-call :CompileShaderSM4%1 DebugEffect vs VSDebugBnInst
-call :CompileShaderSM4%1 DebugEffect vs VSDebugVcInst
-call :CompileShaderSM4%1 DebugEffect vs VSDebugVcBnInst
+call :CompileShader%1 DebugEffect vs VSDebugInst
+call :CompileShader%1 DebugEffect vs VSDebugBnInst
+call :CompileShader%1 DebugEffect vs VSDebugVcInst
+call :CompileShader%1 DebugEffect vs VSDebugVcBnInst
 
-call :CompileShaderSM4%1 DebugEffect ps PSHemiAmbient
-call :CompileShaderSM4%1 DebugEffect ps PSRGBNormals
-call :CompileShaderSM4%1 DebugEffect ps PSRGBTangents
-call :CompileShaderSM4%1 DebugEffect ps PSRGBBiTangents
+call :CompileShader%1 DebugEffect ps PSHemiAmbient
+call :CompileShader%1 DebugEffect ps PSRGBNormals
+call :CompileShader%1 DebugEffect ps PSRGBTangents
+call :CompileShader%1 DebugEffect ps PSRGBBiTangents
 
 call :CompileShader%1 NPREffect vs VSNPREffect
 call :CompileShader%1 NPREffect vs VSNPREffectBn
@@ -283,37 +281,37 @@ call :CompileShaderHLSL%1 DGSLUnlit ps mainTxTk
 call :CompileShaderHLSL%1 DGSLLambert ps mainTxTk
 call :CompileShaderHLSL%1 DGSLPhong ps mainTxTk
 
-call :CompileShaderSM4%1 PostProcess vs VSQuad
-call :CompileShaderSM4%1 PostProcess ps PSCopy
-call :CompileShaderSM4%1 PostProcess ps PSMonochrome
-call :CompileShaderSM4%1 PostProcess ps PSSepia
-call :CompileShaderSM4%1 PostProcess ps PSDownScale2x2
-call :CompileShaderSM4%1 PostProcess ps PSDownScale4x4
-call :CompileShaderSM4%1 PostProcess ps PSGaussianBlur5x5
-call :CompileShaderSM4%1 PostProcess ps PSBloomExtract
-call :CompileShaderSM4%1 PostProcess ps PSBloomBlur
-call :CompileShaderSM4%1 PostProcess ps PSMerge
-call :CompileShaderSM4%1 PostProcess ps PSBloomCombine
+call :CompileShader%1 PostProcess vs VSQuad
+call :CompileShader%1 PostProcess ps PSCopy
+call :CompileShader%1 PostProcess ps PSMonochrome
+call :CompileShader%1 PostProcess ps PSSepia
+call :CompileShader%1 PostProcess ps PSDownScale2x2
+call :CompileShader%1 PostProcess ps PSDownScale4x4
+call :CompileShader%1 PostProcess ps PSGaussianBlur5x5
+call :CompileShader%1 PostProcess ps PSBloomExtract
+call :CompileShader%1 PostProcess ps PSBloomBlur
+call :CompileShader%1 PostProcess ps PSMerge
+call :CompileShader%1 PostProcess ps PSBloomCombine
 
-call :CompileShaderSM4%1 ToneMap vs VSQuad
-call :CompileShaderSM4%1 ToneMap ps PSCopy
-call :CompileShaderSM4%1 ToneMap ps PSSaturate
-call :CompileShaderSM4%1 ToneMap ps PSReinhard
-call :CompileShaderSM4%1 ToneMap ps PSACESFilmic
-call :CompileShaderSM4%1 ToneMap ps PS_SRGB
-call :CompileShaderSM4%1 ToneMap ps PSSaturate_SRGB
-call :CompileShaderSM4%1 ToneMap ps PSReinhard_SRGB
-call :CompileShaderSM4%1 ToneMap ps PSACESFilmic_SRGB
-call :CompileShaderSM4%1 ToneMap ps PSHDR10
+call :CompileShader%1 ToneMap vs VSQuad
+call :CompileShader%1 ToneMap ps PSCopy
+call :CompileShader%1 ToneMap ps PSSaturate
+call :CompileShader%1 ToneMap ps PSReinhard
+call :CompileShader%1 ToneMap ps PSACESFilmic
+call :CompileShader%1 ToneMap ps PS_SRGB
+call :CompileShader%1 ToneMap ps PSSaturate_SRGB
+call :CompileShader%1 ToneMap ps PSReinhard_SRGB
+call :CompileShader%1 ToneMap ps PSACESFilmic_SRGB
+call :CompileShader%1 ToneMap ps PSHDR10
 
 if NOT %1.==xbox. goto skipxboxonly
 
-call :CompileShaderSM4xbox ToneMap ps PSHDR10_Saturate
-call :CompileShaderSM4xbox ToneMap ps PSHDR10_Reinhard
-call :CompileShaderSM4xbox ToneMap ps PSHDR10_ACESFilmic
-call :CompileShaderSM4xbox ToneMap ps PSHDR10_Saturate_SRGB
-call :CompileShaderSM4xbox ToneMap ps PSHDR10_Reinhard_SRGB
-call :CompileShaderSM4xbox ToneMap ps PSHDR10_ACESFilmic_SRGB
+call :CompileShaderxbox ToneMap ps PSHDR10_Saturate
+call :CompileShaderxbox ToneMap ps PSHDR10_Reinhard
+call :CompileShaderxbox ToneMap ps PSHDR10_ACESFilmic
+call :CompileShaderxbox ToneMap ps PSHDR10_Saturate_SRGB
+call :CompileShaderxbox ToneMap ps PSHDR10_Reinhard_SRGB
+call :CompileShaderxbox ToneMap ps PSHDR10_ACESFilmic_SRGB
 
 :skipxboxonly
 
@@ -330,13 +328,6 @@ endlocal
 exit /b 0
 
 :CompileShader
-set fxc=%PCFXC% "%1.fx" %FXCOPTS% /T%2_4_0_level_9_1 /E%3 "/Fh%CompileShadersOutput%\%1_%3.inc" "/Fd%CompileShadersOutput%\%1_%3.pdb" /Vn%1_%3
-echo.
-echo %fxc%
-%fxc% || set error=1
-exit /b
-
-:CompileShaderSM4
 set fxc=%PCFXC% "%1.fx" %FXCOPTS% /T%2_4_0 /E%3 "/Fh%CompileShadersOutput%\%1_%3.inc" "/Fd%CompileShadersOutput%\%1_%3.pdb" /Vn%1_%3
 echo.
 echo %fxc%
@@ -344,14 +335,13 @@ echo %fxc%
 exit /b
 
 :CompileShaderHLSL
-set fxc=%PCFXC% "%1.hlsl" %FXCOPTS% /T%2_4_0_level_9_1 /E%3 "/Fh%CompileShadersOutput%\%1_%3.inc" "/Fd%CompileShadersOutput%\%1_%3.pdb" /Vn%1_%3
+set fxc=%PCFXC% "%1.hlsl" %FXCOPTS% /T%2_4_0 /E%3 "/Fh%CompileShadersOutput%\%1_%3.inc" "/Fd%CompileShadersOutput%\%1_%3.pdb" /Vn%1_%3
 echo.
 echo %fxc%
 %fxc% || set error=1
 exit /b
 
 :CompileShaderxbox
-:CompileShaderSM4xbox
 set fxc=%XBOXFXC% "%1.fx" %FXCOPTS% /T%2_5_0 %XBOXOPTS% /E%3 "/Fh%CompileShadersOutput%\XboxOne%1_%3.inc" "/Fd%CompileShadersOutput%\XboxOne%1_%3.pdb" /Vn%1_%3
 echo.
 echo %fxc%

--- a/Src/SpriteBatch.cpp
+++ b/Src/SpriteBatch.cpp
@@ -235,6 +235,16 @@ const XMFLOAT2 SpriteBatch::Float2Zero(0, 0);
 SpriteBatch::Impl::DeviceResources::DeviceResources(_In_ ID3D11Device* device)
     : stateObjects(device)
 {
+    if (!device)
+    {
+        throw std::invalid_argument("Direct3D device is null");
+    }
+
+    if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
+    {
+        throw std::runtime_error("DirectX Tool Kit requires Feature Level 10.0 or later");
+    }
+
     CreateShaders(device);
     CreateIndexBuffer(device);
 }

--- a/Src/ToneMapPostProcess.cpp
+++ b/Src/ToneMapPostProcess.cpp
@@ -193,7 +193,17 @@ namespace
             mVertexShader{},
             mPixelShaders{},
             mMutex{}
-        {}
+        {
+            if (!device)
+            {
+                throw std::invalid_argument("Direct3D device is null");
+            }
+
+            if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
+            {
+                throw std::runtime_error("DirectX Tool Kit requires Feature Level 10.0 or later");
+            }
+        }
 
         DeviceResources(const DeviceResources&) = delete;
         DeviceResources& operator=(const DeviceResources&) = delete;
@@ -302,11 +312,6 @@ ToneMapPostProcess::Impl::Impl(_In_ ID3D11Device* device)
     mConstantBuffer(device),
     mDeviceResources(deviceResourcesPool.DemandCreate(device))
 {
-    if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0)
-    {
-        throw std::runtime_error("ToneMapPostProcess requires Feature Level 10.0 or later");
-    }
-
     memcpy(constants.colorRotation, c_from709to2020, sizeof(c_from709to2020));
 
     SetDebugObjectName(mConstantBuffer.GetBuffer(), "ToneMapPostProcess");

--- a/Src/WICTextureLoader.cpp
+++ b/Src/WICTextureLoader.cpp
@@ -305,12 +305,8 @@ namespace
             {
             case D3D_FEATURE_LEVEL_9_1:
             case D3D_FEATURE_LEVEL_9_2:
-                maxsize = 2048u /*D3D_FL9_1_REQ_TEXTURE2D_U_OR_V_DIMENSION*/;
-                break;
-
             case D3D_FEATURE_LEVEL_9_3:
-                maxsize = 4096u /*D3D_FL9_3_REQ_TEXTURE2D_U_OR_V_DIMENSION*/;
-                break;
+                return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
 
             case D3D_FEATURE_LEVEL_10_0:
             case D3D_FEATURE_LEVEL_10_1:


### PR DESCRIPTION
All shaders now build with the `4_0` profiles instead of the `4_0_level_9_1` profiles, and all classes that use shaders now require `D3D_FEATURE_LEVEL_10_0` or greater. This reduces the footprint of the shader blobs by half.

> Direct3D Hardware Feature Level 9.x was really last relevant for original Windows Phone and Surface RT, neither of which remain in the market. Some newer features of the toolkit (**PBREffect**, **NormalMapEffect**, and **PostProcess** already required 10.0+).