### PR TITLE
Fix issue with DLL build

### DIFF
--- a/Inc/Effects.h
+++ b/Inc/Effects.h
@@ -927,7 +927,7 @@ namespace DirectX
             DIRECTX_TOOLKIT_API void XM_CALLCONV SetColorAndAlpha(FXMVECTOR value);
 
             // Light settings.
-            void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
+            DIRECTX_TOOLKIT_API void XM_CALLCONV SetLightDirection(int whichLight, FXMVECTOR value) override;
             DIRECTX_TOOLKIT_API void __cdecl EnableDefaultLighting() override;
 
             static constexpr int MaxDirectionalLights = 1;

--- a/Src/NPREffect.cpp
+++ b/Src/NPREffect.cpp
@@ -91,7 +91,6 @@ public:
     int weightsPerVertex;
 
     NPREffect::Mode nprMode;
-    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> texture;
     Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> matcap;
 
     int GetCurrentShaderPermutation() const noexcept;


### PR DESCRIPTION
Fixed build break in DLL build variant introduced in #655

Also resolves a clang warning.